### PR TITLE
Resolve ActiveToken for a GH_USER-selected account

### DIFF
--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -1027,3 +1027,33 @@ func TestSwitchUserStillWorksWithGHUserSet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "test-user-1", activeUser)
 }
+
+func TestActiveTokenGHUserFallsBackToLegacyTokenForActiveUser(t *testing.T) {
+	// Given a legacy keyring: the active user's token lives only in the unkeyed
+	// slot (no per-user entry), as set up by a very old CLI
+	authCfg := newTestAuthConfig(t)
+	authCfg.cfg.Set([]string{hostsKey, "github.com", userKey}, "test-user-1")
+	require.NoError(t, keyring.Set(keyringServiceName("github.com"), "", "legacy-token"))
+
+	// When GH_USER names that same stored active user
+	t.Setenv("GH_USER", "test-user-1")
+
+	// Then the legacy unkeyed token is still returned (fallback preserved)
+	token, source := authCfg.ActiveToken("github.com")
+	require.Equal(t, "legacy-token", token)
+	require.Equal(t, "keyring", source)
+}
+
+func TestActiveTokenGHUserDoesNotLeakLegacyTokenToOtherUser(t *testing.T) {
+	// Given a legacy keyring whose unkeyed token belongs to the active user
+	authCfg := newTestAuthConfig(t)
+	authCfg.cfg.Set([]string{hostsKey, "github.com", userKey}, "test-user-1")
+	require.NoError(t, keyring.Set(keyringServiceName("github.com"), "", "legacy-token"))
+
+	// When GH_USER names a different account
+	t.Setenv("GH_USER", "test-user-2")
+
+	// Then no token is returned - the legacy token is not handed to another user
+	token, _ := authCfg.ActiveToken("github.com")
+	require.Empty(t, token)
+}

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -1057,3 +1057,124 @@ func TestActiveTokenGHUserDoesNotLeakLegacyTokenToOtherUser(t *testing.T) {
 	token, _ := authCfg.ActiveToken("github.com")
 	require.Empty(t, token)
 }
+
+func TestActiveTokenGHUserEmptyStringIsIgnored(t *testing.T) {
+	// Given an authenticated user
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user-1", "test-token-1", "", true)
+	require.NoError(t, err)
+
+	// When GH_USER is set but empty (as `unset` in most shells)
+	t.Setenv("GH_USER", "")
+
+	// Then it is ignored and the stored active user's token is returned
+	token, source := authCfg.ActiveToken("github.com")
+	require.Equal(t, "test-token-1", token)
+	require.Equal(t, "keyring", source)
+}
+
+func TestActiveTokenGHUserSelectsCorrectAccountAmongThree(t *testing.T) {
+	// Given three authenticated users (test-user-3 active)
+	authCfg := newTestAuthConfig(t)
+	for _, u := range []struct{ name, token string }{
+		{"test-user-1", "token-1"}, {"test-user-2", "token-2"}, {"test-user-3", "token-3"},
+	} {
+		_, err := authCfg.Login("github.com", u.name, u.token, "", true)
+		require.NoError(t, err)
+	}
+
+	// When GH_USER selects the middle account
+	t.Setenv("GH_USER", "test-user-2")
+
+	// Then exactly that account's token is returned
+	token, _ := authCfg.ActiveToken("github.com")
+	require.Equal(t, "token-2", token)
+}
+
+func TestActiveTokenGHUserOverridesInsecureActiveUserToken(t *testing.T) {
+	// Given the active user is stored insecurely (token in config), and a
+	// different account is stored securely in the keyring
+	authCfg := newTestAuthConfig(t)
+	authCfg.cfg.Set([]string{hostsKey, "github.com", userKey}, "insecure-user")
+	authCfg.cfg.Set([]string{hostsKey, "github.com", oauthTokenKey}, "insecure-token")
+	require.NoError(t, keyring.Set(keyringServiceName("github.com"), "secure-user", "secure-token"))
+
+	// When GH_USER selects the secure account
+	t.Setenv("GH_USER", "secure-user")
+
+	// Then the keyring token wins over the active user's config token
+	token, source := authCfg.ActiveToken("github.com")
+	require.Equal(t, "secure-token", token)
+	require.Equal(t, "keyring", source)
+}
+
+func TestActiveTokenGHUserForInsecureActiveUserReturnsConfigToken(t *testing.T) {
+	// Given only an insecurely-stored active user (token in config, not keyring)
+	authCfg := newTestAuthConfig(t)
+	authCfg.cfg.Set([]string{hostsKey, "github.com", userKey}, "insecure-user")
+	authCfg.cfg.Set([]string{hostsKey, "github.com", oauthTokenKey}, "insecure-token")
+
+	// When GH_USER names that same active user
+	t.Setenv("GH_USER", "insecure-user")
+
+	// Then its config token is still returned (fall-through to normal resolution)
+	token, source := authCfg.ActiveToken("github.com")
+	require.Equal(t, "insecure-token", token)
+	require.Equal(t, oauthTokenKey, source)
+}
+
+func TestHasActiveTokenReflectsGHUser(t *testing.T) {
+	// Given two authenticated users
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user-1", "test-token-1", "", true)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "test-user-2", "test-token-2", "", true)
+	require.NoError(t, err)
+
+	// Then HasActiveToken is true for an authenticated GH_USER
+	t.Setenv("GH_USER", "test-user-1")
+	require.True(t, authCfg.HasActiveToken("github.com"))
+
+	// And false for an unauthenticated GH_USER
+	t.Setenv("GH_USER", "nobody")
+	require.False(t, authCfg.HasActiveToken("github.com"))
+}
+
+func TestActiveTokenGHUserResolvesPerHost(t *testing.T) {
+	// Given user-a on github.com and user-b on an enterprise host
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "user-a", "gh-token-a", "", true)
+	require.NoError(t, err)
+	_, err = authCfg.Login("ghe.example.com", "user-b", "ghe-token-b", "", true)
+	require.NoError(t, err)
+
+	// When GH_USER=user-b
+	t.Setenv("GH_USER", "user-b")
+
+	// Then the enterprise host resolves user-b's token
+	token, _ := authCfg.ActiveToken("ghe.example.com")
+	require.Equal(t, "ghe-token-b", token)
+
+	// And github.com (where user-b doesn't exist) yields no token, rather than
+	// leaking github.com's active user's (user-a's) token
+	token, _ = authCfg.ActiveToken("github.com")
+	require.Empty(t, token)
+}
+
+func TestActiveTokenGHUserSelectsPerHostAccountWithSameName(t *testing.T) {
+	// Given the same username authenticated on two hosts with different tokens
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "shared", "gh-token", "", true)
+	require.NoError(t, err)
+	_, err = authCfg.Login("ghe.example.com", "shared", "ghe-token", "", true)
+	require.NoError(t, err)
+
+	// When GH_USER=shared
+	t.Setenv("GH_USER", "shared")
+
+	// Then each host resolves its own token
+	tok1, _ := authCfg.ActiveToken("github.com")
+	require.Equal(t, "gh-token", tok1)
+	tok2, _ := authCfg.ActiveToken("ghe.example.com")
+	require.Equal(t, "ghe-token", tok2)
+}

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -947,3 +947,83 @@ func preMigrationLogin(c *AuthConfig, hostname, username, token, gitProtocol str
 	}
 	return insecureStorageUsed, ghConfig.Write(c.cfg)
 }
+
+func TestActiveTokenRespectsGHUser(t *testing.T) {
+	// Given two users authenticated in the keyring (test-user-2 active)
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user-1", "test-token-1", "ssh", true)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "test-user-2", "test-token-2", "ssh", true)
+	require.NoError(t, err)
+
+	// When GH_USER selects the non-active user
+	t.Setenv("GH_USER", "test-user-1")
+
+	// Then ActiveToken returns that user's token from the keyring
+	token, source := authCfg.ActiveToken("github.com")
+	require.Equal(t, "test-token-1", token)
+	require.Equal(t, "keyring", source)
+}
+
+func TestActiveTokenGHUserDoesNotChangeStoredActiveUser(t *testing.T) {
+	// Given two users, test-user-2 active
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user-1", "test-token-1", "ssh", true)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "test-user-2", "test-token-2", "ssh", true)
+	require.NoError(t, err)
+
+	// When GH_USER points at the other user
+	t.Setenv("GH_USER", "test-user-1")
+
+	// Then the stored active user is unchanged (GH_USER is invocation-scoped)
+	activeUser, err := authCfg.ActiveUser("github.com")
+	require.NoError(t, err)
+	require.Equal(t, "test-user-2", activeUser)
+}
+
+func TestActiveTokenGHTokenTakesPrecedenceOverGHUser(t *testing.T) {
+	// Given a keyring user and both env vars set
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user-1", "test-token-1", "ssh", true)
+	require.NoError(t, err)
+	t.Setenv("GH_TOKEN", "env-token")
+	t.Setenv("GH_USER", "test-user-1")
+
+	// Then GH_TOKEN wins
+	token, source := authCfg.ActiveToken("github.com")
+	require.Equal(t, "env-token", token)
+	require.Equal(t, "GH_TOKEN", source)
+}
+
+func TestActiveTokenGHUserUnauthenticatedReturnsNoToken(t *testing.T) {
+	// Given one authenticated user
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user-1", "test-token-1", "ssh", true)
+	require.NoError(t, err)
+
+	// When GH_USER names an account with no stored token
+	t.Setenv("GH_USER", "nobody")
+
+	// Then no token is returned, rather than silently falling back to another account
+	token, _ := authCfg.ActiveToken("github.com")
+	require.Empty(t, token)
+}
+
+func TestSwitchUserStillWorksWithGHUserSet(t *testing.T) {
+	// Given two users and GH_USER pointing at one of them
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user-1", "test-token-1", "ssh", true)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "test-user-2", "test-token-2", "ssh", true)
+	require.NoError(t, err)
+	t.Setenv("GH_USER", "test-user-1")
+
+	// When we switch the stored active user
+	require.NoError(t, authCfg.SwitchUser("github.com", "test-user-1"))
+
+	// Then the stored active user reflects the real switch (GH_USER never leaks in)
+	activeUser, err := authCfg.ActiveUser("github.com")
+	require.NoError(t, err)
+	require.Equal(t, "test-user-1", activeUser)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -240,6 +240,17 @@ func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 	}
 	token, source := ghauth.TokenFromEnvOrConfig(hostname)
 	if token == "" {
+		// GH_USER selects an already-authenticated account for this invocation,
+		// without mutating the stored active account (no `gh auth switch`), so
+		// concurrent shells/agents can act as different accounts from one shared
+		// config. GH_TOKEN still takes precedence above. Scoped to token
+		// resolution so it never corrupts the stored active user in switch/logout.
+		if envUser := os.Getenv("GH_USER"); envUser != "" {
+			if t, err := c.TokenFromKeyringForUser(hostname, envUser); err == nil {
+				return t, "keyring"
+			}
+			return "", ""
+		}
 		var user string
 		var err error
 		if user, err = c.ActiveUser(hostname); err == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,8 +246,18 @@ func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 		// config. GH_TOKEN still takes precedence above. Scoped to token
 		// resolution so it never corrupts the stored active user in switch/logout.
 		if envUser := os.Getenv("GH_USER"); envUser != "" {
-			if t, err := c.TokenFromKeyringForUser(hostname, envUser); err == nil {
-				return t, "keyring"
+			token, err := c.TokenFromKeyringForUser(hostname, envUser)
+			if err != nil {
+				// Legacy keyrings (set up by a very old CLI) store the active
+				// user's token in an unkeyed slot. Fall back to it only when
+				// GH_USER is that stored active user, so a different requested
+				// account never receives the active user's token.
+				if activeUser, activeErr := c.ActiveUser(hostname); activeErr == nil && activeUser == envUser {
+					token, err = c.TokenFromKeyring(hostname)
+				}
+			}
+			if err == nil {
+				return token, "keyring"
 			}
 			return "", ""
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -239,28 +239,32 @@ func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 		return c.tokenOverride(hostname)
 	}
 	token, source := ghauth.TokenFromEnvOrConfig(hostname)
-	if token == "" {
-		// GH_USER selects an already-authenticated account for this invocation,
-		// without mutating the stored active account (no `gh auth switch`), so
-		// concurrent shells/agents can act as different accounts from one shared
-		// config. GH_TOKEN still takes precedence above. Scoped to token
-		// resolution so it never corrupts the stored active user in switch/logout.
-		if envUser := os.Getenv("GH_USER"); envUser != "" {
-			token, err := c.TokenFromKeyringForUser(hostname, envUser)
-			if err != nil {
-				// Legacy keyrings (set up by a very old CLI) store the active
-				// user's token in an unkeyed slot. Fall back to it only when
-				// GH_USER is that stored active user, so a different requested
-				// account never receives the active user's token.
-				if activeUser, activeErr := c.ActiveUser(hostname); activeErr == nil && activeUser == envUser {
-					token, err = c.TokenFromKeyring(hostname)
-				}
-			}
-			if err == nil {
-				return token, "keyring"
-			}
+
+	// A token supplied via the environment (GH_TOKEN/GITHUB_TOKEN) always wins.
+	if token != "" && source != oauthTokenKey {
+		return token, source
+	}
+
+	// GH_USER selects an already-authenticated account for this invocation,
+	// without mutating the stored active account (no `gh auth switch`), so
+	// concurrent shells/agents can act as different accounts from one shared
+	// config. It overrides the stored active account's config or keyring token,
+	// but not an environment token (handled above). Scoped here so it never
+	// corrupts the stored active user that switch/login/logout read and write.
+	if envUser := os.Getenv("GH_USER"); envUser != "" {
+		if userToken, err := c.TokenFromKeyringForUser(hostname, envUser); err == nil {
+			return userToken, "keyring"
+		}
+		// GH_USER's own token is not in the keyring. When GH_USER is the stored
+		// active user, fall through to normal resolution (its config token, or a
+		// legacy unkeyed keyring token). When it names a different account,
+		// return nothing rather than that account's stored active token.
+		if activeUser, err := c.ActiveUser(hostname); err != nil || activeUser != envUser {
 			return "", ""
 		}
+	}
+
+	if token == "" {
 		var user string
 		var err error
 		if user, err = c.ActiveUser(hostname); err == nil {


### PR DESCRIPTION
### Why

Multiple authenticated accounts on one host is a long-standing pain (#12145, #12885, #326, #9111, #11938). Switching means `gh auth switch`, which mutates the shared active-account state, so it races across concurrent shells, scripts, and agent runs. There's no per-invocation way to pick an account.

#12145 asks for a `GH_USER` env var to select an account. This is the token-resolution half of it.

### What

`ActiveToken` honors `GH_USER`: when it's set, resolve the selected account's token instead of the stored active account, per host, without changing what any other shell sees. `GH_USER=work gh pr create` acts as `work`.

- An environment `GH_TOKEN`/`GITHUB_TOKEN` still wins; `GH_USER` overrides only the stored active account's config or keyring token.
- Resolved per host, so a `GH_USER` that exists on one host doesn't leak another host's active token.
- When `GH_USER` is the active user with no keyring entry, it falls through to normal resolution (config token, or a legacy unkeyed keyring token).
- A different account with no stored token yields nothing, never another account's token.
- Scoped to token resolution, so it never touches the stored active user that switch/login/logout read and write.

Complementary to the `--user` flag discussed in #12145: env var for interactive sessions, flag for scripted/agent callers.

### Testing

Unit, `internal/config` (14 tests): non-active selection, stored-active untouched, `GH_TOKEN` precedence, unauthenticated yields no token, `switch` unaffected, empty-string ignored, three-account selection, `HasActiveToken`, legacy-keyring fallback and its no-leak case, config-token override for mixed secure/insecure storage, multi-host resolution with cross-host no-leak, and same-username-per-host. Full package passes.

Manual, two real accounts on github.com: `GH_USER=<other> gh api user` returns the other account; no `GH_USER` (and empty `GH_USER`) returns the stored active; `GH_TOKEN` overrides `GH_USER`; an unknown `GH_USER` returns auth-required.

### Process

I know #12145 isn't `help wanted` yet. This is a reference implementation to make the design concrete, not to bypass the process — happy to hold or reshape until it's labelled. Re: #12145, #12885.
