### PR TITLE
Replace Windsurf with Devin in skill agents

### DIFF
--- a/internal/skills/registry/registry.go
+++ b/internal/skills/registry/registry.go
@@ -171,6 +171,12 @@ var Agents = []AgentHost{
 		UserDir:    ".deepagents/agent/skills",
 	},
 	{
+		ID:         "devin",
+		Name:       "Devin",
+		ProjectDir: ".devin/skills",
+		UserDir:    ".devin/skills",
+	},
+	{
 		ID:         "droid",
 		Name:       "Droid",
 		ProjectDir: ".factory/skills",
@@ -331,12 +337,6 @@ var Agents = []AgentHost{
 		Name:       "Warp",
 		ProjectDir: sharedProjectSkillsDir,
 		UserDir:    ".agents/skills",
-	},
-	{
-		ID:         "windsurf",
-		Name:       "Windsurf",
-		ProjectDir: ".windsurf/skills",
-		UserDir:    ".codeium/windsurf/skills",
 	},
 	{
 		ID:         "zencoder",

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -23,7 +23,9 @@ func TestFindByID(t *testing.T) {
 		{name: "antigravity", id: "antigravity", wantName: "Antigravity"},
 		{name: "antigravity-cli", id: "antigravity-cli", wantName: "Antigravity CLI"},
 		{name: "antigravity2.0", id: "antigravity2.0", wantName: "Antigravity 2.0"},
+		{name: "devin", id: "devin", wantName: "Devin"},
 		{name: "grok", id: "grok", wantName: "Grok"},
+		{name: "windsurf is no longer supported", id: "windsurf", wantErr: "unknown agent"},
 		{name: "unknown agent", id: "nonexistent", wantErr: "unknown agent"},
 	}
 	for _, tt := range tests {
@@ -159,6 +161,22 @@ func TestInstallDir(t *testing.T) {
 			gitRoot: "/tmp/monalisa-repo",
 			homeDir: "/home/monalisa",
 			wantDir: filepath.Join("/home/monalisa", ".gemini", "config", "skills"),
+		},
+		{
+			name:    "devin project scope",
+			hostID:  "devin",
+			scope:   ScopeProject,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/tmp/monalisa-repo", ".devin", "skills"),
+		},
+		{
+			name:    "devin user scope",
+			hostID:  "devin",
+			scope:   ScopeUser,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/home/monalisa", ".devin", "skills"),
 		},
 		{
 			name:    "grok project scope",

--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -89,7 +89,7 @@ func NewCmdInstall(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, ru
 
 			A wide range of AI coding agents are supported, including GitHub
 			Copilot, Claude Code, Cursor, Codex, Gemini CLI, Antigravity, Amp,
-			Goose, Grok, Junie, OpenCode, Windsurf, and many more.
+			Devin, Goose, Grok, Junie, OpenCode, and many more.
 
 			Supported %[1]s--agent%[1]s values:
 


### PR DESCRIPTION
Fixes #13986

- Replace the `windsurf` agent entry with `devin`
- Install Devin skills in `.devin/skills` at project and user scope
- Update install help text and registry tests

## Testing

- `go test ./internal/skills/... ./pkg/cmd/skills/...`