### PR TITLE
Route deploy key requests through api.Client

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -4,6 +4,9 @@ package acceptance_test
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	cryptorand "crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -20,6 +23,9 @@ import (
 	"github.com/cli/cli/v2/internal/ghcmd"
 	"github.com/cli/go-gh/v2/pkg/jq"
 	"github.com/cli/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 )
 
 func ghMain() int {
@@ -30,6 +36,35 @@ func TestMain(m *testing.M) {
 	os.Exit(testscript.RunMain(m, map[string]func() int{
 		"gh": ghMain,
 	}))
+}
+
+func TestGenerateSSHPublicKey(t *testing.T) {
+	first, err := generateSSHPublicKey("myTitle")
+	require.NoError(t, err)
+	second, err := generateSSHPublicKey("myTitle")
+	require.NoError(t, err)
+
+	publicKey, comment, options, rest, err := ssh.ParseAuthorizedKey(first)
+	require.NoError(t, err)
+	assert.Equal(t, ssh.KeyAlgoED25519, publicKey.Type())
+	assert.Equal(t, "myTitle", comment)
+	assert.Empty(t, options)
+	assert.Empty(t, rest)
+	assert.NotEqual(t, first, second)
+}
+
+func TestSandboxFilePath(t *testing.T) {
+	root := t.TempDir()
+
+	path, err := sandboxFilePath(root, root, "keys/deploy.pub")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(root, "keys/deploy.pub"), path)
+
+	_, err = sandboxFilePath(root, root, filepath.Join(root, "deploy.pub"))
+	assert.EqualError(t, err, "path must be relative to the testscript sandbox")
+
+	_, err = sandboxFilePath(root, root, "../deploy.pub")
+	assert.EqualError(t, err, "path must stay within the testscript sandbox")
 }
 
 func TestAPI(t *testing.T) {
@@ -322,6 +357,24 @@ func sharedCmds(tsEnv testScriptEnv) map[string]func(ts *testscript.TestScript, 
 				ts.Setenv(env[:i], strings.ToUpper(env[i+1:]))
 			}
 		},
+		"generate-ssh-key": func(ts *testscript.TestScript, neg bool, args []string) {
+			if neg {
+				ts.Fatalf("unsupported: ! generate-ssh-key")
+			}
+			if len(args) < 1 || len(args) > 2 {
+				ts.Fatalf("usage: generate-ssh-key file [comment]")
+			}
+
+			comment := ""
+			if len(args) == 2 {
+				comment = args[1]
+			}
+			publicKey, err := generateSSHPublicKey(comment)
+			ts.Check(err)
+			outputPath, err := sandboxFilePath(ts.Getenv("WORK"), ts.MkAbs("."), args[0])
+			ts.Check(err)
+			ts.Check(os.WriteFile(outputPath, publicKey, 0o644))
+		},
 		"replace": func(ts *testscript.TestScript, neg bool, args []string) {
 			if neg {
 				ts.Fatalf("unsupported: ! replace")
@@ -438,6 +491,41 @@ func sharedCmds(tsEnv testScriptEnv) map[string]func(ts *testscript.TestScript, 
 			ts.Setenv(args[2], result)
 		},
 	}
+}
+
+func generateSSHPublicKey(comment string) ([]byte, error) {
+	publicKey, _, err := ed25519.GenerateKey(cryptorand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	sshPublicKey, err := ssh.NewPublicKey(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	authorizedKey := bytes.TrimSpace(ssh.MarshalAuthorizedKey(sshPublicKey))
+	if comment != "" {
+		authorizedKey = append(authorizedKey, ' ')
+		authorizedKey = append(authorizedKey, comment...)
+	}
+	return append(authorizedKey, '\n'), nil
+}
+
+func sandboxFilePath(root, currentDir, name string) (string, error) {
+	if filepath.IsAbs(name) {
+		return "", errors.New("path must be relative to the testscript sandbox")
+	}
+
+	outputPath := filepath.Clean(filepath.Join(currentDir, name))
+	relativePath, err := filepath.Rel(root, outputPath)
+	if err != nil {
+		return "", err
+	}
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
+		return "", errors.New("path must stay within the testscript sandbox")
+	}
+	return outputPath, nil
 }
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")

--- a/acceptance/testdata/repo/repo-deploy-key.txtar
+++ b/acceptance/testdata/repo/repo-deploy-key.txtar
@@ -4,6 +4,9 @@ exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private --cl
 # Defer repo cleanup
 defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
 
+# Generate a globally unique deploy key
+generate-ssh-key deployKey.pub myTitle
+
 # cd to the repo and list the deploy keys. There should be no keys
 cd $SCRIPT_NAME-$RANDOM_STRING
 exec gh repo deploy-key list --json=title
@@ -26,6 +29,3 @@ exec gh repo deploy-key delete $DEPLOY_KEY_ID
 # Ensure the deploy key was deleted
 exec gh repo deploy-key list --json=id --jq='.[].id'
 ! stdout $DEPLOY_KEY_ID
-
--- deployKey.pub --
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAZmdeRNskfpvYL5YHB/YJaW8hTEXpnvPMkx5Ri+YwUr myTitle

--- a/pkg/cmd/repo/deploy-key/add/add_test.go
+++ b/pkg/cmd/repo/deploy-key/add/add_test.go
@@ -2,11 +2,15 @@ package add
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_addRun(t *testing.T) {
@@ -82,4 +86,27 @@ func Test_addRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUploadDeployKeyHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/keys"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	err := uploadDeployKey(
+		&http.Client{Transport: reg},
+		ghrepo.New("OWNER", "REPO"),
+		strings.NewReader("PUBKEY\n"),
+		"my sacred key",
+		false,
+	)
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
 }

--- a/pkg/cmd/repo/deploy-key/add/http.go
+++ b/pkg/cmd/repo/deploy-key/add/http.go
@@ -7,13 +7,12 @@ import (
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
 
 func uploadDeployKey(httpClient *http.Client, repo ghrepo.Interface, keyFile io.Reader, title string, isWritable bool) error {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "keys")
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "keys")
 	if err != nil {
 		return err
 	}
@@ -34,25 +33,8 @@ func uploadDeployKey(httpClient *http.Client, repo ghrepo.Interface, keyFile io.
 		return err
 	}
 
-	req, err := http.NewRequest("POST", url.String(), bytes.NewBuffer(payloadBytes))
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
-	}
-
-	_, err = io.Copy(io.Discard, resp.Body)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	return api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), "POST", path.String(), bytes.NewBuffer(payloadBytes), nil)
 }

--- a/pkg/cmd/repo/deploy-key/delete/delete_test.go
+++ b/pkg/cmd/repo/deploy-key/delete/delete_test.go
@@ -4,10 +4,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_deleteRun(t *testing.T) {
@@ -37,4 +39,25 @@ func Test_deleteRun(t *testing.T) {
 
 	assert.Equal(t, "", stderr.String())
 	assert.Equal(t, "✓ Deploy key deleted from OWNER/REPO\n", stdout.String())
+}
+
+func TestDeleteDeployKeyHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("DELETE", "repos/OWNER/REPO/keys/1234"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	err := deleteDeployKey(
+		&http.Client{Transport: reg},
+		ghrepo.New("OWNER", "REPO"),
+		"1234",
+	)
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
 }

--- a/pkg/cmd/repo/deploy-key/delete/http.go
+++ b/pkg/cmd/repo/deploy-key/delete/http.go
@@ -1,40 +1,20 @@
 package delete
 
 import (
-	"io"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
 
 func deleteDeployKey(httpClient *http.Client, repo ghrepo.Interface, id string) error {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "keys", id)
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "keys", id)
 	if err != nil {
 		return err
 	}
-
-	req, err := http.NewRequest("DELETE", url.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
-	}
-
-	_, err = io.Copy(io.Discard, resp.Body)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	return api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), "DELETE", path.String(), nil, nil)
 }

--- a/pkg/cmd/repo/deploy-key/list/http.go
+++ b/pkg/cmd/repo/deploy-key/list/http.go
@@ -1,13 +1,10 @@
 package list
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 	"time"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
@@ -21,33 +18,17 @@ type deployKey struct {
 }
 
 func repoKeys(httpClient *http.Client, repo ghrepo.Interface) ([]deployKey, error) {
-	u, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "keys")
+	u, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "keys")
 	if err != nil {
 		return nil, err
 	}
 	u.SetQuery("per_page", "100")
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
 
 	var keys []deployKey
-	err = json.Unmarshal(b, &keys)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), "GET", u.String(), nil, &keys)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/repo/deploy-key/list/list_test.go
+++ b/pkg/cmd/repo/deploy-key/list/list_test.go
@@ -7,9 +7,12 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListRun(t *testing.T) {
@@ -130,4 +133,24 @@ func TestListRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRepoKeysHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "repos/OWNER/REPO/keys"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	_, err := repoKeys(
+		&http.Client{Transport: reg},
+		ghrepo.New("OWNER", "REPO"),
+	)
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
 }


### PR DESCRIPTION
## Description

Part of https://github.com/cli/cli/issues/13991

This PR migrates `deploy-key add`, `deploy-key delete` and `deploy-list` to use the `api.Client` for API interactions. There should be no user visible change.

### Acceptance Tests

I also updated the acceptance test because it was using a static public key which has to be global across GitHub, so it's a terrible test artifact (and likely someone else didn't clean up and left it lying around).

```
GH_ACCEPTANCE_ORG=gh-acceptance-testing \
GH_ACCEPTANCE_TOKEN="$(gh auth token --hostname github.com)" \
GH_ACCEPTANCE_SCRIPT=repo-deploy-key.txtar \
go test -tags=acceptance -count=1 -v -run '^TestRepo$' ./acceptance
=== RUN   TestRepo
=== RUN   TestRepo/repo-deploy-key
=== PAUSE TestRepo/repo-deploy-key
=== CONT  TestRepo/repo-deploy-key
    testscript.go:584: WORK=$WORK
        PATH=/var/folders/z7/869nt6ns29d77xln9h9bm8680000gn/T/testscript-main1443323911/bin:/Users/williammartin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/bin:/Users/williammartin/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/williammartin/.local/bin
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=repo_deploy_key
        GH_CONFIG_DIR=$WORK
        GH_HOST=github.com
        ORG=gh-acceptance-testing
        GH_TOKEN=gho_************************************
        RANDOM_STRING=YrSbuqAAwP
        GH_TELEMETRY=false
        
        # Create and clone a repository with a file so it has a default branch (4.041s)
        > exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private --clone
        [stdout]
        https://github.com/gh-acceptance-testing/repo_deploy_key-YrSbuqAAwP
        [stderr]
        Cloning into 'repo_deploy_key-YrSbuqAAwP'...
        # Defer repo cleanup (0.000s)
        > defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
        # Generate a globally unique deploy key (0.002s)
        > generate-ssh-key deployKey.pub myTitle
        # cd to the repo and list the deploy keys. There should be no keys (0.346s)
        > cd $SCRIPT_NAME-$RANDOM_STRING
        $WORK/repo_deploy_key-YrSbuqAAwP
        > exec gh repo deploy-key list --json=title
        > ! stdout title
        # Add a deploy key (0.470s)
        > exec gh repo deploy-key add ../deployKey.pub
        # Ensure the deploy key was added (0.357s)
        > exec gh repo deploy-key list --json=title --jq='.[].title'
        [stdout]
        myTitle
        > stdout myTitle
        # Get the deploy key id (0.400s)
        > exec gh repo deploy-key list --json=title,id --jq='.[].title="myTitle" | .[].id'
        [stdout]
        158593071
        > stdout2env DEPLOY_KEY_ID
        # Delete the deploy key (0.592s)
        > exec gh repo deploy-key delete $DEPLOY_KEY_ID
        # Ensure the deploy key was deleted (0.412s)
        > exec gh repo deploy-key list --json=id --jq='.[].id'
        > ! stdout $DEPLOY_KEY_ID
        PASS
        
--- PASS: TestRepo (0.00s)
    --- PASS: TestRepo/repo-deploy-key (7.33s)
PASS
ok      github.com/cli/cli/v2/acceptance        7.875s
```

### Notes

**This is a stacked PR.** It targets #13988 and the stack ultimately lands on `wm/support-api-host-lift-and-shift`.