### PR TITLE
Route ssh key requests through api.Client

### DIFF
--- a/acceptance/testdata/ssh-key/ssh-key.txtar
+++ b/acceptance/testdata/ssh-key/ssh-key.txtar
@@ -2,6 +2,9 @@ skip 'it modifies the user''s personal GitHub account SSH keys'
 
 # scopes admin:ssh_signing_key,admin:public_key
 
+# Generate a globally unique account SSH key
+generate-ssh-key sshKey.pub acceptance
+
 # Add an SSH key to the account
 exec gh ssh-key add sshKey.pub --title 'acceptance-test-key'
 
@@ -19,6 +22,3 @@ exec gh ssh-key delete --yes ${SSH_KEY_ID}
 # Check the key is deleted
 exec gh ssh-key list
 ! stdout 'acceptance-test-key'
-
--- sshKey.pub --
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAZmdeRNskfpvYL5YHB/YJaW8hTEXpnvPMkx5Ri+YwUr acceptance

--- a/pkg/cmd/ssh-key/add/add_test.go
+++ b/pkg/cmd/ssh-key/add/add_test.go
@@ -2,13 +2,16 @@ package add
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_runAdd(t *testing.T) {
@@ -30,7 +33,7 @@ func Test_runAdd(t *testing.T) {
 					httpmock.StringResponse("[]"))
 				reg.Register(
 					httpmock.REST("POST", "user/keys"),
-					httpmock.RESTPayload(200, ``, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
 						assert.Contains(t, payload, "key")
 						assert.Empty(t, payload["title"])
 					}))
@@ -49,7 +52,7 @@ func Test_runAdd(t *testing.T) {
 					httpmock.StringResponse("[]"))
 				reg.Register(
 					httpmock.REST("POST", "user/ssh_signing_keys"),
-					httpmock.RESTPayload(200, ``, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
 						assert.Contains(t, payload, "key")
 						assert.Empty(t, payload["title"])
 					}))
@@ -148,4 +151,30 @@ func Test_runAdd(t *testing.T) {
 			assert.Equal(t, tt.wantStderr, stderr.String())
 		})
 	}
+}
+
+func TestSSHKeyUploadHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys"),
+		httpmock.StringResponse("[]"),
+	)
+	reg.Register(
+		httpmock.REST("POST", "user/keys"),
+		httpmock.StatusStringResponse(http.StatusUnprocessableEntity, `{"message":"Validation Failed"}`),
+	)
+
+	uploaded, err := SSHKeyUpload(
+		&http.Client{Transport: reg},
+		"github.com",
+		strings.NewReader("ssh-ed25519 asdf"),
+		"",
+	)
+
+	assert.False(t, uploaded)
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusUnprocessableEntity, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 422")
 }

--- a/pkg/cmd/ssh-key/add/http.go
+++ b/pkg/cmd/ssh-key/add/http.go
@@ -9,14 +9,13 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/ssh-key/shared"
 )
 
 // Uploads the provided SSH key. Returns true if the key was uploaded, false if it was not.
 func SSHKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, title string) (bool, error) {
-	u, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(hostname), "user", "keys")
+	u, err := safeurl.JoinPath("user", "keys")
 	if err != nil {
 		return false, err
 	}
@@ -50,7 +49,7 @@ func SSHKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, t
 		"key":   fullUserKey,
 	}
 
-	err = keyUpload(httpClient, u, payload)
+	err = keyUpload(httpClient, hostname, u, payload)
 
 	if err != nil {
 		return false, err
@@ -61,7 +60,7 @@ func SSHKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, t
 
 // Uploads the provided SSH Signing key. Returns true if the key was uploaded, false if it was not.
 func SSHSigningKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, title string) (bool, error) {
-	u, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(hostname), "user", "ssh_signing_keys")
+	u, err := safeurl.JoinPath("user", "ssh_signing_keys")
 	if err != nil {
 		return false, err
 	}
@@ -95,7 +94,7 @@ func SSHSigningKeyUpload(httpClient *http.Client, hostname string, keyFile io.Re
 		"key":   fullUserKey,
 	}
 
-	err = keyUpload(httpClient, u, payload)
+	err = keyUpload(httpClient, hostname, u, payload)
 
 	if err != nil {
 		return false, err
@@ -104,31 +103,14 @@ func SSHSigningKeyUpload(httpClient *http.Client, hostname string, keyFile io.Re
 	return true, nil
 }
 
-func keyUpload(httpClient *http.Client, u safeurl.SafeURL, payload map[string]string) error {
+func keyUpload(httpClient *http.Client, hostname string, u safeurl.SafeURL, payload map[string]string) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(payloadBytes))
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
-	}
-
-	_, err = io.Copy(io.Discard, resp.Body)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	return api.NewClientFromHTTP(httpClient).REST(hostname, http.MethodPost, u.String(), bytes.NewBuffer(payloadBytes), nil)
 }

--- a/pkg/cmd/ssh-key/delete/delete_test.go
+++ b/pkg/cmd/ssh-key/delete/delete_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/prompter"
@@ -13,6 +14,7 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewCmdDelete(t *testing.T) {
@@ -208,4 +210,37 @@ func Test_deleteRun(t *testing.T) {
 			assert.Equal(t, tt.wantStdout, stdout.String())
 		})
 	}
+}
+
+func TestDeleteSSHKeyHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("DELETE", "user/keys/1234"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+func TestGetSSHKeyHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys/1234"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
+
+	assert.Nil(t, key)
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
 }

--- a/pkg/cmd/ssh-key/delete/http.go
+++ b/pkg/cmd/ssh-key/delete/http.go
@@ -1,12 +1,9 @@
 package delete
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
 
@@ -15,55 +12,26 @@ type sshKey struct {
 }
 
 func deleteSSHKey(httpClient *http.Client, host string, keyID string) error {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(host), "user", "keys", keyID)
+	path, err := safeurl.JoinPath("user", "keys", keyID)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("DELETE", url.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
-	}
-
-	return nil
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
 }
 
 func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(host), "user", "keys", keyID)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
 	var key sshKey
-	err = json.Unmarshal(b, &key)
+	path, err := safeurl.JoinPath("user", "keys", keyID)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodGet, path.String(), nil, &key)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/ssh-key/shared/user_keys.go
+++ b/pkg/cmd/ssh-key/shared/user_keys.go
@@ -1,13 +1,10 @@
 package shared
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 	"time"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
 
@@ -25,19 +22,19 @@ type sshKey struct {
 }
 
 func UserKeys(httpClient *http.Client, host, userHandle string) ([]sshKey, error) {
-	u, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(host), "user", "keys")
+	u, err := safeurl.JoinPath("user", "keys")
 	if err != nil {
 		return nil, err
 	}
 	if userHandle != "" {
-		u, err = safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(host), "users", userHandle, "keys")
+		u, err = safeurl.JoinPath("users", userHandle, "keys")
 		if err != nil {
 			return nil, err
 		}
 	}
 	u.SetQuery("per_page", "100")
 
-	keys, err := getUserKeys(httpClient, u)
+	keys, err := getUserKeys(httpClient, host, u)
 
 	if err != nil {
 		return nil, err
@@ -51,19 +48,19 @@ func UserKeys(httpClient *http.Client, host, userHandle string) ([]sshKey, error
 }
 
 func UserSigningKeys(httpClient *http.Client, host, userHandle string) ([]sshKey, error) {
-	u, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(host), "user", "ssh_signing_keys")
+	u, err := safeurl.JoinPath("user", "ssh_signing_keys")
 	if err != nil {
 		return nil, err
 	}
 	if userHandle != "" {
-		u, err = safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(host), "users", userHandle, "ssh_signing_keys")
+		u, err = safeurl.JoinPath("users", userHandle, "ssh_signing_keys")
 		if err != nil {
 			return nil, err
 		}
 	}
 	u.SetQuery("per_page", "100")
 
-	keys, err := getUserKeys(httpClient, u)
+	keys, err := getUserKeys(httpClient, host, u)
 
 	if err != nil {
 		return nil, err
@@ -76,29 +73,12 @@ func UserSigningKeys(httpClient *http.Client, host, userHandle string) ([]sshKey
 	return keys, nil
 }
 
-func getUserKeys(httpClient *http.Client, u safeurl.SafeURL) ([]sshKey, error) {
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
+func getUserKeys(httpClient *http.Client, hostname string, u safeurl.SafeURL) ([]sshKey, error) {
 	var keys []sshKey
-	err = json.Unmarshal(b, &keys)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err := api.NewClientFromHTTP(httpClient).REST(hostname, http.MethodGet, u.String(), nil, &keys)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/ssh-key/shared/user_keys_test.go
+++ b/pkg/cmd/ssh-key/shared/user_keys_test.go
@@ -1,0 +1,28 @@
+package shared
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserKeysHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	keys, err := UserKeys(&http.Client{Transport: reg}, "github.com", "")
+
+	assert.Nil(t, keys)
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}


### PR DESCRIPTION
## Description

Part of https://github.com/cli/cli/issues/13991

This PR migrates `ssh-key add`, `ssh-key delete` and `ssh-key list` to use the `api.Client` for API interactions. There should be no user visible change.

Two test stubs changed from `RESTPayload(200, "")` to `RESTPayload(200, "{}")` because the api client expects to unmarshal json (where previously the body was just thrown away); The REST endpoints do return JSON. We also backfill tests for error paths.

### Acceptance Test

```
➜  williammartin-fuzzy-happiness git:(williammartin-route-ssh-key-api-client) GH_ACCEPTANCE_HOST=github.com \
GH_ACCEPTANCE_ORG=gh-acceptance-testing \
GH_ACCEPTANCE_TOKEN="$(gh auth token --hostname github.com)" \
GH_ACCEPTANCE_SCRIPT=ssh-key.txtar \
go test -tags=acceptance -count=1 -v -run '^TestSSHKeys$' ./acceptance
=== RUN   TestSSHKeys
=== RUN   TestSSHKeys/ssh-key
=== PAUSE TestSSHKeys/ssh-key
=== CONT  TestSSHKeys/ssh-key
    testscript.go:584: WORK=$WORK
        PATH=/var/folders/z7/869nt6ns29d77xln9h9bm8680000gn/T/testscript-main2246370769/bin:/Users/williammartin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/bin:/Users/williammartin/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/williammartin/.local/bin
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=ssh_key
        GH_CONFIG_DIR=$WORK
        GH_HOST=github.com
        ORG=gh-acceptance-testing
        GH_TOKEN=gho_************************************
        RANDOM_STRING=fLRDwDIyZK
        GH_TELEMETRY=false
        
        # skip 'it modifies the user''s personal GitHub account SSH keys'
        # scopes admin:ssh_signing_key,admin:public_key
        # Generate a globally unique account SSH key (0.001s)
        > generate-ssh-key sshKey.pub acceptance
        # Add an SSH key to the account (1.004s)
        > exec gh ssh-key add sshKey.pub --title 'acceptance-test-key'
        [stderr]
        ✓ Public key added to your account
        # List the SSH keys (0.477s)
        > exec gh ssh-key list
        [stdout]
        williammartin@github.com        ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFo0cmX3RoBGVVXxRDuaSCnirI4BZxsfZ6DwuusqBcBK        2026-01-06T07:33:03Z    139697945       authentication
        Prod    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO1mDtJU7B4IMgXZPAuc8g51ttgfQVN/QvSDfmbJjOJE        2026-04-02T11:44:06Z    147421671       authentication
        acceptance-test-key     ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDYCuEYTC/tycRuYQtka9GljaxsTz3ZuCLNdcYzdjGCK2026-07-28T14:08:32Z    158597383       authentication
        > stdout 'acceptance-test-key'
        # Get the ID of the key we created (0.284s)
        > exec gh api /user/keys --jq '.[] | select(.title == "acceptance-test-key") | .id'
        [stdout]
        158597383
        > stdout2env SSH_KEY_ID
        # Delete the SSH key (0.495s)
        > exec gh ssh-key delete --yes ${SSH_KEY_ID}
        # Check the key is deleted (0.543s)
        > exec gh ssh-key list
        [stdout]
        williammartin@github.com        ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFo0cmX3RoBGVVXxRDuaSCnirI4BZxsfZ6DwuusqBcBK        2026-01-06T07:33:03Z    139697945       authentication
        Prod    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO1mDtJU7B4IMgXZPAuc8g51ttgfQVN/QvSDfmbJjOJE        2026-04-02T11:44:06Z    147421671       authentication
        > ! stdout 'acceptance-test-key'
        PASS
        
--- PASS: TestSSHKeys (0.00s)
    --- PASS: TestSSHKeys/ssh-key (2.81s)
PASS
ok      github.com/cli/cli/v2/acceptance        3.247s
```

### Notes

**This is a stacked PR.** It targets #13989 and the stack ultimately lands on `wm/support-api-host-lift-and-shift`.