### PR TITLE
Route gpg key requests through api.Client

### DIFF
--- a/pkg/cmd/gpg-key/add/add_test.go
+++ b/pkg/cmd/gpg-key/add/add_test.go
@@ -2,15 +2,92 @@ package add
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func Test_gpgKeyUploadScopesMissing(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "user/gpg_keys"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	err := gpgKeyUpload(&http.Client{Transport: reg}, "github.com", strings.NewReader("-----BEGIN PGP PUBLIC KEY BLOCK-----"), "")
+
+	require.Same(t, errScopesMissing, err)
+}
+
+func Test_gpgKeyUploadDuplicateKeyBeforeWrongFormat(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "user/gpg_keys"),
+		httpmock.WithHeader(httpmock.StatusStringResponse(http.StatusUnprocessableEntity, `{
+			"message": "Validation Failed",
+			"errors": [{
+				"resource": "GpgKey",
+				"code": "custom",
+				"field": "key_id",
+				"message": "key_id already exists"
+			}]
+		}`), "Content-Type", "application/json"),
+	)
+
+	err := gpgKeyUpload(&http.Client{Transport: reg}, "github.com", strings.NewReader("binary-key"), "")
+
+	require.Same(t, errDuplicateKey, err)
+}
+
+func Test_gpgKeyUploadWrongFormat(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "user/gpg_keys"),
+		httpmock.StatusStringResponse(http.StatusUnprocessableEntity, `{
+			"message": "Validation Failed",
+			"errors": [{
+				"resource": "GpgKey",
+				"code": "custom",
+				"message": "We got an error doing that."
+			}]
+		}`),
+	)
+
+	err := gpgKeyUpload(&http.Client{Transport: reg}, "github.com", strings.NewReader("binary-key"), "")
+
+	require.Same(t, errWrongFormat, err)
+}
+
+func Test_gpgKeyUploadHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "user/gpg_keys"),
+		httpmock.WithHeader(
+			httpmock.StatusStringResponse(http.StatusInternalServerError, `{"message":"Internal Server Error"}`),
+			"Content-Type", "application/json",
+		),
+	)
+
+	err := gpgKeyUpload(&http.Client{Transport: reg}, "github.com", strings.NewReader("-----BEGIN PGP PUBLIC KEY BLOCK-----"), "")
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 500")
+	assert.EqualError(t, err, "HTTP 500: Internal Server Error (https://api.github.com/user/gpg_keys)")
+}
 
 func Test_runAdd(t *testing.T) {
 	tests := []struct {
@@ -28,7 +105,7 @@ func Test_runAdd(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("POST", "user/gpg_keys"),
-					httpmock.RESTPayload(200, ``, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
 						assert.Contains(t, payload, "armored_public_key")
 						assert.NotContains(t, payload, "title")
 					}))
@@ -44,7 +121,7 @@ func Test_runAdd(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("POST", "user/gpg_keys"),
-					httpmock.RESTPayload(200, ``, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
 						assert.Contains(t, payload, "armored_public_key")
 						assert.Contains(t, payload, "name")
 					}))

--- a/pkg/cmd/gpg-key/add/http.go
+++ b/pkg/cmd/gpg-key/add/http.go
@@ -44,8 +44,7 @@ func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, t
 	apiClient := api.NewClientFromHTTP(httpClient)
 	err = apiClient.REST(hostname, "POST", path.String(), bytes.NewBuffer(payloadBytes), nil)
 	if err != nil {
-		var httpError api.HTTPError
-		if errors.As(err, &httpError) {
+		if httpError, ok := errors.AsType[api.HTTPError](err); ok {
 			if httpError.StatusCode == 404 {
 				return errScopesMissing
 			}

--- a/pkg/cmd/gpg-key/add/http.go
+++ b/pkg/cmd/gpg-key/add/http.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
 
@@ -17,11 +16,6 @@ var errDuplicateKey = errors.New("key already exists")
 var errWrongFormat = errors.New("key in wrong format")
 
 func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, title string) error {
-	u, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(hostname), "user", "gpg_keys")
-	if err != nil {
-		return err
-	}
-
 	keyBytes, err := io.ReadAll(keyFile)
 	if err != nil {
 		return err
@@ -39,36 +33,34 @@ func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, t
 		return err
 	}
 
-	req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(payloadBytes))
+	path, err := safeurl.JoinPath("user", "gpg_keys")
 	if err != nil {
 		return err
 	}
 
-	resp, err := httpClient.Do(req)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	apiClient := api.NewClientFromHTTP(httpClient)
+	err = apiClient.REST(hostname, "POST", path.String(), bytes.NewBuffer(payloadBytes), nil)
 	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == 404 {
-		return errScopesMissing
-	} else if resp.StatusCode > 299 {
-		err := api.HandleHTTPError(resp)
 		var httpError api.HTTPError
 		if errors.As(err, &httpError) {
+			if httpError.StatusCode == 404 {
+				return errScopesMissing
+			}
 			for _, e := range httpError.Errors {
-				if resp.StatusCode == 422 && e.Field == "key_id" && e.Message == "key_id already exists" {
+				if httpError.StatusCode == 422 && e.Field == "key_id" && e.Message == "key_id already exists" {
 					return errDuplicateKey
 				}
 			}
-		}
-		if resp.StatusCode == 422 && !isGpgKeyArmored(keyBytes) {
-			return errWrongFormat
+			if httpError.StatusCode == 422 && !isGpgKeyArmored(keyBytes) {
+				return errWrongFormat
+			}
 		}
 		return err
 	}
 
-	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
 }
 

--- a/pkg/cmd/gpg-key/delete/delete_test.go
+++ b/pkg/cmd/gpg-key/delete/delete_test.go
@@ -3,18 +3,62 @@ package delete
 import (
 	"bytes"
 	"net/http"
+	"net/url"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/cli/go-gh/v2/pkg/api"
+	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func Test_deleteGPGKeyHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("DELETE", "user/gpg_keys/123"),
+		httpmock.WithHeader(
+			httpmock.StatusStringResponse(http.StatusInternalServerError, `{"message":"Internal Server Error"}`),
+			"Content-Type", "application/json",
+		),
+	)
+
+	err := deleteGPGKey(&http.Client{Transport: reg}, "github.com", "123")
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 500")
+	assert.EqualError(t, err, "HTTP 500: Internal Server Error (https://api.github.com/user/gpg_keys/123)")
+}
+
+func Test_getGPGKeysHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.QueryMatcher("GET", "user/gpg_keys", url.Values{"per_page": []string{"100"}}),
+		httpmock.WithHeader(
+			httpmock.StatusStringResponse(http.StatusInternalServerError, `{"message":"Internal Server Error"}`),
+			"Content-Type", "application/json",
+		),
+	)
+
+	keys, err := getGPGKeys(&http.Client{Transport: reg}, "github.com")
+
+	assert.Nil(t, keys)
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 500")
+	assert.EqualError(t, err, "HTTP 500: Internal Server Error (https://api.github.com/user/gpg_keys?per_page=100)")
+}
 
 func TestNewCmdDelete(t *testing.T) {
 	tests := []struct {
@@ -177,7 +221,7 @@ func Test_deleteRun(t *testing.T) {
 			opts: DeleteOptions{KeyID: "ABC123", Confirmed: true},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, keysResp))
-				reg.Register(httpmock.REST("DELETE", "user/gpg_keys/123"), httpmock.JSONErrorResponse(404, api.HTTPError{
+				reg.Register(httpmock.REST("DELETE", "user/gpg_keys/123"), httpmock.JSONErrorResponse(404, ghAPI.HTTPError{
 					StatusCode: 404,
 					Message:    "GPG key 123 not found",
 				}))

--- a/pkg/cmd/gpg-key/delete/http.go
+++ b/pkg/cmd/gpg-key/delete/http.go
@@ -1,12 +1,9 @@
 package delete
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
 
@@ -16,59 +13,30 @@ type gpgKey struct {
 }
 
 func deleteGPGKey(httpClient *http.Client, host, id string) error {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(host), "user", "gpg_keys", id)
+	path, err := safeurl.JoinPath("user", "gpg_keys", id)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("DELETE", url.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
-	}
-
-	return nil
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	return api.NewClientFromHTTP(httpClient).REST(host, "DELETE", path.String(), nil, nil)
 }
 
 func getGPGKeys(httpClient *http.Client, host string) ([]gpgKey, error) {
-	u, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(host), "user", "gpg_keys")
+	u, err := safeurl.JoinPath("user", "gpg_keys")
 	if err != nil {
 		return nil, err
 	}
 	u.SetQuery("per_page", "100")
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
 
 	var keys []gpgKey
-	err = json.Unmarshal(b, &keys)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(host, "GET", u.String(), nil, &keys)
 	if err != nil {
 		return nil, err
 	}
-
 	return keys, nil
 }

--- a/pkg/cmd/gpg-key/list/http.go
+++ b/pkg/cmd/gpg-key/list/http.go
@@ -1,15 +1,12 @@
 package list
 
 import (
-	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
 
@@ -38,42 +35,28 @@ type gpgKey struct {
 }
 
 func userKeys(httpClient *http.Client, host, userHandle string) ([]gpgKey, error) {
-	u, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(host), "user", "gpg_keys")
+	u, err := safeurl.JoinPath("user", "gpg_keys")
 	if err != nil {
 		return nil, err
 	}
 	if userHandle != "" {
-		u, err = safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(host), "users", userHandle, "gpg_keys")
+		u, err = safeurl.JoinPath("users", userHandle, "gpg_keys")
 		if err != nil {
 			return nil, err
 		}
 	}
 	u.SetQuery("per_page", "100")
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == 404 {
-		return nil, errScopes
-	} else if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
 
 	var keys []gpgKey
-	err = json.Unmarshal(b, &keys)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(host, "GET", u.String(), nil, &keys)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+			return nil, errScopes
+		}
 		return nil, err
 	}
 

--- a/pkg/cmd/gpg-key/list/http.go
+++ b/pkg/cmd/gpg-key/list/http.go
@@ -53,8 +53,7 @@ func userKeys(httpClient *http.Client, host, userHandle string) ([]gpgKey, error
 	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
 	err = api.NewClientFromHTTP(httpClient).REST(host, "GET", u.String(), nil, &keys)
 	if err != nil {
-		var httpErr api.HTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+		if httpErr, ok := errors.AsType[api.HTTPError](err); ok && httpErr.StatusCode == 404 {
 			return nil, errScopes
 		}
 		return nil, err

--- a/pkg/cmd/gpg-key/list/list_test.go
+++ b/pkg/cmd/gpg-key/list/list_test.go
@@ -3,16 +3,69 @@ package list
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func Test_userKeysScopesMissing(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.QueryMatcher("GET", "user/gpg_keys", url.Values{"per_page": []string{"100"}}),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	keys, err := userKeys(&http.Client{Transport: reg}, "github.com", "")
+
+	assert.Nil(t, keys)
+	require.Same(t, errScopes, err)
+}
+
+func Test_userKeysHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.QueryMatcher("GET", "user/gpg_keys", url.Values{"per_page": []string{"100"}}),
+		httpmock.WithHeader(
+			httpmock.StatusStringResponse(http.StatusInternalServerError, `{"message":"Internal Server Error"}`),
+			"Content-Type", "application/json",
+		),
+	)
+
+	keys, err := userKeys(&http.Client{Transport: reg}, "github.com", "")
+
+	assert.Nil(t, keys)
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 500")
+	assert.EqualError(t, err, "HTTP 500: Internal Server Error (https://api.github.com/user/gpg_keys?per_page=100)")
+}
+
+func Test_userKeysForUser(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.QueryMatcher("GET", "users/monalisa/gpg_keys", url.Values{"per_page": []string{"100"}}),
+		httpmock.StringResponse(`[{"key_id":"ABC123"}]`),
+	)
+
+	keys, err := userKeys(&http.Client{Transport: reg}, "github.com", "monalisa")
+
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "ABC123", keys[0].KeyID)
+}
 
 func Test_listRun(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

Part of https://github.com/cli/cli/issues/13991

This PR migrates `gpg-key add`, `gpg-key delete` and `gpg-key list` to use the `api.Client` for API interactions. There should be no user visible change.

We add tests for three ordered sentinel errors:
 1. `404` -> `errScopesMissing`
 2. `422` mentioning a duplicate `key_id` -> `errDuplicateKey` 
 3.  `422` for an unarmored key -> `errWrongFormat`.

This _might_ be an overspecification of the tests, but it is behaviour that might be depended upon by someone out there, so at least worth knowing if it changed.

Two test stubs changed from `RESTPayload(200, "")` to `RESTPayload(200, "{}")` because the api client expects to unmarshal json (where previously the body was just thrown away); The REST endpoints do return JSON. We also backfill tests for other error paths.

### Acceptance Test

```
➜  williammartin-laughing-couscous git:(williammartin-route-gpg-key-api) ✗ GH_ACCEPTANCE_HOST=github.com \
GH_ACCEPTANCE_ORG=gh-acceptance-testing \
GH_ACCEPTANCE_TOKEN="$(gh auth token --hostname github.com)" \
GH_ACCEPTANCE_SCRIPT=gpg-key.txtar \
go test -tags=acceptance -count=1 -v -run '^TestGPGKeys$' ./acceptance
=== RUN   TestGPGKeys
=== RUN   TestGPGKeys/gpg-key
=== PAUSE TestGPGKeys/gpg-key
=== CONT  TestGPGKeys/gpg-key
    testscript.go:584: WORK=$WORK
        PATH=/var/folders/z7/869nt6ns29d77xln9h9bm8680000gn/T/testscript-main1374413527/bin:/Users/williammartin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/bin:/Users/williammartin/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/williammartin/.local/bin
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=gpg_key
        GH_CONFIG_DIR=$WORK
        GH_HOST=github.com
        ORG=gh-acceptance-testing
        GH_TOKEN=gho_************************************
        RANDOM_STRING=fVJVPWtXGk
        GH_TELEMETRY=false
        
        #skip 'it modifies the user''s personal GitHub account GPG keys'
        # This test requires the admin:gpg_key scope to add and delete GPG keys to and
        # from the user's personal GitHub account. 
        # This test uses a GPG key that generated for this test only. The private key
        # has been deleted
        # Add the gpg key to GH account (0.816s)
        > exec gh gpg-key add gpg-key.pub
        # Verify the gpg key was added to GH account (0.316s)
        > exec gh gpg-key list
        [stdout]
        cli@github.com  24C30F9C9115E747        xjMEZxpWhhYJKwYBBAHaRw8BAQdAmYiobR2ai/lVWOBtlAPRG1ZEMG5Effavpt5wn+wQ//U=        2026-07-28T17:44:54+02:00       2024-10-25T16:15:34+02:00
        > stdout '24C30F9C9115E747'
        # Delete the gpg key from GH account (0.613s)
        > exec gh gpg-key delete --yes '24C30F9C9115E747'
        # Check the key is deleted (0.310s)
        > exec gh gpg-key list
        > ! stdout '24C30F9C9115E747'
        PASS
        
--- PASS: TestGPGKeys (0.00s)
    --- PASS: TestGPGKeys/gpg-key (2.06s)
PASS
ok      github.com/cli/cli/v2/acceptance        2.776s
```