### PR TITLE
Add issue subscription API support

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -24,30 +24,32 @@ type IssuesAndTotalCount struct {
 }
 
 type Issue struct {
-	Typename         string `json:"__typename"`
-	ID               string
-	Number           int
-	Title            string
-	URL              string
-	State            string
-	StateReason      string
-	Closed           bool
-	Body             string
-	ActiveLockReason string
-	Locked           bool
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
-	ClosedAt         *time.Time
-	Comments         Comments
-	Author           Author
-	Assignees        Assignees
-	AssignedActors   AssignedActors
-	Labels           Labels
-	ProjectCards     ProjectCards
-	ProjectItems     ProjectItems
-	Milestone        *Milestone
-	ReactionGroups   ReactionGroups
-	IsPinned         bool
+	Typename           string `json:"__typename"`
+	ID                 string
+	Number             int
+	Title              string
+	URL                string
+	State              string
+	StateReason        string
+	Closed             bool
+	Body               string
+	ActiveLockReason   string
+	Locked             bool
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+	ClosedAt           *time.Time
+	Comments           Comments
+	Author             Author
+	Assignees          Assignees
+	AssignedActors     AssignedActors
+	Labels             Labels
+	ProjectCards       ProjectCards
+	ProjectItems       ProjectItems
+	Milestone          *Milestone
+	ReactionGroups     ReactionGroups
+	IsPinned           bool
+	ViewerCanSubscribe bool
+	ViewerSubscription *githubv4.SubscriptionState
 
 	IssueType        *IssueType
 	Parent           *LinkedIssue

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -66,6 +66,8 @@ type PullRequest struct {
 	IsCrossRepository   bool
 	IsDraft             bool
 	MaintainerCanModify bool
+	ViewerCanSubscribe  bool
+	ViewerSubscription  *githubv4.SubscriptionState
 
 	BaseRef struct {
 		BranchProtectionRule struct {

--- a/api/queries_subscription.go
+++ b/api/queries_subscription.go
@@ -1,0 +1,23 @@
+package api
+
+import "github.com/shurcooL/githubv4"
+
+// UpdateSubscription changes the viewer's subscription state for a subscribable node.
+func UpdateSubscription(client *Client, host, id string, state githubv4.SubscriptionState) error {
+	var mutation struct {
+		UpdateSubscription struct {
+			Subscribable struct {
+				ID githubv4.ID
+			}
+		} `graphql:"updateSubscription(input: $input)"`
+	}
+
+	variables := map[string]interface{}{
+		"input": githubv4.UpdateSubscriptionInput{
+			SubscribableID: githubv4.ID(id),
+			State:          state,
+		},
+	}
+
+	return client.Mutate(host, "UpdateSubscription", &mutation, variables)
+}

--- a/api/queries_subscription_test.go
+++ b/api/queries_subscription_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateSubscription(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.GraphQL(`mutation UpdateSubscription\b`),
+		httpmock.GraphQLMutation(`{
+			"data": {
+				"updateSubscription": {
+					"subscribable": {"id": "ISSUE-ID"}
+				}
+			}
+		}`, func(inputs map[string]interface{}) {
+			assert.Equal(t, "ISSUE-ID", inputs["subscribableId"])
+			assert.Equal(t, "SUBSCRIBED", inputs["state"])
+		}),
+	)
+
+	err := UpdateSubscription(newTestClient(reg), "github.com", "ISSUE-ID", githubv4.SubscriptionStateSubscribed)
+	require.NoError(t, err)
+}
+
+func TestUpdateSubscription_error(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.GraphQL(`mutation UpdateSubscription\b`),
+		httpmock.GraphQLMutation(`{
+			"errors": [{"type": "FORBIDDEN", "message": "subscription denied"}]
+		}`, func(inputs map[string]interface{}) {}),
+	)
+
+	err := UpdateSubscription(newTestClient(reg), "github.com", "ISSUE-ID", githubv4.SubscriptionStateSubscribed)
+	require.EqualError(t, err, "GraphQL: subscription denied")
+}

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -330,6 +330,7 @@ var sharedIssuePRFields = []string{
 	"title",
 	"updatedAt",
 	"url",
+	"viewerSubscription",
 }
 
 // Some fields are only valid in the context of issues.

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -19,6 +19,11 @@ func TestPullRequestGraphQL(t *testing.T) {
 			want:   "number,title",
 		},
 		{
+			name:   "subscription fields",
+			fields: []string{"viewerCanSubscribe", "viewerSubscription"},
+			want:   "viewerCanSubscribe,viewerSubscription",
+		},
+		{
 			name:   "fields with nested structures",
 			fields: []string{"author", "assignees"},
 			want:   "author{login,...on User{id,name}},assignees(first:100){nodes{id,login,name,databaseId},totalCount}",
@@ -63,6 +68,11 @@ func TestIssueGraphQL(t *testing.T) {
 			name:   "simple fields",
 			fields: []string{"number", "title"},
 			want:   "number,title",
+		},
+		{
+			name:   "subscription fields",
+			fields: []string{"viewerCanSubscribe", "viewerSubscription"},
+			want:   "viewerCanSubscribe,viewerSubscription",
 		},
 		{
 			name:   "fields with nested structures",

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -3,6 +3,7 @@ package view
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -46,6 +47,7 @@ func TestJSONFields(t *testing.T) {
 		"title",
 		"updatedAt",
 		"url",
+		"viewerSubscription",
 		"isPinned",
 		"stateReason",
 		"issueType",
@@ -940,6 +942,51 @@ func TestIssueView_json_IssueType(t *testing.T) {
 	assert.Equal(t, "Bug", issueType["name"])
 	assert.Equal(t, "Something is not working", issueType["description"])
 	assert.Equal(t, "d73a4a", issueType["color"])
+}
+
+func TestIssueView_json_ViewerSubscription(t *testing.T) {
+	tests := []struct {
+		name                   string
+		viewerSubscription     string
+		wantViewerSubscription any
+	}{
+		{
+			name:                   "subscribed",
+			viewerSubscription:     `"SUBSCRIBED"`,
+			wantViewerSubscription: "SUBSCRIBED",
+		},
+		{
+			name:                   "not reported",
+			viewerSubscription:     "null",
+			wantViewerSubscription: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpReg := &httpmock.Registry{}
+			defer httpReg.Verify(t)
+
+			httpReg.Register(
+				httpmock.GraphQL(`query IssueByNumber\b`),
+				httpmock.StringResponse(fmt.Sprintf(`{
+					"data": {
+						"repository": {
+							"hasIssuesEnabled": true,
+							"issue": {"viewerSubscription": %s}
+						}
+					}
+				}`, tt.viewerSubscription)),
+			)
+
+			output, err := runCommand(httpReg, false, `123 --json viewerSubscription`)
+			require.NoError(t, err)
+
+			var data map[string]interface{}
+			require.NoError(t, json.Unmarshal(output.OutBuf.Bytes(), &data))
+			assert.Equal(t, tt.wantViewerSubscription, data["viewerSubscription"])
+		})
+	}
 }
 
 func TestIssueView_json_ParentSubIssues(t *testing.T) {

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cli/cli/v2/pkg/jsonfieldstest"
 	"github.com/cli/cli/v2/test"
 	"github.com/google/shlex"
+	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -74,7 +75,41 @@ func TestJSONFields(t *testing.T) {
 		"title",
 		"updatedAt",
 		"url",
+		"viewerSubscription",
 	})
+}
+
+func TestPRView_json_ViewerSubscription(t *testing.T) {
+	subscribed := githubv4.SubscriptionStateSubscribed
+	tests := []struct {
+		name               string
+		viewerSubscription *githubv4.SubscriptionState
+		want               string
+	}{
+		{
+			name:               "subscribed",
+			viewerSubscription: &subscribed,
+			want:               `{"viewerSubscription":"SUBSCRIBED"}`,
+		},
+		{
+			name: "not reported",
+			want: `{"viewerSubscription":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			pr := &api.PullRequest{ViewerSubscription: tt.viewerSubscription}
+			shared.StubFinderForRunCommandStyleTests(t, "12", pr, ghrepo.New("OWNER", "REPO"))
+
+			output, err := runCommand(reg, "", false, `12 --json viewerSubscription`)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, output.String())
+		})
+	}
 }
 
 func Test_NewCmdView(t *testing.T) {


### PR DESCRIPTION
- Part of https://github.com/cli/cli/issues/14009

This is the first PR in a stack of several PRs to allow users to manage notification subscriptions for issues/PRs. It is intended to be a simple way to utilize the same functionality that exists in the issues UI with the "subscribe" and "unsubscribe" button in the sidebar:

<img width="730" height="318" alt="Notifications section on a GitHub Issue, showing an unsubscribe button for the issue" src="https://github.com/user-attachments/assets/c31cf093-57aa-4553-8840-eed1f6daa7af" />

## This PR

- Adds the ability to request `viewerSubscription` when viewing the JSON output for issues and pull requests. This lets you see if you are subscribed to an issue/PR or not. The `gh issue view` has not been updated by default.
- Adds a `UpdateSubscription` operation that uses GraphQL to update a subscription for anything that is subscribable. This is not used yet, but will be used by the issue unsubscribe/subscribe commands in following PRs.

## Stack

I couldn't create a true stack of PRs since I don't have write access. I split this work up into smaller reviewable PRs though. This first PR is just adding API support, but not necessarily exposing the new subcommands.

I'll create PRs in `cli/cli` for the subsequent work once this is merged.

1. **cli/cli#13998 - API support (this PR)**
2. [camchenry/cli#1 - `gh issue subscribe`](https://github.com/camchenry/cli/pull/1)
3. [camchenry/cli#2 - unsubscribe and ignore](https://github.com/camchenry/cli/pull/2)

---

What follows is a general proposal for all of the functionality in this stack of PRs.

# Proposal: `gh issue subscribe`, `unsubscribe`, and `ignore`

There currently isn't a way in the GitHub CLI to directly manage notifications for an issue or PR. This proposal adds three targeted commands:

```sh
gh issue subscribe <number | url>
gh issue unsubscribe <number | url>
```

This keeps the API narrow and matches existing pairs such as `gh issue close/reopen`, `lock/unlock`, and `pin/unpin`. It also reuses the selectors already in the CLI where you can pass an issue or pull request number in the current repository (or other repo with `--repo`), or a full issue or pull request URL.

## Behavior

Each command maps directly to a documented GraphQL `SubscriptionState`:

| Command | Mutation input | Documented meaning |
| --- | --- | --- |
| `subscribe` | `SUBSCRIBED` | Notify for all activity |
| `unsubscribe` | `UNSUBSCRIBED` | Notify only when participating or mentioned |
| `ignore` | `IGNORED` | Never notify |

### Unsubscribe vs ignore

The distinction between unsubscribe and ignore is meaningful for repository subscriptions. But for issues, it is not quite as meaningful, because the API normalizes both `UNSUBSCRIBED` and `IGNORED` inputs to `viewerSubscription: IGNORED` and `viewerThreadSubscriptionStatus: IGNORING_THREAD`. The issue UI still sends `UNSUBSCRIBED` for its Unsubscribe button though.

I would say we should add `gh issue ignore` as an alias of `gh issue unsubscribe`.

### `gh pr`?

Like existing `gh issue` commands, these commands also accept pull request numbers and URLs. This preserves parity within the `issue` command group without adding a separate `gh pr subscribe` command in the same change. We could add support for a `gh pr subscribe` and `gh pr unsubscribe` command as well in the future.

## Example usage

```console
$ gh issue subscribe 123
✓ Subscribed to issue cli/cli#123 (Add subscription commands)

$ gh issue unsubscribe 123 --repo cli/cli
✓ Unsubscribed from issue cli/cli#123 (Add subscription commands)
```

Issue and pull request URLs select their repository automatically:

```console
$ gh issue subscribe https://github.com/cli/cli/pull/456
✓ Subscribed to issue cli/cli#456 (Handle notification scopes)
```

This follows existing `gh issue close/reopen` output, which uses "issue" when a pull request is addressed through the `issue` command group. A future `gh pr subscribe` command could use "pull request" instead though.

The state can also be inspected through existing JSON output with the `--json` flag on `gh issue view`:

```console
$ gh issue view 123 --json viewerSubscription --jq .viewerSubscription
SUBSCRIBED
```

After either an explicit unsubscribe or ignore, the API currently reports `IGNORED`:

```console
$ gh issue view 123 --json viewerSubscription --jq .viewerSubscription
IGNORED
```

If an issue is already subscribed/unsubscribed, then we report that nothing changed.

```console
$ gh issue subscribe 123
! Issue cli/cli#123 (Add subscription commands) is already subscribed

$ gh issue unsubscribe 456
✓ Unsubscribed from issue cli/cli#456 (Handle notification scopes)
```

Invalid selectors and missing targets use the existing `gh issue` errors:

```console
$ gh issue subscribe not-an-issue
invalid issue format: "not-an-issue"

$ gh issue subscribe 999999999
GraphQL: Could not resolve to an issue or pull request with the number of 999999999.
```

When the API rejects the mutation because the token lacks the required scope, the command provides the recovery command:

```console
$ gh issue subscribe 123
This API operation needs the "notifications" scope. To request it, run:  gh auth refresh -h github.com -s notifications
```

If the target exists but `viewerCanSubscribe` is false, the command returns `cannot change subscription for cli/cli#123`. Other API errors are returned unchanged.

## Authentication scope

The API requires the OAuth `notifications` scope for `updateSubscription`, which isn't one of the default scopes. This is similar to how we require `projects` scope for any `gh project` usage.

The handling should stay local to these commands rather than changing `api.Client` for every GraphQL request so that we don't require this scope for all commands, just the subscribe/unsubscribe commands.

## Alternatives considered

### `gh subscribe <target>`

A top-level `gh subscribe <target>` is shorter, but it introduces a new cross-resource command that doesn't match how `gh` already groups actions by resource mostly. This PR doesn't preclude adding this eventually though.

### `gh issue subscription set` / `gh issue subscription --set`

A single `gh issue subscription set --state ...` command mirrors the GraphQL API more closely, but makes the common workflow harder to discover and use. It's not as intuitive to use I think.

## Future extension

The shared mutation for updating subscriptions can later be used for other similar commands:

```sh
# PR subscriptions
gh pr subscribe <number | url | branch>
gh pr unsubscribe <number | url | branch>
gh pr ignore <number | url | branch>

# Watching/unwatching repositories
gh repo subscribe [<repository>]
gh repo unsubscribe [<repository>]
gh repo ignore [<repository>]

# Discussions
gh discussion subscribe <number | url>
gh discussion unsubscribe <number | url>
gh discussion ignore <number | url>
```

A future command could be added for listing all subscriptions (like discussed in https://github.com/cli/cli/issues/8139), but I don't think that should prevent us from adding this functionality right now. 