### PR TITLE
Add a code review agent skill

### DIFF
--- a/.github/skills/cli-code-reviewer/SKILL.md
+++ b/.github/skills/cli-code-reviewer/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: cli-code-reviewer
+description: Reviews GitHub CLI (gh) pull requests against codebase conventions
+---
+
+# CLI Code Reviewer
+
+You review pull requests for the GitHub CLI (`gh`). Hold each change to the conventions in `AGENTS.md` and hunt for the issues below.
+
+## Understand intent first
+
+Before critiquing the diff, establish what the change is for and whether it was agreed.
+
+- Read the linked issue, its comments, and the PR description for the spec and acceptance criteria.
+- Search related issues, pull requests, and commits for prior decisions on the same idea.
+- Prefer correctness and regression findings over style. Verify a claim against the code before raising it, so the review posts no false positives.
+
+## Conventions
+
+`AGENTS.md` at the repo root is the authoritative convention set. Read it fresh and hold every changed file to it; its rules take precedence over your own preferences.
+
+## What to look for
+
+### 🛑 Requirement
+
+Severity: blocking
+
+- A change that contradicts a past maintainer decision. Cite the commit, pull request, or issue where the idea was rejected.
+- A breaking change the PR does not document or a maintainer has not approved. See What counts as breaking below.
+- A downstream break, such as changing an error-message string that a later conditional keys on.
+- New or changed API surface: validate it, and confirm whether feature detection or other GHES handling is required.
+- New behavior that ships without tests. Every new branch, validator, and error case needs coverage, not just the happy path.
+- Logic that reimplements something the codebase already makes reusable.
+  - Search for an existing equivalent before accepting new helper code, and flag the duplication.
+  - Look first in:
+    - the command set's `shared` package, for logic shared across its subcommands
+    - the top-level `api` and `git` packages, for operations that span command sets
+    - cross-cutting `internal` helpers such as `internal/text`
+    - the Go standard library
+- A bug, a security issue, or otherwise incorrect behavior.
+- A violated `AGENTS.md` rule, or a failing `go test ./...` or `make lint`.
+
+### 💭 Commentary
+
+Severity: non-blocking
+
+- Go modernization the toolchain would apply, such as what `go fix` would change.
+- A refactor that meaningfully cuts lines of code.
+- An alternative approach with different trade-offs.
+- Command-local logic that might be worth exporting / migrating into a shared package.
+
+### 💅 Nit
+
+Severity: non-blocking
+
+- Overly long or pointless comments to shorten.
+- Readability and naming.
+
+### Scope and reviewability
+
+Severity: non-blocking
+
+Beyond the code, review the shape of the PR and advise on how to make it reviewable.
+
+- Scope: keep a PR to one concern. Flag a PR that bundles an unrelated refactor or fix with its main change, and name what to split out.
+- Commits: commits should be atomic and easy to review. Large mechanical or repetitive changes in one commit are fine, but flag complex logic crammed into a single commit or a history that is hard to follow. Read the code and suggest reviewable chunks to break it into.
+
+## What counts as breaking
+
+A change can be breaking even when it is intentional, well-reasoned, and documented. Do not wave one through because the PR argues it is an improvement. Judge it by who consumes the behavior:
+
+- Interactive (TTY): a human runs the command, reads the output, and answers prompts. They can pick a different option or read a changed label, so changes to interactive flows are not breaking.
+- Non-interactive (non-TTY): a script runs the command, passes flags, and consumes output deterministically. Changing anything a script depends on is breaking.
+
+Flag a change to the non-interactive contract as a requirement:
+
+- Moving output between stdout and stderr, or changing what a command writes on the non-TTY path. Scripts redirect and consume those streams.
+- Changing the output a script parses, such as a `--json` field or a command's default output.
+- Changing a default value or behavior on the non-interactive path.
+- Tightening the input a flag accepts, so a value that used to work now errors.
+- Changing an exit code, or erroring where the command used to succeed.
+- Renaming any command input: flags, arguments, or subcommands.
+
+## How to report
+
+Each finding needs a severity label:
+
+- 🛑 Requirement: a breaking change, security concern, deviation from convention.
+- 💭 Commentary: a non-blocking improvement or food for thought.
+- 💅 Nit: a non-blocking, minor polish.
+
+Structure the review this way:
+
+- Group findings by severity: requirements first, then commentary, then nits.
+
+Write each finding with this style guide:
+
+- Label it with its severity label.
+- Describing behavior changes from a user perspective is a helpful framing tool; "A user who runs `gh foo bar` will have this problem".
+- Use annotated code blocks to help highlight the problem and the fix where it is appropriate to do so.
+- Describe each finding in plain language, ramp up to the technical details as needed, giving plain language exposition.
+- Avoid inline code-fences referring to type names, functions, etc.; prefer annotated code blocks.
+- OPTIONAL: Include a "References" section with links to related issues, pull requests, or commits that provide context for the finding.
+    - High value references are things like a prior PR that rejected the same idea, or a commit that introduced the code in question, or a maintainer's comment regarding this logic.
+
+Write each finding with this template:
+
+```markdown
+<SEVERITY LABEL>: <1-LINE SUMMARY OF THE FINDING>
+
+<DETAILS>
+
+References:
+<OTHER ISSUE AND PR CONTEXT>
+```

--- a/.github/skills/cli-code-reviewer/SKILL.md
+++ b/.github/skills/cli-code-reviewer/SKILL.md
@@ -45,6 +45,7 @@ Severity: blocking
 Severity: non-blocking
 
 - Go modernization the toolchain would apply, such as what `go fix` would change.
+- Any issues reported by running `golangci-lint run`, or any non-empty diff returned by `golangci-lint fmt --diff`.
 - A refactor that meaningfully cuts lines of code.
 - An alternative approach with different trade-offs.
 - Command-local logic that might be worth exporting / migrating into a shared package.
@@ -79,6 +80,7 @@ Flag a change to the non-interactive contract as a requirement:
 - Changing a default value or behavior on the non-interactive path.
 - Tightening the input a flag accepts, so a value that used to work now errors.
 - Changing an exit code, or erroring where the command used to succeed.
+- Changing an error message
 - Renaming any command input: flags, arguments, or subcommands.
 
 ## How to report

--- a/.github/skills/cli-code-reviewer/SKILL.md
+++ b/.github/skills/cli-code-reviewer/SKILL.md
@@ -99,7 +99,7 @@ Write each finding with this style guide:
 - Describing behavior changes from a user perspective is a helpful framing tool; "A user who runs `gh foo bar` will have this problem".
 - Use annotated code blocks to help highlight the problem and the fix where it is appropriate to do so.
 - Describe each finding in plain language, ramp up to the technical details as needed, giving plain language exposition.
-- Avoid inline code-fences referring to type names, functions, etc.; prefer annotated code blocks.
+- Avoid inline code spans referring to type names, functions, etc.; prefer annotated code blocks.
 - OPTIONAL: Include a "References" section with links to related issues, pull requests, or commits that provide context for the finding.
     - High value references are things like a prior PR that rejected the same idea, or a commit that introduced the code in question, or a maintainer's comment regarding this logic.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,11 @@ Add `--json`, `--jq`, `--template` flags via `cmdutil.AddJSONFlags(cmd, &opts.Ex
 
 ## Testing
 
+Test architecture for commands should generally follow this pattern:
+
+- One table test for the command constructor (`NewCmdFoo`) to verify flag parsing and `Opts` curation.
+- One table test for the run function (`fooRun`) to verify business logic, output, and mocked HTTP/Git interactions.
+
 ### HTTP Mocking
 
 Use `httpmock.Registry` with `defer reg.Verify(t)` to ensure all stubs are called:
@@ -138,6 +143,7 @@ for _, tt := range tests {
 
 - Add godoc comments to all exported functions, types, and constants
 - Avoid unnecessary code comments — only comment when the *why* isn't obvious from the code
+- Comments that imbue sanitized and summarized context from your conversation with a human are very valuable. For example, if you found during development that without the code something downstream would break, that's good context to include.
 - Do not comment just to restate what the code does
 - Never use em dashes (—) in code, comments, or documentation; use regular dashes (-) or rewrite the sentence instead
 
@@ -165,6 +171,8 @@ if features.SomeCapability {
 }
 ```
 
+Use feature detection only when an API is not GA on all supported GHES versions; skip it for long-established APIs.
+
 ## API Patterns
 
 ```go
@@ -174,3 +182,9 @@ client.REST(hostname, "GET", "repos/owner/repo", nil, &data)
 ```
 
 For host resolution, use `cfg.Authentication().DefaultHost()` — not `ghinstance.Default()` which always returns `github.com`.
+
+Avoid extra round-trips.
+
+## Code Review
+
+Review pull requests with the [`cli-code-reviewer` skill](.github/skills/cli-code-reviewer/SKILL.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ client.GraphQL(hostname, query, variables, &data)
 client.REST(hostname, "GET", "repos/owner/repo", nil, &data)
 ```
 
-For host resolution, use `cfg.Authentication().DefaultHost()` — not `ghinstance.Default()` which always returns `github.com`.
+For host resolution, use `cfg.Authentication().DefaultHost()`; do not use `ghinstance.Default()` which always returns `github.com`.
 
 Avoid extra round-trips.
 


### PR DESCRIPTION
### Description

This adds a `cli-code-reviewer` agent skill that captures how an agent can review `gh` pull requests, and reference it in `AGENTS.md`.

This will cause our CCR workflows to read this skill automatically and follow the methodology in that skill for discovery of problems.

### Review Methodology

The skill directs the reviewer to work in this order:

- Understand intent first. Read the linked issue, the PR description, and prior discussion to learn what the change is for, then verify each claim against the code so the review posts no false positives.
- Hold the diff to `AGENTS.md`. Those conventions are authoritative.
- Sort every finding into one of three buckets: a blocking Requirement, non-blocking Commentary, or a Nit.
- Judge breaking changes based on our classification: who consumes the behavior. Interactive output is for a human and may change, while the non-interactive surface that scripts parse is a contract, so changing it is blocking.
- Review the shape of the PR too: keep it to one concern and flag commits that are hard to follow.
- Report findings grouped by severity, each with a severity label and, where it helps, links to the issues or pull requests that give context.

### Key Technical Points

- The skill lives under `.github/skills/` instead of at the repo root's `skills` folder. This is because this isn't a published skill. It's meant to be consumed by agents working in this repo only, like agents that have checked out this repo or CCR/CCA
- The skill defers to `AGENTS.md` for code conventions rather than restating them
- `AGENTS.md` gains a short Code Review section that points back at the skill, hinting at CCR to pick it up
- This PR also introduces a few more codebase convention notes to `AGENTS.md`