### PR TITLE
Establish a pull request template for scale

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,60 @@
 <!--
-  Thank you for contributing to GitHub CLI!
-  To reference an open issue, please write this in your description: `Fixes #NUMBER`
+Thank you for contributing to GitHub CLI!
+
+If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
 -->
+
+<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->
+
+### Description
+
+<!--
+What's the problem? How are we addressing it?
+
+Write for a reviewer who has not worked in this part of the codebase. Give them the
+background they need before the problem makes sense, and avoid jargon.
+-->
+
+### How did you test this change?
+
+<!--
+Demonstrate the code is solid, and how you know it solves the problem in the description.
+Give the exact commands you ran and their output.
+If this changes command output, show it before and after. Screenshot images are preferred over pasted text.
+
+If you leave this empty, your pull request will very likely be closed.
+-->
+
+### Key points
+
+<!--
+Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
+-->
+
+### Notes for reviewers
+
+<!--
+Where should review start, and what should be read next? Call out anything you are unsure about.
+
+Link related issues or prior discussion, with one sentence on why each matters.
+-->
+
+### Authorship and follow-up
+
+<!--
+REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.
+
+Check exactly one box in each list.
+-->
+
+Who wrote this:
+
+- [ ] A human wrote it.
+- [ ] An agent wrote it under close human direction.
+- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.
+
+Who answers review comments:
+
+- [ ] @username will read and reply directly. Name the account.
+- [ ] An agent will draft replies and @username will read them before they are posted.
+- [ ] Nobody has explicitly committed to replying.


### PR DESCRIPTION
### Description
Our pull request template was a single comment. That left reviewers to reconstruct the problem, the approach, and whether anything had really been verified aside from superficial "I ran the tests" type comments.

In the agentic era, we also need to guess about if someone is a human and if they'll be around to answer questions. Let's stop guessing so much and ask - if they lie, so be it. But let's try and encourage transparency.

This replaces the PR template with a real one. Each section asks for something a reviewer cannot get by reading the code.

### Key & Interesting Points
The development of this template came from my personal opinions and anecdotes, augmented with what I could find across other open source repositories.

The testing section follows [React's template](https://github.com/facebook/react/blob/main/.github/PULL_REQUEST_TEMPLATE.md). They ask for "the exact commands you ran and their output," and make visual evidence conditional on the change touching the interface. That phrasing still extracts terminal output when output changes, and it survives refactors that have none.

React's "If you leave this empty, your PR will very likely be closed" is the cheapest enforcement in any template I looked at, because it needs no CI. I'm not suggesting we add automation here; there will absolutely be cases where we feel it's warranted to violate the template's rules. For example, documentation and test harness changes seem like an appropriate candidate to omit this section.

The authorship checkboxes are part of my augmented own hot take on AI disclosure. [deno](https://github.com/denoland/deno/blob/main/.github/PULL_REQUEST_TEMPLATE.md), [Homebrew](https://github.com/Homebrew/brew/blob/main/.github/PULL_REQUEST_TEMPLATE.md), and [curl](https://github.com/curl/curl/blob/master/docs/CONTRIBUTE.md) all require AI disclosure, but none of them asks who will answer review comments. Hopefully unattended pull requests become visible.

### Additional Context
- [React's PR template](https://github.com/facebook/react/blob/main/.github/PULL_REQUEST_TEMPLATE.md) is where the testing section and the close warning come from.
- [deno's template](https://github.com/denoland/deno/blob/main/.github/PULL_REQUEST_TEMPLATE.md) rejects pull requests on suspicion of undisclosed AI use, the strongest disclosure requirement I found.
- [Homebrew's template](https://github.com/Homebrew/brew/blob/main/.github/PULL_REQUEST_TEMPLATE.md) pairs an AI checkbox with a throttle, "Non-maintainers may only have one AI-assisted PR open at a time," which we also turned on, but didn't document anywhere.
- [curl's contributing guide](https://github.com/curl/curl/blob/master/docs/CONTRIBUTE.md) makes responsiveness standing policy rather than a per-pull-request promise, which is probably where a durable version of the follow-up question belongs.
- [Kubernetes' review guide](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md) on keeping pull requests small, as a reminder that no template rescues a change that is too big to review.

### Follow-up
While developing this template, I realized that our contribution guidelines don't have much quality steering. The information is too light, [AGENTS.md](https://github.com/cli/cli/blob/b1a9f7b183c12ae111ea63048d49aad2a53e9101/AGENTS.md) is a better technical contributing guide. It focuses a lot on finding issues to work on or surface level things, but not enough about what does a quality contribution look like once you're writing code. An honourable mention is also the responsiveness thing - something like that seems practical to have in a contribution guide. Problems for another time and another PR.