### PR TITLE
Route autolink requests through api.Client

### DIFF
--- a/acceptance/testdata/repo/repo-autolink.txtar
+++ b/acceptance/testdata/repo/repo-autolink.txtar
@@ -1,0 +1,31 @@
+# Create a repository to hold the autolink references
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# List the autolinks. There should be none
+exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=keyPrefix
+! stdout keyPrefix
+
+# Create an alphanumeric autolink
+exec gh repo autolink create --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING TICKET- 'https://example.com/TICKET?query=<num>'
+
+# Ensure the autolink was created
+exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=keyPrefix --jq='.[].keyPrefix'
+stdout 'TICKET-'
+
+# Get the autolink id
+exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=keyPrefix,id --jq='.[] | select(.keyPrefix == "TICKET-") | .id'
+stdout2env AUTOLINK_ID
+
+# View the autolink and ensure the url template round tripped
+exec gh repo autolink view --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING $AUTOLINK_ID --json=urlTemplate --jq='.urlTemplate'
+stdout 'https://example\.com/TICKET\?query=<num>'
+
+# Delete the autolink
+exec gh repo autolink delete --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING $AUTOLINK_ID --yes
+
+# Ensure the autolink was deleted
+exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=id --jq='.[].id'
+! stdout $AUTOLINK_ID

--- a/pkg/cmd/repo/autolink/create/http.go
+++ b/pkg/cmd/repo/autolink/create/http.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
@@ -24,7 +23,7 @@ type AutolinkCreateRequest struct {
 }
 
 func (a *AutolinkCreator) Create(repo ghrepo.Interface, request AutolinkCreateRequest) (*shared.Autolink, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "autolinks")
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "autolinks")
 	if err != nil {
 		return nil, err
 	}
@@ -35,47 +34,19 @@ func (a *AutolinkCreator) Create(repo ghrepo.Interface, request AutolinkCreateRe
 	}
 	requestBody := bytes.NewReader(requestByte)
 
-	req, err := http.NewRequest(http.MethodPost, url.String(), requestBody)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := a.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-
-	err = handleAutolinkCreateError(resp)
-
-	if err != nil {
-		return nil, err
-	}
-
 	var autolink shared.Autolink
-
-	err = json.NewDecoder(resp.Body).Decode(&autolink)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(a.HTTPClient).REST(repo.RepoHost(), http.MethodPost, path.String(), requestBody, &autolink)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			httpErr.Message = "Must have admin rights to Repository."
+			return nil, httpErr
+		}
 		return nil, err
 	}
 
 	return &autolink, nil
-}
-
-func handleAutolinkCreateError(resp *http.Response) error {
-	switch resp.StatusCode {
-	case http.StatusCreated:
-		return nil
-	case http.StatusNotFound:
-		err := api.HandleHTTPError(resp)
-		var httpErr api.HTTPError
-		if errors.As(err, &httpErr) {
-			httpErr.Message = "Must have admin rights to Repository."
-			return httpErr
-		}
-		return err
-	default:
-		return api.HandleHTTPError(resp)
-	}
 }

--- a/pkg/cmd/repo/autolink/create/http_test.go
+++ b/pkg/cmd/repo/autolink/create/http_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
 	"github.com/cli/cli/v2/pkg/httpmock"
@@ -25,6 +26,7 @@ func TestAutolinkCreator_Create(t *testing.T) {
 		expectedAutolink *shared.Autolink
 		expectErr        bool
 		expectedErrMsg   string
+		expectedStatus   int
 	}{
 		{
 			name: "201 successful creation",
@@ -68,7 +70,8 @@ func TestAutolinkCreator_Create(t *testing.T) {
 				"documentation_url": "https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository",
 				"status": "422"
 				}`,
-			expectErr: true,
+			expectErr:      true,
+			expectedStatus: http.StatusUnprocessableEntity,
 			expectedErrMsg: heredoc.Doc(`
 				HTTP 422: Validation Failed (https://api.github.com/repos/OWNER/REPO/autolinks)
 				url_template must be an absolute URL`),
@@ -88,6 +91,7 @@ func TestAutolinkCreator_Create(t *testing.T) {
 			}`,
 			expectErr:      true,
 			expectedErrMsg: "HTTP 404: Must have admin rights to Repository. (https://api.github.com/repos/OWNER/REPO/autolinks)",
+			expectedStatus: http.StatusNotFound,
 		},
 		{
 			name: "422 URL template missing <num>",
@@ -96,9 +100,10 @@ func TestAutolinkCreator_Create(t *testing.T) {
 				KeyPrefix:      "TICKET-",
 				URLTemplate:    "https://example.com/TICKET",
 			},
-			stubStatus:   http.StatusUnprocessableEntity,
-			stubRespJSON: `{"message":"Validation Failed","errors":[{"resource":"KeyLink","code":"custom","field":"url_template","message":"url_template is missing a <num> token"}],"documentation_url":"https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository","status":"422"}`,
-			expectErr:    true,
+			stubStatus:     http.StatusUnprocessableEntity,
+			stubRespJSON:   `{"message":"Validation Failed","errors":[{"resource":"KeyLink","code":"custom","field":"url_template","message":"url_template is missing a <num> token"}],"documentation_url":"https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository","status":"422"}`,
+			expectErr:      true,
+			expectedStatus: http.StatusUnprocessableEntity,
 			expectedErrMsg: heredoc.Doc(`
 				HTTP 422: Validation Failed (https://api.github.com/repos/OWNER/REPO/autolinks)
 				url_template is missing a <num> token`),
@@ -110,9 +115,10 @@ func TestAutolinkCreator_Create(t *testing.T) {
 				KeyPrefix:      "TICKET-",
 				URLTemplate:    "https://example.com/TICKET?query=<num>",
 			},
-			stubStatus:   http.StatusUnprocessableEntity,
-			stubRespJSON: `{"message":"Validation Failed","errors":[{"resource":"KeyLink","code":"already_exists","field":"key_prefix"}],"documentation_url":"https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository","status":"422"}`,
-			expectErr:    true,
+			stubStatus:     http.StatusUnprocessableEntity,
+			stubRespJSON:   `{"message":"Validation Failed","errors":[{"resource":"KeyLink","code":"already_exists","field":"key_prefix"}],"documentation_url":"https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository","status":"422"}`,
+			expectErr:      true,
+			expectedStatus: http.StatusUnprocessableEntity,
 			expectedErrMsg: heredoc.Doc(`
 				HTTP 422: Validation Failed (https://api.github.com/repos/OWNER/REPO/autolinks)
 				KeyLink.key_prefix already exists`),
@@ -146,6 +152,9 @@ func TestAutolinkCreator_Create(t *testing.T) {
 
 			if tt.expectErr {
 				require.EqualError(t, err, tt.expectedErrMsg)
+				var httpErr api.HTTPError
+				require.ErrorAs(t, err, &httpErr)
+				assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedAutolink, autolink)

--- a/pkg/cmd/repo/autolink/delete/http.go
+++ b/pkg/cmd/repo/autolink/delete/http.go
@@ -1,11 +1,11 @@
 package delete
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
@@ -15,25 +15,21 @@ type AutolinkDeleter struct {
 }
 
 func (a *AutolinkDeleter) Delete(repo ghrepo.Interface, id string) error {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "autolinks", id)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest(http.MethodDelete, url.String(), nil)
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "autolinks", id)
 	if err != nil {
 		return err
 	}
 
-	resp, err := a.HTTPClient.Do(req)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(a.HTTPClient).REST(repo.RepoHost(), http.MethodDelete, path.String(), nil, nil)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("error deleting autolink: HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", httpErr.RequestURL)
+		}
 		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("error deleting autolink: HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", url)
-	} else if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
 	}
 
 	return nil

--- a/pkg/cmd/repo/autolink/delete/http_test.go
+++ b/pkg/cmd/repo/autolink/delete/http_test.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 	"testing"
 
+	cliapi "github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
-	"github.com/cli/go-gh/v2/pkg/api"
+	ghapi "github.com/cli/go-gh/v2/pkg/api"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +24,7 @@ func TestAutolinkDeleter_Delete(t *testing.T) {
 
 		expectErr      bool
 		expectedErrMsg string
+		expectedStatus int
 	}{
 		{
 			name:       "204 successful delete",
@@ -38,12 +41,13 @@ func TestAutolinkDeleter_Delete(t *testing.T) {
 		{
 			name: "500 unexpected error",
 			id:   "123",
-			stubResp: api.HTTPError{
+			stubResp: ghapi.HTTPError{
 				Message: "arbitrary error",
 			},
 			stubStatus:     http.StatusInternalServerError,
 			expectErr:      true,
 			expectedErrMsg: "HTTP 500: arbitrary error (https://api.github.com/repos/OWNER/REPO/autolinks/123)",
+			expectedStatus: http.StatusInternalServerError,
 		},
 	}
 
@@ -67,6 +71,12 @@ func TestAutolinkDeleter_Delete(t *testing.T) {
 
 			if tt.expectErr {
 				require.EqualError(t, err, tt.expectedErrMsg)
+				if tt.expectedStatus != 0 {
+					var httpErr cliapi.HTTPError
+					require.ErrorAs(t, err, &httpErr)
+					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
+					assert.Contains(t, err.Error(), "HTTP 500")
+				}
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/cmd/repo/autolink/delete/http_test.go
+++ b/pkg/cmd/repo/autolink/delete/http_test.go
@@ -75,7 +75,6 @@ func TestAutolinkDeleter_Delete(t *testing.T) {
 					var httpErr cliapi.HTTPError
 					require.ErrorAs(t, err, &httpErr)
 					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
-					assert.Contains(t, err.Error(), "HTTP 500")
 				}
 			} else {
 				require.NoError(t, err)

--- a/pkg/cmd/repo/autolink/list/http.go
+++ b/pkg/cmd/repo/autolink/list/http.go
@@ -1,12 +1,11 @@
 package list
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
@@ -17,29 +16,21 @@ type AutolinkLister struct {
 }
 
 func (a *AutolinkLister) List(repo ghrepo.Interface) ([]shared.Autolink, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "autolinks")
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "autolinks")
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := a.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("error getting autolinks: HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", url)
-	} else if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
-	}
 	var autolinks []shared.Autolink
-	err = json.NewDecoder(resp.Body).Decode(&autolinks)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(a.HTTPClient).REST(repo.RepoHost(), http.MethodGet, path.String(), nil, &autolinks)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("error getting autolinks: HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", httpErr.RequestURL)
+		}
 		return nil, err
 	}
 

--- a/pkg/cmd/repo/autolink/list/http_test.go
+++ b/pkg/cmd/repo/autolink/list/http_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
 	"github.com/cli/cli/v2/pkg/httpmock"
@@ -14,16 +15,20 @@ import (
 
 func TestAutolinkLister_List(t *testing.T) {
 	tests := []struct {
-		name   string
-		repo   ghrepo.Interface
-		resp   []shared.Autolink
-		status int
+		name              string
+		repo              ghrepo.Interface
+		resp              any
+		status            int
+		expectedAutolinks []shared.Autolink
+		expectedErrMsg    string
+		expectedStatus    int
 	}{
 		{
-			name:   "no autolinks",
-			repo:   ghrepo.New("OWNER", "REPO"),
-			resp:   []shared.Autolink{},
-			status: http.StatusOK,
+			name:              "no autolinks",
+			repo:              ghrepo.New("OWNER", "REPO"),
+			resp:              []shared.Autolink{},
+			status:            http.StatusOK,
+			expectedAutolinks: []shared.Autolink{},
 		},
 		{
 			name: "two autolinks",
@@ -43,11 +48,39 @@ func TestAutolinkLister_List(t *testing.T) {
 				},
 			},
 			status: http.StatusOK,
+			expectedAutolinks: []shared.Autolink{
+				{
+					ID:             1,
+					IsAlphanumeric: true,
+					KeyPrefix:      "key",
+					URLTemplate:    "https://example.com",
+				},
+				{
+					ID:             2,
+					IsAlphanumeric: false,
+					KeyPrefix:      "key2",
+					URLTemplate:    "https://example2.com",
+				},
+			},
 		},
 		{
-			name:   "http error",
-			repo:   ghrepo.New("OWNER", "REPO"),
-			status: http.StatusNotFound,
+			name: "404 repo not found",
+			repo: ghrepo.New("OWNER", "REPO"),
+			resp: map[string]any{
+				"message": "Not Found",
+			},
+			status:         http.StatusNotFound,
+			expectedErrMsg: "error getting autolinks: HTTP 404: Perhaps you are missing admin rights to the repository? (https://api.github.com/repos/OWNER/REPO/autolinks)",
+		},
+		{
+			name: "500 unexpected error",
+			repo: ghrepo.New("OWNER", "REPO"),
+			resp: map[string]any{
+				"message": "arbitrary error",
+			},
+			status:         http.StatusInternalServerError,
+			expectedErrMsg: "HTTP 500: arbitrary error (https://api.github.com/repos/OWNER/REPO/autolinks)",
+			expectedStatus: http.StatusInternalServerError,
 		},
 	}
 
@@ -64,12 +97,17 @@ func TestAutolinkLister_List(t *testing.T) {
 				HTTPClient: &http.Client{Transport: reg},
 			}
 			autolinks, err := autolinkLister.List(tt.repo)
-			if tt.status == http.StatusNotFound {
-				require.Error(t, err)
-				assert.Equal(t, "error getting autolinks: HTTP 404: Perhaps you are missing admin rights to the repository? (https://api.github.com/repos/OWNER/REPO/autolinks)", err.Error())
+			if tt.expectedErrMsg != "" {
+				require.EqualError(t, err, tt.expectedErrMsg)
+				if tt.expectedStatus != 0 {
+					var httpErr api.HTTPError
+					require.ErrorAs(t, err, &httpErr)
+					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
+					assert.Contains(t, err.Error(), "HTTP 500")
+				}
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tt.resp, autolinks)
+				assert.Equal(t, tt.expectedAutolinks, autolinks)
 			}
 		})
 	}

--- a/pkg/cmd/repo/autolink/list/http_test.go
+++ b/pkg/cmd/repo/autolink/list/http_test.go
@@ -103,7 +103,6 @@ func TestAutolinkLister_List(t *testing.T) {
 					var httpErr api.HTTPError
 					require.ErrorAs(t, err, &httpErr)
 					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
-					assert.Contains(t, err.Error(), "HTTP 500")
 				}
 			} else {
 				require.NoError(t, err)

--- a/pkg/cmd/repo/autolink/view/http.go
+++ b/pkg/cmd/repo/autolink/view/http.go
@@ -1,12 +1,11 @@
 package view
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
@@ -17,31 +16,21 @@ type AutolinkViewer struct {
 }
 
 func (a *AutolinkViewer) View(repo ghrepo.Interface, id string) (*shared.Autolink, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "autolinks", id)
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "autolinks", id)
 	if err != nil {
 		return nil, err
-	}
-	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := a.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", url)
-	} else if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
 	}
 
 	var autolink shared.Autolink
-	err = json.NewDecoder(resp.Body).Decode(&autolink)
-
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(a.HTTPClient).REST(repo.RepoHost(), http.MethodGet, path.String(), nil, &autolink)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", httpErr.RequestURL)
+		}
 		return nil, err
 	}
 

--- a/pkg/cmd/repo/autolink/view/http_test.go
+++ b/pkg/cmd/repo/autolink/view/http_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
 	"github.com/cli/cli/v2/pkg/httpmock"
@@ -24,6 +25,7 @@ func TestAutolinkViewer_View(t *testing.T) {
 		expectedAutolink *shared.Autolink
 		expectErr        bool
 		expectedErrMsg   string
+		expectedStatus   int
 	}{
 		{
 			name:       "200 successful alphanumeric view",
@@ -71,6 +73,15 @@ func TestAutolinkViewer_View(t *testing.T) {
 			expectErr:      true,
 			expectedErrMsg: "HTTP 404: Perhaps you are missing admin rights to the repository? (https://api.github.com/repos/OWNER/REPO/autolinks/123)",
 		},
+		{
+			name:           "500 unexpected error",
+			id:             "123",
+			stubStatus:     http.StatusInternalServerError,
+			stubRespJSON:   `{"message":"arbitrary error"}`,
+			expectErr:      true,
+			expectedErrMsg: "HTTP 500 (https://api.github.com/repos/OWNER/REPO/autolinks/123)",
+			expectedStatus: http.StatusInternalServerError,
+		},
 	}
 
 	for _, tt := range tests {
@@ -93,6 +104,12 @@ func TestAutolinkViewer_View(t *testing.T) {
 
 			if tt.expectErr {
 				require.EqualError(t, err, tt.expectedErrMsg)
+				if tt.expectedStatus != 0 {
+					var httpErr api.HTTPError
+					require.ErrorAs(t, err, &httpErr)
+					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
+					assert.Contains(t, err.Error(), "HTTP 500")
+				}
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedAutolink, autolink)

--- a/pkg/cmd/repo/autolink/view/http_test.go
+++ b/pkg/cmd/repo/autolink/view/http_test.go
@@ -108,7 +108,6 @@ func TestAutolinkViewer_View(t *testing.T) {
 					var httpErr api.HTTPError
 					require.ErrorAs(t, err, &httpErr)
 					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
-					assert.Contains(t, err.Error(), "HTTP 500")
 				}
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
## Description

Part of https://github.com/cli/cli/issues/13991

This PR migrates `repo autolink create`, `repo autolink delete`, `repo autolink list` and `repo autolink view` to use the `api.Client` for API interactions. There should be no user visible change.

Paths are now built with `safeurl.JoinPath` rather than `safeurl.JoinPathWithHostPrefix`, because `api.Client` prepends the REST prefix itself.

The 404 messages for `delete`, `list` and `view` previously interpolated a locally built URL. They now use `httpErr.RequestURL`, which is the URL actually requested. The rendered message is unchanged, and the existing assertions pass untouched.

Two status handling details changed. Both are inert against the real API, but are worth recording:

 * `create` previously treated only `201` as success (`case http.StatusCreated`), so any other 2xx fell through to `api.HandleHTTPError` and surfaced as, for example, `HTTP 200 (https://api.github.com/repos/OWNER/REPO/autolinks)`. `api.Client.REST` returns `nil` for every 2xx, so such a response now decodes normally. GitHub returns `201`.
 * `delete` previously never read the response body, so any 2xx succeeded. `api.Client.REST` returns early only for `204` and `205`, so another 2xx with an empty body would now fail with `unexpected end of JSON input`. GitHub returns `204`.

`list` and `view` used `if resp.StatusCode > 299`, which is already a range check, so they migrate without any change in accepted statuses.

We also backfill assertions for the 404 and 500 error paths.

### Acceptance Test

There was no acceptance test for `gh repo autolink`, so this PR adds one. It needs no third party service: the `urlTemplate` is an opaque string that GitHub stores and returns, and is never resolved by either GitHub or `gh`.

```
➜  williammartin-psychic-potato git:(williammartin-migrate-repo-autolink) GH_ACCEPTANCE_HOST=github.com \
GH_ACCEPTANCE_ORG=gh-acceptance-testing \
GH_ACCEPTANCE_TOKEN="$(gh auth token --hostname github.com)" \
GH_ACCEPTANCE_SCRIPT=repo-autolink.txtar \
go test -tags=acceptance -count=1 -v -run '^TestRepo$' ./acceptance
=== RUN   TestRepo
=== RUN   TestRepo/repo-autolink
=== PAUSE TestRepo/repo-autolink
=== CONT  TestRepo/repo-autolink
    testscript.go:584: WORK=$WORK
        PATH=/var/folders/z7/869nt6ns29d77xln9h9bm8680000gn/T/testscript-main4109657185/bin:/Users/williammartin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/bin:/Users/williammartin/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/williammartin/.local/bin
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=repo_autolink
        GH_CONFIG_DIR=$WORK
        GH_HOST=github.com
        ORG=gh-acceptance-testing
        GH_TOKEN=gho_************************************
        RANDOM_STRING=fKzzanQvOQ
        GH_TELEMETRY=false
        
        # Create a repository to hold the autolink references (3.149s)
        > exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
        [stdout]
        https://github.com/gh-acceptance-testing/repo_autolink-fKzzanQvOQ
        # Defer repo cleanup (0.000s)
        > defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
        # List the autolinks. There should be none (0.271s)
        > exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=keyPrefix
        > ! stdout keyPrefix
        # Create an alphanumeric autolink (0.317s)
        > exec gh repo autolink create --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING TICKET- 'https://example.com/TICKET?query=<num>'
        [stdout]
        ✓ Created repository autolink 16207488 on gh-acceptance-testing/repo_autolink-fKzzanQvOQ
        # Ensure the autolink was created (0.274s)
        > exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=keyPrefix --jq='.[].keyPrefix'
        [stdout]
        TICKET-
        > stdout 'TICKET-'
        # Get the autolink id (0.258s)
        > exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=keyPrefix,id --jq='.[] | select(.keyPrefix == "TICKET-") | .id'
        [stdout]
        16207488
        > stdout2env AUTOLINK_ID
        # View the autolink and ensure the url template round tripped (0.326s)
        > exec gh repo autolink view --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING $AUTOLINK_ID --json=urlTemplate --jq='.urlTemplate'
        [stdout]
        https://example.com/TICKET?query=<num>
        > stdout 'https://example\.com/TICKET\?query=<num>'
        # Delete the autolink (0.515s)
        > exec gh repo autolink delete --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING $AUTOLINK_ID --yes
        # Ensure the autolink was deleted (0.279s)
        > exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=id --jq='.[].id'
        > ! stdout $AUTOLINK_ID
        PASS
        
--- PASS: TestRepo (0.00s)
    --- PASS: TestRepo/repo-autolink (6.01s)
PASS
ok  	github.com/cli/cli/v2/acceptance	6.541s
```

### Notes

**This is a stacked PR.** It targets #13997.
