### PR TITLE
feat(discussion): add support for Discussion Templates

### DIFF
--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -50,7 +50,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			Omitting any of these flags triggers interactive prompts when connected to a terminal.
 
 			If the selected category defines a Discussion Category Form (a
-			%[1]s.github/DISCUSSION_TEMPLATE/<category>.yml%[1]s file), and %[1]s--body%[1]s/%[1]s--body-file%[1]s
+			%[1]s.github/DISCUSSION_TEMPLATE/<category-slug>.yml%[1]s file), and %[1]s--body%[1]s/%[1]s--body-file%[1]s
 			was not given, the form's fields are prompted for individually instead of a single free-text body.
 		`, "`"),
 		Example: heredoc.Doc(`
@@ -158,6 +158,9 @@ func createRun(opts *CreateOptions) error {
 	}
 
 	if opts.Body == "" {
+		if !opts.IO.CanPrompt() {
+			return cmdutil.FlagErrorf("discussion body cannot be blank")
+		}
 		opts.Body, err = promptBody(opts, repo, category.Slug)
 		if err != nil {
 			return err

--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -1,7 +1,9 @@
 package create
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -16,10 +18,11 @@ import (
 
 // CreateOptions holds the configuration for the discussion create command.
 type CreateOptions struct {
-	IO       *iostreams.IOStreams
-	BaseRepo func() (ghrepo.Interface, error)
-	Client   func() (client.DiscussionClient, error)
-	Prompter prompter.Prompter
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+	Client     func() (client.DiscussionClient, error)
+	HttpClient func() (*http.Client, error)
+	Prompter   prompter.Prompter
 
 	Title    string
 	Body     string
@@ -31,9 +34,10 @@ type CreateOptions struct {
 // NewCmdCreate returns a cobra command for creating a GitHub Discussion.
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
 	opts := &CreateOptions{
-		IO:       f.IOStreams,
-		Prompter: f.Prompter,
-		Client:   shared.DiscussionClientFunc(f),
+		IO:         f.IOStreams,
+		Prompter:   f.Prompter,
+		Client:     shared.DiscussionClientFunc(f),
+		HttpClient: f.HttpClient,
 	}
 
 	cmd := &cobra.Command{
@@ -44,6 +48,10 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			With %[1]s--title%[1]s, %[1]s--body%[1]s (or %[1]s--body-file%[1]s), and %[1]s--category%[1]s, a discussion is created non-interactively.
 			Omitting any of these flags triggers interactive prompts when connected to a terminal.
+
+			If the selected category defines a Discussion Category Form (a
+			%[1]s.github/DISCUSSION_TEMPLATE/<category>.yml%[1]s file), and %[1]s--body%[1]s/%[1]s--body-file%[1]s
+			was not given, the form's fields are prompted for individually instead of a single free-text body.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Create interactively
@@ -150,12 +158,9 @@ func createRun(opts *CreateOptions) error {
 	}
 
 	if opts.Body == "" {
-		opts.Body, err = opts.Prompter.MarkdownEditor("Discussion body", "", false)
+		opts.Body, err = promptBody(opts, repo, category.Slug)
 		if err != nil {
 			return err
-		}
-		if strings.TrimSpace(opts.Body) == "" {
-			return fmt.Errorf("body cannot be blank")
 		}
 	}
 
@@ -196,4 +201,37 @@ func createRun(opts *CreateOptions) error {
 	fmt.Fprintln(opts.IO.Out, discussion.URL)
 
 	return nil
+}
+
+// promptBody fills in the discussion body, either by walking the selected
+// category's Discussion Category Form field-by-field (if the repository
+// defines one at .github/DISCUSSION_TEMPLATE/<slug>.yml), or by falling back
+// to a single free-text editor prompt when no such form exists.
+func promptBody(opts *CreateOptions, repo ghrepo.Interface, categorySlug string) (string, error) {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return "", err
+	}
+
+	opts.IO.StartProgressIndicator()
+	tpl, err := shared.FetchCategoryTemplate(httpClient, repo, categorySlug)
+	opts.IO.StopProgressIndicator()
+
+	switch {
+	case errors.Is(err, shared.ErrCategoryTemplateNotFound):
+		body, err := opts.Prompter.MarkdownEditor("Discussion body", "", false)
+		if err != nil {
+			return "", err
+		}
+		if strings.TrimSpace(body) == "" {
+			return "", fmt.Errorf("body cannot be blank")
+		}
+		return body, nil
+
+	case err != nil:
+		return "", err
+
+	default:
+		return shared.PromptCategoryTemplate(opts.Prompter, opts.IO, tpl)
+	}
 }

--- a/pkg/cmd/discussion/create/create_test.go
+++ b/pkg/cmd/discussion/create/create_test.go
@@ -3,12 +3,15 @@ package create
 import (
 	"bytes"
 	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
 	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
@@ -148,6 +151,7 @@ func TestCreateRun(t *testing.T) {
 		isTTY        bool
 		stdinContent string
 		setupMock    func(*client.DiscussionClientMock)
+		httpStubs    func(*httpmock.Registry)
 		prompter     *prompter.PrompterMock
 		wantErr      string
 		wantOut      string
@@ -275,6 +279,12 @@ func TestCreateRun(t *testing.T) {
 					return sampleDiscussion(), nil
 				}
 			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/DISCUSSION_TEMPLATE/general.yml"),
+					httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
+				)
+			},
 			prompter: &prompter.PrompterMock{
 				InputFunc: func(prompt, defaultValue string) (string, error) {
 					return "My question", nil
@@ -286,6 +296,57 @@ func TestCreateRun(t *testing.T) {
 				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
 					assert.False(t, blankAllowed, "body editor should not allow blank input")
 					return "Some body text", nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "tty walks category form fields when one exists",
+			opts: CreateOptions{
+				Title:    "My question",
+				Category: "Q&A",
+			},
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "### Summary\n\nSomething broke\n\n### Platform\n\niOS\n", input.Body)
+					return sampleDiscussion(), nil
+				}
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/DISCUSSION_TEMPLATE/q-a.yml"),
+					httpmock.StringResponse(strings.Join([]string{
+						"body:",
+						"  - type: input",
+						"    attributes:",
+						"      label: 'Summary'",
+						"    validations:",
+						"      required: true",
+						"  - type: dropdown",
+						"    attributes:",
+						"      label: 'Platform'",
+						"      options:",
+						"        - 'iOS'",
+						"        - 'Android'",
+						"    validations:",
+						"      required: true",
+						"",
+					}, "\n")),
+				)
+			},
+			prompter: &prompter.PrompterMock{
+				InputFunc: func(prompt, defaultValue string) (string, error) {
+					assert.Equal(t, "Summary", prompt)
+					return "Something broke", nil
+				},
+				SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
+					assert.Equal(t, "Platform", prompt)
+					assert.Equal(t, []string{"iOS", "Android"}, options)
+					return 0, nil
 				},
 			},
 			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
@@ -354,6 +415,12 @@ func TestCreateRun(t *testing.T) {
 					return sampleDiscussion(), nil
 				}
 			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/DISCUSSION_TEMPLATE/q-a.yml"),
+					httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
+				)
+			},
 			prompter: &prompter.PrompterMock{
 				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
 					return "Prompted body", nil
@@ -413,6 +480,12 @@ func TestCreateRun(t *testing.T) {
 					return sampleCategories(), nil
 				}
 			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/DISCUSSION_TEMPLATE/general.yml"),
+					httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
+				)
+			},
 			prompter: &prompter.PrompterMock{
 				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
 					return "   ", nil
@@ -435,6 +508,12 @@ func TestCreateRun(t *testing.T) {
 			mockClient := &client.DiscussionClientMock{}
 			tt.setupMock(mockClient)
 
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			if tt.httpStubs != nil {
+				tt.httpStubs(reg)
+			}
+
 			opts := tt.opts
 			opts.IO = ios
 			opts.BaseRepo = func() (ghrepo.Interface, error) {
@@ -442,6 +521,9 @@ func TestCreateRun(t *testing.T) {
 			}
 			opts.Client = func() (client.DiscussionClient, error) {
 				return mockClient, nil
+			}
+			opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
 			}
 			if tt.prompter != nil {
 				opts.Prompter = tt.prompter

--- a/pkg/cmd/discussion/shared/template.go
+++ b/pkg/cmd/discussion/shared/template.go
@@ -1,0 +1,325 @@
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghinstance"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/markdown"
+	"gopkg.in/yaml.v3"
+)
+
+// ErrCategoryTemplateNotFound indicates that a repository does not define a
+// Discussion Category Form for the requested category slug. This is the
+// common case (most categories have no form), so callers should treat it as
+// a signal to fall back to a plain-text body rather than as a hard failure.
+var ErrCategoryTemplateNotFound = errors.New("no Discussion Category Form found")
+
+// CategoryTemplate is a parsed Discussion Category Form, as defined by a
+// .github/DISCUSSION_TEMPLATE/<category-slug>.yml file. See:
+// https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+type CategoryTemplate struct {
+	Body []TemplateElement `yaml:"body"`
+}
+
+// TemplateElement is a single element of a Discussion Category Form: either a
+// static markdown block, or one input field (input, textarea, dropdown, or
+// checkboxes).
+type TemplateElement struct {
+	Type        string
+	Label       string
+	Description string
+	Value       string // markdown text (type: markdown), or a default value (type: input/textarea)
+	Multiple    bool   // type: dropdown only
+	Required    bool
+	Options     []TemplateOption
+}
+
+// TemplateOption is a single choice within a dropdown or checkboxes element.
+type TemplateOption struct {
+	Label    string
+	Required bool // type: checkboxes only; dropdown options cannot be individually required
+}
+
+// UnmarshalYAML decodes a single body element, dispatching on its "type" to
+// pick out the fields that type supports. Unlike issue/PR templates (plain
+// markdown with YAML front-matter), Discussion Category Forms have no fixed
+// shape: "attributes" means something different for every element type.
+func (e *TemplateElement) UnmarshalYAML(value *yaml.Node) error {
+	var shape struct {
+		Type        string    `yaml:"type"`
+		Attributes  yaml.Node `yaml:"attributes"`
+		Validations struct {
+			Required bool `yaml:"required"`
+		} `yaml:"validations"`
+	}
+	if err := value.Decode(&shape); err != nil {
+		return err
+	}
+
+	e.Type = shape.Type
+	e.Required = shape.Validations.Required
+
+	switch shape.Type {
+	case "markdown":
+		var attrs struct {
+			Value string `yaml:"value"`
+		}
+		if err := shape.Attributes.Decode(&attrs); err != nil {
+			return err
+		}
+		e.Value = attrs.Value
+
+	case "input", "textarea":
+		var attrs struct {
+			Label       string `yaml:"label"`
+			Description string `yaml:"description"`
+			Value       string `yaml:"value"`
+		}
+		if err := shape.Attributes.Decode(&attrs); err != nil {
+			return err
+		}
+		e.Label, e.Description, e.Value = attrs.Label, attrs.Description, attrs.Value
+
+	case "dropdown":
+		var attrs struct {
+			Label       string   `yaml:"label"`
+			Description string   `yaml:"description"`
+			Multiple    bool     `yaml:"multiple"`
+			Options     []string `yaml:"options"`
+		}
+		if err := shape.Attributes.Decode(&attrs); err != nil {
+			return err
+		}
+		e.Label, e.Description, e.Multiple = attrs.Label, attrs.Description, attrs.Multiple
+		for _, o := range attrs.Options {
+			e.Options = append(e.Options, TemplateOption{Label: o})
+		}
+
+	case "checkboxes":
+		var attrs struct {
+			Label       string `yaml:"label"`
+			Description string `yaml:"description"`
+			Options     []struct {
+				Label    string `yaml:"label"`
+				Required bool   `yaml:"required"`
+			} `yaml:"options"`
+		}
+		if err := shape.Attributes.Decode(&attrs); err != nil {
+			return err
+		}
+		e.Label, e.Description = attrs.Label, attrs.Description
+		for _, o := range attrs.Options {
+			e.Options = append(e.Options, TemplateOption{Label: o.Label, Required: o.Required})
+		}
+
+	default:
+		return fmt.Errorf("unsupported Discussion Category Form element type: %q", shape.Type)
+	}
+
+	return nil
+}
+
+// FetchCategoryTemplate fetches and parses the Discussion Category Form for
+// the given category slug, from the repository's default branch. It returns
+// ErrCategoryTemplateNotFound if the repository has no form defined for that
+// category, which is the common case and not itself an error condition.
+func FetchCategoryTemplate(httpClient *http.Client, repo ghrepo.Interface, slug string) (*CategoryTemplate, error) {
+	filePath := fmt.Sprintf(".github/DISCUSSION_TEMPLATE/%s.yml", slug)
+	apiPath := fmt.Sprintf("%srepos/%s/%s/contents/.github/DISCUSSION_TEMPLATE/%s.yml",
+		ghinstance.RESTPrefix(repo.RepoHost()), repo.RepoOwner(), repo.RepoName(), url.PathEscape(slug))
+
+	req, err := http.NewRequest("GET", apiPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.raw")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 299 {
+		err := api.HandleHTTPError(resp)
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, ErrCategoryTemplateNotFound
+		}
+		return nil, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var tpl CategoryTemplate
+	if err := yaml.Unmarshal(body, &tpl); err != nil {
+		return nil, fmt.Errorf("failed to parse Discussion Category Form %q: %w", filePath, err)
+	}
+
+	return &tpl, nil
+}
+
+// noResponse is the placeholder GitHub's web UI substitutes for an optional
+// field the user left blank, so a form-generated body matches what the web
+// UI would have produced.
+const noResponse = "_No response_"
+
+// PromptCategoryTemplate walks the elements of a Discussion Category Form,
+// prompting the user for each input field, and assembles the responses into
+// body markdown in the same "### label" section format GitHub's web UI
+// produces when a Discussion is created from a category form.
+func PromptCategoryTemplate(p prompter.Prompter, io *iostreams.IOStreams, tpl *CategoryTemplate) (string, error) {
+	var sb strings.Builder
+
+	for _, el := range tpl.Body {
+		if el.Type == "markdown" {
+			rendered, err := markdown.Render(el.Value,
+				markdown.WithTheme(io.TerminalTheme()),
+				markdown.WithWrap(io.TerminalWidth()))
+			if err != nil {
+				return "", err
+			}
+			fmt.Fprintln(io.Out, rendered)
+			continue
+		}
+
+		if el.Description != "" {
+			fmt.Fprintln(io.Out, io.ColorScheme().Muted(el.Description))
+		}
+
+		answer, err := promptTemplateElement(p, el)
+		if err != nil {
+			return "", err
+		}
+
+		sb.WriteString("### ")
+		sb.WriteString(el.Label)
+		sb.WriteString("\n\n")
+		if answer == "" {
+			sb.WriteString(noResponse)
+		} else {
+			sb.WriteString(answer)
+		}
+		sb.WriteString("\n\n")
+	}
+
+	return strings.TrimRight(sb.String(), "\n") + "\n", nil
+}
+
+// skipOption is offered for optional dropdowns so the user can leave them
+// unanswered, since Select (unlike Input) cannot return a blank result.
+const skipOption = "Skip"
+
+func promptTemplateElement(p prompter.Prompter, el TemplateElement) (string, error) {
+	switch el.Type {
+	case "input":
+		answer, err := p.Input(el.Label, el.Value)
+		if err != nil {
+			return "", err
+		}
+		if el.Required && strings.TrimSpace(answer) == "" {
+			return "", fmt.Errorf("%q is required", el.Label)
+		}
+		return answer, nil
+
+	case "textarea":
+		answer, err := p.MarkdownEditor(el.Label, el.Value, !el.Required)
+		if err != nil {
+			return "", err
+		}
+		if el.Required && strings.TrimSpace(answer) == "" {
+			return "", fmt.Errorf("%q is required", el.Label)
+		}
+		return answer, nil
+
+	case "dropdown":
+		labels := optionLabels(el.Options)
+
+		if el.Multiple {
+			idxs, err := p.MultiSelect(el.Label, nil, labels)
+			if err != nil {
+				return "", err
+			}
+			if el.Required && len(idxs) == 0 {
+				return "", fmt.Errorf("%q is required", el.Label)
+			}
+			selected := make([]string, len(idxs))
+			for i, idx := range idxs {
+				selected[i] = labels[idx]
+			}
+			return strings.Join(selected, ", "), nil
+		}
+
+		options := labels
+		if !el.Required {
+			options = append(append([]string{}, labels...), skipOption)
+		}
+		idx, err := p.Select(el.Label, "", options)
+		if err != nil {
+			return "", err
+		}
+		if options[idx] == skipOption {
+			return "", nil
+		}
+		return options[idx], nil
+
+	case "checkboxes":
+		labels := optionLabels(el.Options)
+		idxs, err := p.MultiSelect(el.Label, nil, labels)
+		if err != nil {
+			return "", err
+		}
+
+		checked := make(map[int]bool, len(idxs))
+		for _, idx := range idxs {
+			checked[idx] = true
+		}
+
+		var missing []string
+		for i, opt := range el.Options {
+			if opt.Required && !checked[i] {
+				missing = append(missing, opt.Label)
+			}
+		}
+		if len(missing) > 0 {
+			return "", fmt.Errorf("%q is required", strings.Join(missing, ", "))
+		}
+
+		var sb strings.Builder
+		for i, label := range labels {
+			if i > 0 {
+				sb.WriteString("\n")
+			}
+			if checked[i] {
+				sb.WriteString("- [x] ")
+			} else {
+				sb.WriteString("- [ ] ")
+			}
+			sb.WriteString(label)
+		}
+		return sb.String(), nil
+
+	default:
+		return "", fmt.Errorf("unsupported Discussion Category Form element type: %q", el.Type)
+	}
+}
+
+func optionLabels(options []TemplateOption) []string {
+	labels := make([]string, len(options))
+	for i, o := range options {
+		labels[i] = o.Label
+	}
+	return labels
+}

--- a/pkg/cmd/discussion/shared/template.go
+++ b/pkg/cmd/discussion/shared/template.go
@@ -54,6 +54,8 @@ type TemplateOption struct {
 // markdown with YAML front-matter), Discussion Category Forms have no fixed
 // shape: "attributes" means something different for every element type.
 func (e *TemplateElement) UnmarshalYAML(value *yaml.Node) error {
+	*e = TemplateElement{}
+
 	var shape struct {
 		Type        string    `yaml:"type"`
 		Attributes  yaml.Node `yaml:"attributes"`

--- a/pkg/cmd/discussion/shared/template_test.go
+++ b/pkg/cmd/discussion/shared/template_test.go
@@ -1,0 +1,283 @@
+package shared
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCategoryTemplateUnmarshalYAML(t *testing.T) {
+	src := `
+body:
+  - type: markdown
+    attributes:
+      value: 'Please fill this in.'
+  - type: input
+    attributes:
+      label: 'Summary'
+      description: 'One line'
+      value: 'default summary'
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 'Details'
+  - type: dropdown
+    attributes:
+      label: 'Platform'
+      multiple: true
+      options:
+        - 'iOS'
+        - 'Android'
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: 'Code of Conduct'
+      options:
+        - label: 'I agree'
+          required: true
+        - label: 'Optional extra'
+`
+	var tpl CategoryTemplate
+	require.NoError(t, yaml.Unmarshal([]byte(src), &tpl))
+	require.Len(t, tpl.Body, 5)
+
+	assert.Equal(t, TemplateElement{Type: "markdown", Value: "Please fill this in."}, tpl.Body[0])
+
+	assert.Equal(t, TemplateElement{
+		Type:        "input",
+		Label:       "Summary",
+		Description: "One line",
+		Value:       "default summary",
+		Required:    true,
+	}, tpl.Body[1])
+
+	assert.Equal(t, TemplateElement{Type: "textarea", Label: "Details"}, tpl.Body[2])
+
+	assert.Equal(t, TemplateElement{
+		Type:     "dropdown",
+		Label:    "Platform",
+		Multiple: true,
+		Required: true,
+		Options: []TemplateOption{
+			{Label: "iOS"},
+			{Label: "Android"},
+		},
+	}, tpl.Body[3])
+
+	assert.Equal(t, TemplateElement{
+		Type:  "checkboxes",
+		Label: "Code of Conduct",
+		Options: []TemplateOption{
+			{Label: "I agree", Required: true},
+			{Label: "Optional extra"},
+		},
+	}, tpl.Body[4])
+}
+
+func TestCategoryTemplateUnmarshalYAMLUnknownType(t *testing.T) {
+	src := `
+body:
+  - type: carousel
+    attributes:
+      label: 'Nope'
+`
+	var tpl CategoryTemplate
+	err := yaml.Unmarshal([]byte(src), &tpl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unsupported Discussion Category Form element type: "carousel"`)
+}
+
+func TestFetchCategoryTemplate(t *testing.T) {
+	tests := []struct {
+		name      string
+		httpStubs func(*httpmock.Registry)
+		wantErr   error
+		wantErrIs error
+		wantLen   int
+	}{
+		{
+			name: "found",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/DISCUSSION_TEMPLATE/general.yml"),
+					httpmock.StringResponse("body:\n  - type: input\n    attributes:\n      label: 'X'\n"),
+				)
+			},
+			wantLen: 1,
+		},
+		{
+			name: "not found",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/DISCUSSION_TEMPLATE/general.yml"),
+					httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
+				)
+			},
+			wantErrIs: ErrCategoryTemplateNotFound,
+		},
+		{
+			name: "server error",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/DISCUSSION_TEMPLATE/general.yml"),
+					httpmock.StatusStringResponse(500, `{"message":"boom"}`),
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			tt.httpStubs(reg)
+
+			httpClient := &http.Client{Transport: reg}
+			repo := ghrepo.New("OWNER", "REPO")
+
+			tpl, err := FetchCategoryTemplate(httpClient, repo, "general")
+			if tt.wantErrIs != nil {
+				require.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+			if tt.name == "server error" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "HTTP 500")
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, tpl.Body, tt.wantLen)
+		})
+	}
+}
+
+func TestPromptCategoryTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		tpl      *CategoryTemplate
+		prompter *prompter.PrompterMock
+		wantBody string
+		wantErr  string
+	}{
+		{
+			name: "input, textarea, single dropdown",
+			tpl: &CategoryTemplate{Body: []TemplateElement{
+				{Type: "markdown", Value: "Read this first."},
+				{Type: "input", Label: "Summary", Required: true},
+				{Type: "textarea", Label: "Details"},
+				{Type: "dropdown", Label: "Platform", Required: true, Options: []TemplateOption{
+					{Label: "iOS"}, {Label: "Android"},
+				}},
+			}},
+			prompter: &prompter.PrompterMock{
+				InputFunc: func(prompt, defaultValue string) (string, error) {
+					assert.Equal(t, "Summary", prompt)
+					return "A summary", nil
+				},
+				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
+					assert.Equal(t, "Details", prompt)
+					assert.True(t, blankAllowed)
+					return "", nil
+				},
+				SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
+					assert.Equal(t, "Platform", prompt)
+					assert.Equal(t, []string{"iOS", "Android"}, options)
+					return 1, nil
+				},
+			},
+			wantBody: "### Summary\n\nA summary\n\n### Details\n\n_No response_\n\n### Platform\n\nAndroid\n",
+		},
+		{
+			name: "required input left blank errors",
+			tpl: &CategoryTemplate{Body: []TemplateElement{
+				{Type: "input", Label: "Summary", Required: true},
+			}},
+			prompter: &prompter.PrompterMock{
+				InputFunc: func(prompt, defaultValue string) (string, error) {
+					return "   ", nil
+				},
+			},
+			wantErr: `"Summary" is required`,
+		},
+		{
+			name: "optional dropdown can be skipped",
+			tpl: &CategoryTemplate{Body: []TemplateElement{
+				{Type: "dropdown", Label: "Platform", Options: []TemplateOption{{Label: "iOS"}, {Label: "Android"}}},
+			}},
+			prompter: &prompter.PrompterMock{
+				SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
+					assert.Equal(t, []string{"iOS", "Android", skipOption}, options)
+					return 2, nil
+				},
+			},
+			wantBody: "### Platform\n\n_No response_\n",
+		},
+		{
+			name: "multi-select dropdown joins with comma",
+			tpl: &CategoryTemplate{Body: []TemplateElement{
+				{Type: "dropdown", Label: "Platform", Multiple: true, Options: []TemplateOption{{Label: "iOS"}, {Label: "Android"}, {Label: "Web"}}},
+			}},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					return []int{0, 2}, nil
+				},
+			},
+			wantBody: "### Platform\n\niOS, Web\n",
+		},
+		{
+			name: "checkboxes render as a task list",
+			tpl: &CategoryTemplate{Body: []TemplateElement{
+				{Type: "checkboxes", Label: "Checks", Options: []TemplateOption{
+					{Label: "First", Required: true},
+					{Label: "Second"},
+				}},
+			}},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					assert.Equal(t, []string{"First", "Second"}, options)
+					return []int{0}, nil
+				},
+			},
+			wantBody: "### Checks\n\n- [x] First\n- [ ] Second\n",
+		},
+		{
+			name: "missing required checkbox errors",
+			tpl: &CategoryTemplate{Body: []TemplateElement{
+				{Type: "checkboxes", Label: "Checks", Options: []TemplateOption{
+					{Label: "I agree", Required: true},
+				}},
+			}},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					return nil, nil
+				},
+			},
+			wantErr: `"I agree" is required`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, stdout, _ := iostreams.Test()
+
+			body, err := PromptCategoryTemplate(tt.prompter, ios, tt.tpl)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantBody, body)
+			_ = stdout
+		})
+	}
+}


### PR DESCRIPTION




<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description


Per #14015, it would be useful to present the user with an interactive
prompt when authoring a Discussion on a repository that has Discussion
Template(s) in place.

This builds on top of code from
https://github.com/jamietanna/gh-discussion (Apache-2.0) and rewritten
in the style of the project by Claude Sonnet 5.

Closes #14015.

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

### How did you test this change?

<!--
Demonstrate the code is solid, and how you know it solves the problem in the description.
Give the exact commands you ran and their output.
If this changes command output, show it before and after. Screenshot images are preferred over pasted text.

If you leave this empty, your pull request will very likely be closed.
-->

```console
# running it against a repo with Discussions enabled, but no templates
% go run ./cmd/gh discussion create  --repo JamieTanna-Mend-testing/renovatebot-renovate-discussions-42829
? Discussion title Example
? Discussion category Announcements
? Discussion body [(e) to launch nvim]
# ^^ not using a template

# running it against a repo with Discussions enabled + a template
% go run ./cmd/gh discussion create  --repo JamieTanna-Mend-testing/discussion-closing
? Discussion title Example
? Discussion category Mend Hosted Request
? What would you like help with? Upgrade to the Community (OSS) plan
? Please share the URL to the organisation you're creating this request for https://example.com
Please provide any relevant information about your project, such as the license(s) used by your project.

? Additional information [(e) to launch nvim, enter to skip]
...
# ^^ uses the form
```

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @jamietanna will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
