### PR TITLE
Require explicit PR review ownership

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,7 +42,7 @@ Link related issues or prior discussion, with one sentence on why each matters.
 ### Authorship and follow-up
 
 <!--
-REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.
+REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.
 
 Check exactly one box in each list.
 -->


### PR DESCRIPTION
### Description

AI agents filling out the pull request template could silently select `Nobody has explicitly committed to replying` when review ownership had not been established. Update the required agent instruction so an agent must pause and ask the human before creating or updating the pull request, must not infer ownership from contextual signals, and must select exactly the human's explicit choice.

### How did you test this change?

- Ran `git diff --check`; it exited successfully with no output.
- Confirmed the new instruction includes the pause-and-ask rule, all prohibited inference sources, and the explicit-selection rule.
- Confirmed the old silent-default instruction is absent.
- Confirmed both checkbox lists, all six options, and `Check exactly one box in each list.` remain unchanged.

### Key points

The change is limited to the hidden AI-agent instruction in `.github/PULL_REQUEST_TEMPLATE.md`; contributor-facing checkbox options are unchanged.

### Notes for reviewers

Start with the updated instruction under `### Authorship and follow-up`. The wording directly covers both creating and updating a pull request.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.