### PR TITLE
ci: add Linux binary release for loong64, ppc64le, and riscv64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,7 @@ builds:
 
   - id: linux #build:linux
     goos: [linux]
-    goarch: ["386", arm, amd64, arm64]
+    goarch: ["386", amd64, arm, arm64, loong64, ppc64le, riscv64]
     env:
       - CGO_ENABLED=0
     hooks:


### PR DESCRIPTION
Add Linux binary release targets for loong64, ppc64le, and riscv64, these are architectures that are available both as desktop and server products. It is also reasonable to assume that they are used by developers as host machines, where this CLI tool would have been used.

This commit is made with the understanding that GitHub has no interest in limiting usage of hardware of architectures other than x86, x86-64, Arm32, and Arm64.

Given that GitHub CLI is largely an architecture-agnostic tool (at least with its built-in functionalities), that adding binary releases is rather trivial with GoReleaser, that Golang support is quite mature (and actively maintained) for the three architectures above, and that i386 is still a supported architecture despite host machines of strictly 32-bit x86 architecture likely being even more obscure, so add them.

Link: https://github.com/cli/cli/issues/14012
Link: https://github.com/cli/cli/issues/8611
Link: https://github.com/cli/cli/pull/9410
Link: https://github.com/cli/cli/pull/8612
Link: https://github.com/cli/cli/pull/3615
Link: https://github.com/cli/cli/pull/1724

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [x] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @username will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
