### PR TITLE
fix: report actual error when auth status token check fails for non-401

### DIFF
--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -30,6 +30,7 @@ const (
 type authEntry struct {
 	State       authEntryState `json:"state"`
 	Error       string         `json:"error,omitempty"`
+	StatusCode  int            `json:"statusCode,omitempty"`
 	Active      bool           `json:"active"`
 	Host        string         `json:"host"`
 	Login       string         `json:"login"`
@@ -93,8 +94,14 @@ func (e authEntry) String(cs *iostreams.ColorScheme) string {
 		}
 		activeStr := fmt.Sprintf("%v", e.Active)
 		sb.WriteString(fmt.Sprintf("  - Active account: %s\n", cs.Bold(activeStr)))
-		sb.WriteString(fmt.Sprintf("  - The token in %s is invalid.\n", e.TokenSource))
-		if authTokenWriteable(e.TokenSource) {
+		if e.StatusCode == http.StatusUnauthorized {
+			sb.WriteString(fmt.Sprintf("  - The token in %s is invalid.\n", e.TokenSource))
+		} else if e.Error != "" {
+			sb.WriteString(fmt.Sprintf("  - Could not verify token in %s: %s\n", e.TokenSource, e.Error))
+		} else {
+			sb.WriteString(fmt.Sprintf("  - Could not verify token in %s.\n", e.TokenSource))
+		}
+		if authTokenWriteable(e.TokenSource) && e.StatusCode == http.StatusUnauthorized {
 			loginInstructions := fmt.Sprintf("gh auth login -h %s", e.Host)
 			if shared.AuthTokenRefreshable(e.Token, e.TokenSource) {
 				loginInstructions = fmt.Sprintf("gh auth refresh -h %s", e.Host)
@@ -411,6 +418,10 @@ func buildEntry(httpClient *http.Client, opts buildEntryOptions) authEntry {
 
 		entry.State = authEntryStateError
 		entry.Error = err.Error()
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) {
+			entry.StatusCode = httpErr.StatusCode
+		}
 		return entry
 	}
 	entry.Scopes = scopesHeader

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -176,7 +176,7 @@ func Test_statusRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				// mock for HeaderHasMinimumScopes api requests to a non-github.com host
-				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(400, "no bueno"))
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(401, "no bueno"))
 			},
 			wantErr: cmdutil.SilentError,
 			wantErrOut: heredoc.Doc(`
@@ -211,6 +211,24 @@ func Test_statusRun(t *testing.T) {
 			`),
 		},
 		{
+			name: "rate limited",
+			opts: StatusOptions{},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				login(t, c, "github.com", "monalisa", "gho_abc123", "https")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				// mock for HeaderHasMinimumScopes api requests to github.com
+				reg.Register(httpmock.REST("GET", ""), httpmock.WithHeader(httpmock.StatusStringResponse(403, `{"message":"API rate limit exceeded for user ID 123"}`), "Content-Type", "application/json"))
+			},
+			wantErr: cmdutil.SilentError,
+			wantErrOut: heredoc.Doc(`
+				github.com
+				  X Failed to log in to github.com account monalisa (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - Could not verify token in GH_CONFIG_DIR/hosts.yml: HTTP 403: API rate limit exceeded for user ID 123 (https://api.github.com/)
+			`),
+		},
+		{
 			name: "bad token on selected host",
 			opts: StatusOptions{
 				Hostname: "ghe.io",
@@ -221,7 +239,7 @@ func Test_statusRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				// mocks for HeaderHasMinimumScopes api requests to a non-github.com host
-				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(400, "no bueno"))
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(401, "no bueno"))
 			},
 			wantErr: cmdutil.SilentError,
 			wantErrOut: heredoc.Doc(`
@@ -446,9 +464,7 @@ func Test_statusRun(t *testing.T) {
 
 				  X Failed to log in to ghe.io account monalisa-ghe (GH_CONFIG_DIR/hosts.yml)
 				  - Active account: false
-				  - The token in GH_CONFIG_DIR/hosts.yml is invalid.
-				  - To re-authenticate, run: gh auth refresh -h ghe.io
-				  - To forget about this account, run: gh auth logout -h ghe.io -u monalisa-ghe
+				  - Could not verify token in GH_CONFIG_DIR/hosts.yml: HTTP 404 (https://ghe.io/api/v3/)
 			`),
 		},
 		{
@@ -534,9 +550,7 @@ func Test_statusRun(t *testing.T) {
 				ghe.io
 				  X Failed to log in to ghe.io account monalisa-ghe-2 (GH_CONFIG_DIR/hosts.yml)
 				  - Active account: true
-				  - The token in GH_CONFIG_DIR/hosts.yml is invalid.
-				  - To re-authenticate, run: gh auth refresh -h ghe.io
-				  - To forget about this account, run: gh auth logout -h ghe.io -u monalisa-ghe-2
+				  - Could not verify token in GH_CONFIG_DIR/hosts.yml: HTTP 404 (https://ghe.io/api/v3/)
 			`),
 		},
 		{
@@ -653,9 +667,9 @@ func Test_statusRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				// mock for HeaderHasMinimumScopes api requests to a non-github.com host
-				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(400, "no bueno"))
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(401, "no bueno"))
 			},
-			wantOut: `{"hosts":{"ghe.io":[{"state":"error","error":"HTTP 400 (https://ghe.io/api/v3/)","active":true,"host":"ghe.io","login":"monalisa-ghe","tokenSource":"GH_CONFIG_DIR/hosts.yml","gitProtocol":"https"}]}}` + "\n",
+			wantOut: `{"hosts":{"ghe.io":[{"state":"error","error":"HTTP 401 (https://ghe.io/api/v3/)","statusCode":401,"active":true,"host":"ghe.io","login":"monalisa-ghe","tokenSource":"GH_CONFIG_DIR/hosts.yml","gitProtocol":"https"}]}}` + "\n",
 			wantErr: nil, // should not return error in machine-readable mode
 		},
 		{


### PR DESCRIPTION
## Summary

`gh auth status` currently renders "The token in `<source>` is invalid." for **any** token-verification failure: 401, 403 rate limit, 5xx, and network/DNS errors all produce the same misleading message plus a "To re-authenticate, run: gh auth refresh" hint that only makes sense for genuinely invalid or revoked tokens. Refreshing while rate limited does not help, and the message actively misleads users (and agents reading the output) into thinking their token is dead.

This PR records the HTTP status code of the verification request and only reports the token as invalid for `401 Unauthorized`. For every other failure it surfaces the actual error instead, and the re-auth/logout hints are only shown for genuine auth failures.

This follows existing precedent in the codebase rather than introducing a new mechanism:
- `internal/ghcmd/cmd.go` already special-cases `errors.As(err, &api.HTTPError) && httpErr.StatusCode == 401` for the "Try authenticating with" hint (#13068).
- Timeouts were misreported the same way and received a dedicated state (#8293); this addresses the remaining error cases.

Real-world trigger: an agent daemon sharing the same token exhausted the account's API quota, and `gh auth status` kept reporting the token as invalid with a useless refresh hint - the token itself was fine and worked again after the rate limit reset. The same misleading output appears for sandboxed/network-restricted environments (DNS failures, blocked connections), as documented in #12891.

## Changes

- `pkg/cmd/auth/status/status.go`
  - `authEntry` gains a `StatusCode` field (exposed in `--json` output as `statusCode`, omitted when unset).
  - `buildEntry` records the status code from `api.HTTPError` when the scopes request fails.
  - `String()` now renders:
    - `401` - unchanged: "The token in `<source>` is invalid." plus re-auth/logout hints.
    - anything else - "Could not verify token in `<source>`: `<actual error>`" with no re-auth hint.
- `pkg/cmd/auth/status/status_test.go`
  - "bad token" cases now stub `401` (the real status for bad credentials) instead of `400`.
  - New "rate limited" case stubs a `403` rate-limit response and asserts the new message and the absence of the re-auth hint.
  - JSON case asserts the new `statusCode` field.

## Known limitations (deliberately out of scope)

- **Env-token path**: tokens from `GH_TOKEN`/`GH_ENTERPRISE_TOKEN` are validated via a GraphQL call (`CurrentLoginName`) whose errors do not carry an HTTP status code, so the statusCode-based discrimination does not apply there; a genuinely invalid env token reports "Could not verify token" with the underlying error rather than "invalid". Fixing this requires touching the GraphQL client's error surface.
- **SSO-enforced 403s** (403 + `X-GitHub-SSO` header) keep their existing handling; that flow is managed separately in `internal/ghcmd` via the SSO URL mechanism.

## Test plan

- `go test ./pkg/cmd/auth/status/...` - all pass.
- `go build ./...` - clean.

## Related

- Fixes #12891 (gh auth status should distinguish transport failures from invalid credentials)
- Also addresses #14053 (reported rate-limit misreporting; triaged as a duplicate of #12891)
