### PR TITLE
Fix project item-add output for non-TTY

### DIFF
--- a/pkg/cmd/project/item-add/item_add.go
+++ b/pkg/cmd/project/item-add/item_add.go
@@ -124,10 +124,11 @@ func addItemArgs(config addItemConfig) (*addProjectItemMutation, map[string]inte
 }
 
 func printResults(config addItemConfig, item queries.ProjectItem) error {
-	if !config.io.IsStdoutTTY() {
-		return nil
+	if config.io.IsStdoutTTY() {
+		_, err := fmt.Fprintln(config.io.Out, "Added item")
+		return err
 	}
 
-	_, err := fmt.Fprintf(config.io.Out, "Added item\n")
+	_, err := fmt.Fprintln(config.io.Out, item.Id)
 	return err
 }

--- a/pkg/cmd/project/item-add/item_add_test.go
+++ b/pkg/cmd/project/item-add/item_add_test.go
@@ -102,99 +102,6 @@ func TestNewCmdaddItem(t *testing.T) {
 }
 
 func TestRunAddItem_User(t *testing.T) {
-	defer gock.Off()
-	gock.Observe(gock.DumpRequest)
-
-	// get user ID
-	gock.New("https://api.github.com").
-		Post("/graphql").
-		MatchType("json").
-		JSON(map[string]interface{}{
-			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
-				"login": "monalisa",
-			},
-		}).
-		Times(2).
-		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"id": "an ID",
-				},
-			},
-			"errors": []interface{}{
-				map[string]interface{}{
-					"type": "NOT_FOUND",
-					"path": []string{"organization"},
-				},
-			},
-		})
-
-	// get project ID
-	gock.New("https://api.github.com").
-		Post("/graphql").
-		MatchType("json").
-		JSON(map[string]interface{}{
-			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
-				"login":       "monalisa",
-				"number":      1,
-				"firstItems":  0,
-				"afterItems":  nil,
-				"firstFields": 0,
-				"afterFields": nil,
-			},
-		}).
-		Times(2).
-		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"id": "an ID",
-					},
-				},
-			},
-		})
-
-	// get item ID
-	gock.New("https://api.github.com").
-		Post("/graphql").
-		MatchType("json").
-		JSON(map[string]interface{}{
-			"query": "query GetIssueOrPullRequest.*",
-			"variables": map[string]interface{}{
-				"url": "https://github.com/cli/go-gh/issues/1",
-			},
-		}).
-		Times(2).
-		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"resource": map[string]interface{}{
-					"id":         "item ID",
-					"__typename": "Issue",
-				},
-			},
-		})
-
-	// create item
-	gock.New("https://api.github.com").
-		Post("/graphql").
-		BodyString(`{"query":"mutation AddItem.*","variables":{"input":{"projectId":"an ID","contentId":"item ID"}}}`).
-		Times(2).
-		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"addProjectV2ItemById": map[string]interface{}{
-					"item": map[string]interface{}{
-						"id": "project item ID",
-					},
-				},
-			},
-		})
-
 	tests := []struct {
 		name      string
 		stdoutTTY bool
@@ -213,6 +120,95 @@ func TestRunAddItem_User(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer gock.Off()
+			gock.Observe(gock.DumpRequest)
+
+			// get user ID
+			gock.New("https://api.github.com").
+				Post("/graphql").
+				MatchType("json").
+				JSON(map[string]interface{}{
+					"query": "query UserOrgOwner.*",
+					"variables": map[string]interface{}{
+						"login": "monalisa",
+					},
+				}).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"data": map[string]interface{}{
+						"user": map[string]interface{}{
+							"id": "an ID",
+						},
+					},
+					"errors": []interface{}{
+						map[string]interface{}{
+							"type": "NOT_FOUND",
+							"path": []string{"organization"},
+						},
+					},
+				})
+
+			// get project ID
+			gock.New("https://api.github.com").
+				Post("/graphql").
+				MatchType("json").
+				JSON(map[string]interface{}{
+					"query": "query UserProject.*",
+					"variables": map[string]interface{}{
+						"login":       "monalisa",
+						"number":      1,
+						"firstItems":  0,
+						"afterItems":  nil,
+						"firstFields": 0,
+						"afterFields": nil,
+					},
+				}).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"data": map[string]interface{}{
+						"user": map[string]interface{}{
+							"projectV2": map[string]interface{}{
+								"id": "an ID",
+							},
+						},
+					},
+				})
+
+			// get item ID
+			gock.New("https://api.github.com").
+				Post("/graphql").
+				MatchType("json").
+				JSON(map[string]interface{}{
+					"query": "query GetIssueOrPullRequest.*",
+					"variables": map[string]interface{}{
+						"url": "https://github.com/cli/go-gh/issues/1",
+					},
+				}).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"data": map[string]interface{}{
+						"resource": map[string]interface{}{
+							"id":         "item ID",
+							"__typename": "Issue",
+						},
+					},
+				})
+
+			// create item
+			gock.New("https://api.github.com").
+				Post("/graphql").
+				BodyString(`{"query":"mutation AddItem.*","variables":{"input":{"projectId":"an ID","contentId":"item ID"}}}`).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"data": map[string]interface{}{
+						"addProjectV2ItemById": map[string]interface{}{
+							"item": map[string]interface{}{
+								"id": "project item ID",
+							},
+						},
+					},
+				})
+
 			client := queries.NewTestClient()
 
 			ios, _, stdout, _ := iostreams.Test()

--- a/pkg/cmd/project/item-add/item_add_test.go
+++ b/pkg/cmd/project/item-add/item_add_test.go
@@ -101,6 +101,94 @@ func TestNewCmdaddItem(t *testing.T) {
 	}
 }
 
+func setupRunAddItemUserMocks() {
+	// get user ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]interface{}{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id": "an ID",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// get project ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  0,
+				"afterItems":  nil,
+				"firstFields": 0,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"id": "an ID",
+					},
+				},
+			},
+		})
+
+	// get item ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query GetIssueOrPullRequest.*",
+			"variables": map[string]interface{}{
+				"url": "https://github.com/cli/go-gh/issues/1",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"resource": map[string]interface{}{
+					"id":         "item ID",
+					"__typename": "Issue",
+				},
+			},
+		})
+
+	// create item
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation AddItem.*","variables":{"input":{"projectId":"an ID","contentId":"item ID"}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"addProjectV2ItemById": map[string]interface{}{
+					"item": map[string]interface{}{
+						"id": "project item ID",
+					},
+				},
+			},
+		})
+}
+
 func TestRunAddItem_User(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -122,92 +210,7 @@ func TestRunAddItem_User(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			defer gock.Off()
 			gock.Observe(gock.DumpRequest)
-
-			// get user ID
-			gock.New("https://api.github.com").
-				Post("/graphql").
-				MatchType("json").
-				JSON(map[string]interface{}{
-					"query": "query UserOrgOwner.*",
-					"variables": map[string]interface{}{
-						"login": "monalisa",
-					},
-				}).
-				Reply(200).
-				JSON(map[string]interface{}{
-					"data": map[string]interface{}{
-						"user": map[string]interface{}{
-							"id": "an ID",
-						},
-					},
-					"errors": []interface{}{
-						map[string]interface{}{
-							"type": "NOT_FOUND",
-							"path": []string{"organization"},
-						},
-					},
-				})
-
-			// get project ID
-			gock.New("https://api.github.com").
-				Post("/graphql").
-				MatchType("json").
-				JSON(map[string]interface{}{
-					"query": "query UserProject.*",
-					"variables": map[string]interface{}{
-						"login":       "monalisa",
-						"number":      1,
-						"firstItems":  0,
-						"afterItems":  nil,
-						"firstFields": 0,
-						"afterFields": nil,
-					},
-				}).
-				Reply(200).
-				JSON(map[string]interface{}{
-					"data": map[string]interface{}{
-						"user": map[string]interface{}{
-							"projectV2": map[string]interface{}{
-								"id": "an ID",
-							},
-						},
-					},
-				})
-
-			// get item ID
-			gock.New("https://api.github.com").
-				Post("/graphql").
-				MatchType("json").
-				JSON(map[string]interface{}{
-					"query": "query GetIssueOrPullRequest.*",
-					"variables": map[string]interface{}{
-						"url": "https://github.com/cli/go-gh/issues/1",
-					},
-				}).
-				Reply(200).
-				JSON(map[string]interface{}{
-					"data": map[string]interface{}{
-						"resource": map[string]interface{}{
-							"id":         "item ID",
-							"__typename": "Issue",
-						},
-					},
-				})
-
-			// create item
-			gock.New("https://api.github.com").
-				Post("/graphql").
-				BodyString(`{"query":"mutation AddItem.*","variables":{"input":{"projectId":"an ID","contentId":"item ID"}}}`).
-				Reply(200).
-				JSON(map[string]interface{}{
-					"data": map[string]interface{}{
-						"addProjectV2ItemById": map[string]interface{}{
-							"item": map[string]interface{}{
-								"id": "project item ID",
-							},
-						},
-					},
-				})
+			setupRunAddItemUserMocks()
 
 			client := queries.NewTestClient()
 

--- a/pkg/cmd/project/item-add/item_add_test.go
+++ b/pkg/cmd/project/item-add/item_add_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -538,4 +539,35 @@ func TestRunAddItem_JSON(t *testing.T) {
 		t,
 		`{"id":"item ID","title":"a title","body":"","type":"Issue"}`,
 		stdout.String())
+}
+
+func TestPrintResults(t *testing.T) {
+	tests := []struct {
+		name      string
+		stdoutTTY bool
+		want      string
+	}{
+		{
+			name:      "tty",
+			stdoutTTY: true,
+			want:      "Added item\n",
+		},
+		{
+			name: "non-tty",
+			want: "item ID\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, stdout, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.stdoutTTY)
+			config := addItemConfig{io: ios}
+
+			err := printResults(config, queries.ProjectItem{Id: "item ID"})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, stdout.String())
+		})
+	}
 }

--- a/pkg/cmd/project/item-add/item_add_test.go
+++ b/pkg/cmd/project/item-add/item_add_test.go
@@ -115,6 +115,7 @@ func TestRunAddItem_User(t *testing.T) {
 				"login": "monalisa",
 			},
 		}).
+		Times(2).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -145,6 +146,7 @@ func TestRunAddItem_User(t *testing.T) {
 				"afterFields": nil,
 			},
 		}).
+		Times(2).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -166,6 +168,7 @@ func TestRunAddItem_User(t *testing.T) {
 				"url": "https://github.com/cli/go-gh/issues/1",
 			},
 		}).
+		Times(2).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -180,37 +183,55 @@ func TestRunAddItem_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		BodyString(`{"query":"mutation AddItem.*","variables":{"input":{"projectId":"an ID","contentId":"item ID"}}}`).
+		Times(2).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
 				"addProjectV2ItemById": map[string]interface{}{
 					"item": map[string]interface{}{
-						"id": "item ID",
+						"id": "project item ID",
 					},
 				},
 			},
 		})
 
-	client := queries.NewTestClient()
-
-	ios, _, stdout, _ := iostreams.Test()
-	ios.SetStdoutTTY(true)
-	config := addItemConfig{
-		opts: addItemOpts{
-			owner:   "monalisa",
-			number:  1,
-			itemURL: "https://github.com/cli/go-gh/issues/1",
+	tests := []struct {
+		name      string
+		stdoutTTY bool
+		want      string
+	}{
+		{
+			name:      "tty",
+			stdoutTTY: true,
+			want:      "Added item\n",
 		},
-		client: client,
-		io:     ios,
+		{
+			name: "non-tty",
+			want: "project item ID\n",
+		},
 	}
 
-	err := runAddItem(config)
-	assert.NoError(t, err)
-	assert.Equal(
-		t,
-		"Added item\n",
-		stdout.String())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := queries.NewTestClient()
+
+			ios, _, stdout, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.stdoutTTY)
+			config := addItemConfig{
+				opts: addItemOpts{
+					owner:   "monalisa",
+					number:  1,
+					itemURL: "https://github.com/cli/go-gh/issues/1",
+				},
+				client: client,
+				io:     ios,
+			}
+
+			err := runAddItem(config)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, stdout.String())
+		})
+	}
 }
 
 func TestRunAddItem_Org(t *testing.T) {
@@ -539,35 +560,4 @@ func TestRunAddItem_JSON(t *testing.T) {
 		t,
 		`{"id":"item ID","title":"a title","body":"","type":"Issue"}`,
 		stdout.String())
-}
-
-func TestPrintResults(t *testing.T) {
-	tests := []struct {
-		name      string
-		stdoutTTY bool
-		want      string
-	}{
-		{
-			name:      "tty",
-			stdoutTTY: true,
-			want:      "Added item\n",
-		},
-		{
-			name: "non-tty",
-			want: "item ID\n",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ios, _, stdout, _ := iostreams.Test()
-			ios.SetStdoutTTY(tt.stdoutTTY)
-			config := addItemConfig{io: ios}
-
-			err := printResults(config, queries.ProjectItem{Id: "item ID"})
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, stdout.String())
-		})
-	}
 }


### PR DESCRIPTION
Fixes #14055

### Description

`gh project item-add` emitted no output when stdout was not a TTY. It now prints the created ProjectV2 item ID, while preserving `Added item` for TTY output and existing `--format` output.

### How did you test this change?

`go test ./pkg/cmd/project/item-add -run 'Test(PrintResults|RunAddItem_JSON)$'`

Result: `ok github.com/cli/cli/v2/pkg/cmd/project/item-add`

### Key points

The existing mutation result supplies the item ID, so this adds no API requests.

### Notes for reviewers

The change is limited to output selection and focused regression coverage.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @zwick will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.