### PR TITLE
docs: recommend nix-shell over nix-env for Nix/NixOS

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -378,13 +378,15 @@ pkgin install gh
 
 ### Nix/NixOS
 
-The [GitHub CLI package](https://search.nixos.org/packages?query=gh&sort=relevance&show=gh) is supported by the NixOS community with updates powered by [NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/gh/gh).
+The [GitHub CLI package](https://search.nixos.org/packages?channel=26.05&query=gh#show=gh) is supported by the NixOS community with updates powered by [NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/gh/gh).
 
-To install:
+For a temporary shell with `gh` available:
 
 ```bash
-nix-env -iA nixos.gh
+nix-shell -p gh
 ```
+
+For permanent installation options (NixOS module, Home Manager, flakes, etc.), see the [NixOS package page](https://search.nixos.org/packages?channel=26.05&query=gh#show=gh).
 
 ### OpenBSD
 


### PR DESCRIPTION
﻿### Description

NixOS packaging guidance discourages `nix-env` because it permanently mutates a local profile. This updates the community Nix/NixOS install docs to:

- recommend `nix-shell -p gh` for temporary use
- link the [NixOS package page](https://search.nixos.org/packages?channel=26.05&query=gh#show=gh) for permanent install options

Fixes #14045

Related: closed PR #14021 (maintainer asked for this shape of change).

### How did you test this change?

- Reviewed rendered markdown locally
- Confirmed `nix-shell -p gh` is the documented temporary-use path on search.nixos.org

### Key points

Keeping `nix-env` as the only snippet would continue to steer new users toward a discouraged workflow.

### Notes for reviewers

Diff is confined to `docs/install_linux.md` under the community Nix/NixOS section.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] I (Felipe Fernandes / felipeofdev-ai) will reply if needed.

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/
