### PR TITLE
Route extension requests through api.Client

### DIFF
--- a/acceptance/testdata/repo/repo-autolink.txtar
+++ b/acceptance/testdata/repo/repo-autolink.txtar
@@ -1,0 +1,31 @@
+# Create a repository to hold the autolink references
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# List the autolinks. There should be none
+exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=keyPrefix
+! stdout keyPrefix
+
+# Create an alphanumeric autolink
+exec gh repo autolink create --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING TICKET- 'https://example.com/TICKET?query=<num>'
+
+# Ensure the autolink was created
+exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=keyPrefix --jq='.[].keyPrefix'
+stdout 'TICKET-'
+
+# Get the autolink id
+exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=keyPrefix,id --jq='.[] | select(.keyPrefix == "TICKET-") | .id'
+stdout2env AUTOLINK_ID
+
+# View the autolink and ensure the url template round tripped
+exec gh repo autolink view --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING $AUTOLINK_ID --json=urlTemplate --jq='.urlTemplate'
+stdout 'https://example\.com/TICKET\?query=<num>'
+
+# Delete the autolink
+exec gh repo autolink delete --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING $AUTOLINK_ID --yes
+
+# Ensure the autolink was deleted
+exec gh repo autolink list --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json=id --jq='.[].id'
+! stdout $AUTOLINK_ID

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -24,6 +24,8 @@ func repoExists(httpClient *http.Client, repo ghrepo.Interface) (bool, error) {
 		return false, err
 	}
 
+	// TODO(api-client-rollout)
+	// This has been deferred from moving to api.Client due to its exact-status contract and body-blind response handling.
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return false, err
@@ -82,6 +84,8 @@ func downloadAsset(httpClient *http.Client, assetURL safeurl.SafeURL, destPath s
 	req.Header.Set("Accept", "application/octet-stream")
 
 	var resp *http.Response
+	// TODO(api-client-rollout)
+	// This has been deferred from moving to api.Client due to its custom Accept header and binary response streaming.
 	if resp, downloadErr = httpClient.Do(req); downloadErr != nil {
 		return
 	}
@@ -178,6 +182,8 @@ func fetchCommitSHA(httpClient *http.Client, baseRepo ghrepo.Interface, targetRe
 	}
 
 	req.Header.Set("Accept", "application/vnd.github.v3.sha")
+	// TODO(api-client-rollout)
+	// This has been deferred from moving to api.Client due to its custom Accept header and bare SHA response body.
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", err

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -14,25 +14,30 @@ import (
 )
 
 func repoExists(httpClient *http.Client, repo ghrepo.Interface) (bool, error) {
-	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName())
+	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName())
 	if err != nil {
 		return false, err
 	}
 
-	var data struct{}
-	// TODO(api-client-rollout)
-	// This line of code is part of a mechanical roll out of the api client.
-	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	err = api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), http.MethodGet, path.String(), nil, &data)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
-		var httpErr api.HTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			return false, nil
-		}
 		return false, err
 	}
 
-	return true, nil
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, api.HandleHTTPError(resp)
+	}
 }
 
 func hasScript(httpClient *http.Client, repo ghrepo.Interface) (bool, error) {

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -48,11 +48,12 @@ func hasScript(httpClient *http.Client, repo ghrepo.Interface) (bool, error) {
 		return false, err
 	}
 
-	var data struct{}
+	// The response body is not decoded, because a script is considered present for any
+	// successful response regardless of the content type reported.
 	// TODO(api-client-rollout)
 	// This line of code is part of a mechanical roll out of the api client.
 	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	err = api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), http.MethodGet, path.String(), nil, &data)
+	err = api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), http.MethodGet, path.String(), nil, nil)
 	if err != nil {
 		var httpErr api.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -14,53 +14,43 @@ import (
 )
 
 func repoExists(httpClient *http.Client, repo ghrepo.Interface) (bool, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName())
-	if err != nil {
-		return false, err
-	}
-	req, err := http.NewRequest("GET", url.String(), nil)
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName())
 	if err != nil {
 		return false, err
 	}
 
-	resp, err := httpClient.Do(req)
+	var data struct{}
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), http.MethodGet, path.String(), nil, &data)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
 		return false, err
 	}
-	defer resp.Body.Close()
 
-	switch resp.StatusCode {
-	case 200:
-		return true, nil
-	case 404:
-		return false, nil
-	default:
-		return false, api.HandleHTTPError(resp)
-	}
+	return true, nil
 }
 
 func hasScript(httpClient *http.Client, repo ghrepo.Interface) (bool, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "contents", repo.RepoName())
-	if err != nil {
-		return false, err
-	}
-	req, err := http.NewRequest("GET", url.String(), nil)
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "contents", repo.RepoName())
 	if err != nil {
 		return false, err
 	}
 
-	resp, err := httpClient.Do(req)
+	var data struct{}
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), http.MethodGet, path.String(), nil, &data)
 	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == 404 {
-		return false, nil
-	}
-
-	if resp.StatusCode > 299 {
-		err = api.HandleHTTPError(resp)
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
 		return false, err
 	}
 
@@ -117,36 +107,26 @@ var repositoryNotFoundErr = errors.New("repository not found")
 
 // fetchLatestRelease finds the latest published release for a repository.
 func fetchLatestRelease(httpClient *http.Client, baseRepo ghrepo.Interface) (*release, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(baseRepo.RepoHost()), "repos", baseRepo.RepoOwner(), baseRepo.RepoName(), "releases", "latest")
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest("GET", url.String(), nil)
+	path, err := safeurl.JoinPath("repos", baseRepo.RepoOwner(), baseRepo.RepoName(), "releases", "latest")
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := httpClient.Do(req)
+	var data json.RawMessage
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(baseRepo.RepoHost(), http.MethodGet, path.String(), nil, &data)
 	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == 404 {
-		return nil, releaseNotFoundErr
-	}
-	if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, releaseNotFoundErr
+		}
 		return nil, err
 	}
 
 	var r release
-	err = json.Unmarshal(b, &r)
-	if err != nil {
+	if err := json.Unmarshal(data, &r); err != nil {
 		return nil, err
 	}
 
@@ -155,36 +135,26 @@ func fetchLatestRelease(httpClient *http.Client, baseRepo ghrepo.Interface) (*re
 
 // fetchReleaseFromTag finds release by tag name for a repository
 func fetchReleaseFromTag(httpClient *http.Client, baseRepo ghrepo.Interface, tagName string) (*release, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(baseRepo.RepoHost()), "repos", baseRepo.RepoOwner(), baseRepo.RepoName(), "releases", "tags", tagName)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest("GET", url.String(), nil)
+	path, err := safeurl.JoinPath("repos", baseRepo.RepoOwner(), baseRepo.RepoName(), "releases", "tags", tagName)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := httpClient.Do(req)
+	var data json.RawMessage
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(baseRepo.RepoHost(), http.MethodGet, path.String(), nil, &data)
 	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-	if resp.StatusCode == 404 {
-		return nil, releaseNotFoundErr
-	}
-	if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, releaseNotFoundErr
+		}
 		return nil, err
 	}
 
 	var r release
-	err = json.Unmarshal(b, &r)
-	if err != nil {
+	if err := json.Unmarshal(data, &r); err != nil {
 		return nil, err
 	}
 

--- a/pkg/cmd/extension/http_test.go
+++ b/pkg/cmd/extension/http_test.go
@@ -38,14 +38,20 @@ func requireExtensionHTTPError(t *testing.T, err error, status int) {
 func TestRepoExists(t *testing.T) {
 	repo := ghrepo.New("OWNER", "REPO")
 
-	t.Run("success", func(t *testing.T) {
-		client := extensionHTTPClient(t, "repos/OWNER/REPO", http.StatusOK, `{}`)
+	for name, body := range map[string]string{
+		"JSON body":     `{}`,
+		"empty body":    "",
+		"non-JSON body": "repository",
+	} {
+		t.Run("success with "+name, func(t *testing.T) {
+			client := extensionHTTPClient(t, "repos/OWNER/REPO", http.StatusOK, body)
 
-		exists, err := repoExists(client, repo)
+			exists, err := repoExists(client, repo)
 
-		require.NoError(t, err)
-		assert.True(t, exists)
-	})
+			require.NoError(t, err)
+			assert.True(t, exists)
+		})
+	}
 
 	t.Run("not found", func(t *testing.T) {
 		client := extensionHTTPClient(t, "repos/OWNER/REPO", http.StatusNotFound, `{"message":"Not Found"}`)
@@ -64,6 +70,17 @@ func TestRepoExists(t *testing.T) {
 		assert.False(t, exists)
 		requireExtensionHTTPError(t, err, http.StatusInternalServerError)
 	})
+
+	for _, status := range []int{http.StatusCreated, http.StatusNoContent} {
+		t.Run("unexpected "+http.StatusText(status), func(t *testing.T) {
+			client := extensionHTTPClient(t, "repos/OWNER/REPO", status, `{"message":"Unexpected status"}`)
+
+			exists, err := repoExists(client, repo)
+
+			assert.False(t, exists)
+			requireExtensionHTTPError(t, err, status)
+		})
+	}
 }
 
 func TestHasScript(t *testing.T) {

--- a/pkg/cmd/extension/http_test.go
+++ b/pkg/cmd/extension/http_test.go
@@ -1,0 +1,194 @@
+package extension
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func extensionHTTPClient(t *testing.T, path string, status int, body string) *http.Client {
+	t.Helper()
+
+	reg := &httpmock.Registry{}
+	t.Cleanup(func() {
+		reg.Verify(t)
+	})
+	reg.Register(
+		httpmock.REST(http.MethodGet, path),
+		httpmock.StatusStringResponse(status, body),
+	)
+	return &http.Client{Transport: reg}
+}
+
+func requireExtensionHTTPError(t *testing.T, err error, status int) {
+	t.Helper()
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, status, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), fmt.Sprintf("HTTP %d", status))
+}
+
+func TestRepoExists(t *testing.T) {
+	repo := ghrepo.New("OWNER", "REPO")
+
+	t.Run("success", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO", http.StatusOK, `{}`)
+
+		exists, err := repoExists(client, repo)
+
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO", http.StatusNotFound, `{"message":"Not Found"}`)
+
+		exists, err := repoExists(client, repo)
+
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO", http.StatusInternalServerError, `{"message":"Internal Server Error"}`)
+
+		exists, err := repoExists(client, repo)
+
+		assert.False(t, exists)
+		requireExtensionHTTPError(t, err, http.StatusInternalServerError)
+	})
+}
+
+func TestHasScript(t *testing.T) {
+	repo := ghrepo.New("OWNER", "REPO")
+
+	t.Run("success", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO/contents/REPO", http.StatusOK, `{"type":"file"}`)
+
+		hasScript, err := hasScript(client, repo)
+
+		require.NoError(t, err)
+		assert.True(t, hasScript)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO/contents/REPO", http.StatusNotFound, `{"message":"Not Found"}`)
+
+		hasScript, err := hasScript(client, repo)
+
+		require.NoError(t, err)
+		assert.False(t, hasScript)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO/contents/REPO", http.StatusInternalServerError, `{"message":"Internal Server Error"}`)
+
+		hasScript, err := hasScript(client, repo)
+
+		assert.False(t, hasScript)
+		requireExtensionHTTPError(t, err, http.StatusInternalServerError)
+	})
+}
+
+func TestFetchLatestRelease(t *testing.T) {
+	repo := ghrepo.New("OWNER", "REPO")
+
+	t.Run("success", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO/releases/latest", http.StatusOK, `{"tag_name":"v1.2.3","assets":[{"name":"asset","url":"https://example.com/asset"}]}`)
+
+		got, err := fetchLatestRelease(client, repo)
+
+		require.NoError(t, err)
+		assert.Equal(t, &release{
+			Tag: "v1.2.3",
+			Assets: []releaseAsset{{
+				Name:   "asset",
+				APIURL: "https://example.com/asset",
+			}},
+		}, got)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO/releases/latest", http.StatusNotFound, `{"message":"Not Found"}`)
+
+		got, err := fetchLatestRelease(client, repo)
+
+		assert.Nil(t, got)
+		require.Same(t, releaseNotFoundErr, err)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO/releases/latest", http.StatusInternalServerError, `{"message":"Internal Server Error"}`)
+
+		got, err := fetchLatestRelease(client, repo)
+
+		assert.Nil(t, got)
+		requireExtensionHTTPError(t, err, http.StatusInternalServerError)
+	})
+
+	for _, status := range []int{http.StatusNoContent, http.StatusResetContent} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			client := extensionHTTPClient(t, "repos/OWNER/REPO/releases/latest", status, "")
+
+			got, err := fetchLatestRelease(client, repo)
+
+			assert.Nil(t, got)
+			require.EqualError(t, err, "unexpected end of JSON input")
+		})
+	}
+}
+
+func TestFetchReleaseFromTag(t *testing.T) {
+	repo := ghrepo.New("OWNER", "REPO")
+
+	t.Run("success", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO/releases/tags/v1.2.3", http.StatusOK, `{"tag_name":"v1.2.3","assets":[{"name":"asset","url":"https://example.com/asset"}]}`)
+
+		got, err := fetchReleaseFromTag(client, repo, "v1.2.3")
+
+		require.NoError(t, err)
+		assert.Equal(t, &release{
+			Tag: "v1.2.3",
+			Assets: []releaseAsset{{
+				Name:   "asset",
+				APIURL: "https://example.com/asset",
+			}},
+		}, got)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO/releases/tags/v1.2.3", http.StatusNotFound, `{"message":"Not Found"}`)
+
+		got, err := fetchReleaseFromTag(client, repo, "v1.2.3")
+
+		assert.Nil(t, got)
+		require.Same(t, releaseNotFoundErr, err)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		client := extensionHTTPClient(t, "repos/OWNER/REPO/releases/tags/v1.2.3", http.StatusInternalServerError, `{"message":"Internal Server Error"}`)
+
+		got, err := fetchReleaseFromTag(client, repo, "v1.2.3")
+
+		assert.Nil(t, got)
+		requireExtensionHTTPError(t, err, http.StatusInternalServerError)
+	})
+
+	for _, status := range []int{http.StatusNoContent, http.StatusResetContent} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			client := extensionHTTPClient(t, "repos/OWNER/REPO/releases/tags/v1.2.3", status, "")
+
+			got, err := fetchReleaseFromTag(client, repo, "v1.2.3")
+
+			assert.Nil(t, got)
+			require.EqualError(t, err, "unexpected end of JSON input")
+		})
+	}
+}

--- a/pkg/cmd/extension/http_test.go
+++ b/pkg/cmd/extension/http_test.go
@@ -95,6 +95,27 @@ func TestHasScript(t *testing.T) {
 		assert.True(t, hasScript)
 	})
 
+	// The contents endpoint returns an array when the requested path is a directory, and
+	// objects with a non-file type for symlinks and submodules. None of these are treated as
+	// a missing script, so they must not surface a decoding error.
+	t.Run("success for non-file content", func(t *testing.T) {
+		for name, body := range map[string]string{
+			"directory listing": `[{"type":"file","name":"REPO"}]`,
+			"directory":         `{"type":"dir"}`,
+			"symlink":           `{"type":"symlink"}`,
+			"submodule":         `{"type":"submodule"}`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				client := extensionHTTPClient(t, "repos/OWNER/REPO/contents/REPO", http.StatusOK, body)
+
+				hasScript, err := hasScript(client, repo)
+
+				require.NoError(t, err)
+				assert.True(t, hasScript)
+			})
+		}
+	})
+
 	t.Run("not found", func(t *testing.T) {
 		client := extensionHTTPClient(t, "repos/OWNER/REPO/contents/REPO", http.StatusNotFound, `{"message":"Not Found"}`)
 

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -854,7 +854,7 @@ func TestManager_Install_git(t *testing.T) {
 			}))
 	reg.Register(
 		httpmock.REST("GET", "repos/owner/gh-some-ext/contents/gh-some-ext"),
-		httpmock.StringResponse("script"))
+		httpmock.JSONResponse(map[string]string{"type": "file"}))
 
 	repo := ghrepo.New("owner", fakeExtensionName)
 
@@ -934,7 +934,7 @@ func TestManager_Install_git_pinned(t *testing.T) {
 		httpmock.StringResponse("abcd1234"))
 	reg.Register(
 		httpmock.REST("GET", "repos/owner/gh-cool-ext/contents/gh-cool-ext"),
-		httpmock.StringResponse("script"))
+		httpmock.JSONResponse(map[string]string{"type": "file"}))
 
 	_ = os.MkdirAll(filepath.Join(m.installDir(), "gh-cool-ext"), 0700)
 	repo := ghrepo.New("owner", "gh-cool-ext")

--- a/pkg/cmd/repo/autolink/create/http.go
+++ b/pkg/cmd/repo/autolink/create/http.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
@@ -24,7 +23,7 @@ type AutolinkCreateRequest struct {
 }
 
 func (a *AutolinkCreator) Create(repo ghrepo.Interface, request AutolinkCreateRequest) (*shared.Autolink, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "autolinks")
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "autolinks")
 	if err != nil {
 		return nil, err
 	}
@@ -35,47 +34,19 @@ func (a *AutolinkCreator) Create(repo ghrepo.Interface, request AutolinkCreateRe
 	}
 	requestBody := bytes.NewReader(requestByte)
 
-	req, err := http.NewRequest(http.MethodPost, url.String(), requestBody)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := a.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-
-	err = handleAutolinkCreateError(resp)
-
-	if err != nil {
-		return nil, err
-	}
-
 	var autolink shared.Autolink
-
-	err = json.NewDecoder(resp.Body).Decode(&autolink)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(a.HTTPClient).REST(repo.RepoHost(), http.MethodPost, path.String(), requestBody, &autolink)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			httpErr.Message = "Must have admin rights to Repository."
+			return nil, httpErr
+		}
 		return nil, err
 	}
 
 	return &autolink, nil
-}
-
-func handleAutolinkCreateError(resp *http.Response) error {
-	switch resp.StatusCode {
-	case http.StatusCreated:
-		return nil
-	case http.StatusNotFound:
-		err := api.HandleHTTPError(resp)
-		var httpErr api.HTTPError
-		if errors.As(err, &httpErr) {
-			httpErr.Message = "Must have admin rights to Repository."
-			return httpErr
-		}
-		return err
-	default:
-		return api.HandleHTTPError(resp)
-	}
 }

--- a/pkg/cmd/repo/autolink/create/http_test.go
+++ b/pkg/cmd/repo/autolink/create/http_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
 	"github.com/cli/cli/v2/pkg/httpmock"
@@ -25,6 +26,7 @@ func TestAutolinkCreator_Create(t *testing.T) {
 		expectedAutolink *shared.Autolink
 		expectErr        bool
 		expectedErrMsg   string
+		expectedStatus   int
 	}{
 		{
 			name: "201 successful creation",
@@ -68,7 +70,8 @@ func TestAutolinkCreator_Create(t *testing.T) {
 				"documentation_url": "https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository",
 				"status": "422"
 				}`,
-			expectErr: true,
+			expectErr:      true,
+			expectedStatus: http.StatusUnprocessableEntity,
 			expectedErrMsg: heredoc.Doc(`
 				HTTP 422: Validation Failed (https://api.github.com/repos/OWNER/REPO/autolinks)
 				url_template must be an absolute URL`),
@@ -88,6 +91,7 @@ func TestAutolinkCreator_Create(t *testing.T) {
 			}`,
 			expectErr:      true,
 			expectedErrMsg: "HTTP 404: Must have admin rights to Repository. (https://api.github.com/repos/OWNER/REPO/autolinks)",
+			expectedStatus: http.StatusNotFound,
 		},
 		{
 			name: "422 URL template missing <num>",
@@ -96,9 +100,10 @@ func TestAutolinkCreator_Create(t *testing.T) {
 				KeyPrefix:      "TICKET-",
 				URLTemplate:    "https://example.com/TICKET",
 			},
-			stubStatus:   http.StatusUnprocessableEntity,
-			stubRespJSON: `{"message":"Validation Failed","errors":[{"resource":"KeyLink","code":"custom","field":"url_template","message":"url_template is missing a <num> token"}],"documentation_url":"https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository","status":"422"}`,
-			expectErr:    true,
+			stubStatus:     http.StatusUnprocessableEntity,
+			stubRespJSON:   `{"message":"Validation Failed","errors":[{"resource":"KeyLink","code":"custom","field":"url_template","message":"url_template is missing a <num> token"}],"documentation_url":"https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository","status":"422"}`,
+			expectErr:      true,
+			expectedStatus: http.StatusUnprocessableEntity,
 			expectedErrMsg: heredoc.Doc(`
 				HTTP 422: Validation Failed (https://api.github.com/repos/OWNER/REPO/autolinks)
 				url_template is missing a <num> token`),
@@ -110,9 +115,10 @@ func TestAutolinkCreator_Create(t *testing.T) {
 				KeyPrefix:      "TICKET-",
 				URLTemplate:    "https://example.com/TICKET?query=<num>",
 			},
-			stubStatus:   http.StatusUnprocessableEntity,
-			stubRespJSON: `{"message":"Validation Failed","errors":[{"resource":"KeyLink","code":"already_exists","field":"key_prefix"}],"documentation_url":"https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository","status":"422"}`,
-			expectErr:    true,
+			stubStatus:     http.StatusUnprocessableEntity,
+			stubRespJSON:   `{"message":"Validation Failed","errors":[{"resource":"KeyLink","code":"already_exists","field":"key_prefix"}],"documentation_url":"https://docs.github.com/rest/repos/autolinks#create-an-autolink-reference-for-a-repository","status":"422"}`,
+			expectErr:      true,
+			expectedStatus: http.StatusUnprocessableEntity,
 			expectedErrMsg: heredoc.Doc(`
 				HTTP 422: Validation Failed (https://api.github.com/repos/OWNER/REPO/autolinks)
 				KeyLink.key_prefix already exists`),
@@ -146,6 +152,9 @@ func TestAutolinkCreator_Create(t *testing.T) {
 
 			if tt.expectErr {
 				require.EqualError(t, err, tt.expectedErrMsg)
+				var httpErr api.HTTPError
+				require.ErrorAs(t, err, &httpErr)
+				assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedAutolink, autolink)

--- a/pkg/cmd/repo/autolink/delete/http.go
+++ b/pkg/cmd/repo/autolink/delete/http.go
@@ -1,11 +1,11 @@
 package delete
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
@@ -15,25 +15,21 @@ type AutolinkDeleter struct {
 }
 
 func (a *AutolinkDeleter) Delete(repo ghrepo.Interface, id string) error {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "autolinks", id)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest(http.MethodDelete, url.String(), nil)
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "autolinks", id)
 	if err != nil {
 		return err
 	}
 
-	resp, err := a.HTTPClient.Do(req)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(a.HTTPClient).REST(repo.RepoHost(), http.MethodDelete, path.String(), nil, nil)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("error deleting autolink: HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", httpErr.RequestURL)
+		}
 		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("error deleting autolink: HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", url)
-	} else if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
 	}
 
 	return nil

--- a/pkg/cmd/repo/autolink/delete/http_test.go
+++ b/pkg/cmd/repo/autolink/delete/http_test.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 	"testing"
 
+	cliapi "github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
-	"github.com/cli/go-gh/v2/pkg/api"
+	ghapi "github.com/cli/go-gh/v2/pkg/api"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +24,7 @@ func TestAutolinkDeleter_Delete(t *testing.T) {
 
 		expectErr      bool
 		expectedErrMsg string
+		expectedStatus int
 	}{
 		{
 			name:       "204 successful delete",
@@ -38,12 +41,13 @@ func TestAutolinkDeleter_Delete(t *testing.T) {
 		{
 			name: "500 unexpected error",
 			id:   "123",
-			stubResp: api.HTTPError{
+			stubResp: ghapi.HTTPError{
 				Message: "arbitrary error",
 			},
 			stubStatus:     http.StatusInternalServerError,
 			expectErr:      true,
 			expectedErrMsg: "HTTP 500: arbitrary error (https://api.github.com/repos/OWNER/REPO/autolinks/123)",
+			expectedStatus: http.StatusInternalServerError,
 		},
 	}
 
@@ -67,6 +71,12 @@ func TestAutolinkDeleter_Delete(t *testing.T) {
 
 			if tt.expectErr {
 				require.EqualError(t, err, tt.expectedErrMsg)
+				if tt.expectedStatus != 0 {
+					var httpErr cliapi.HTTPError
+					require.ErrorAs(t, err, &httpErr)
+					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
+					assert.Contains(t, err.Error(), "HTTP 500")
+				}
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/cmd/repo/autolink/delete/http_test.go
+++ b/pkg/cmd/repo/autolink/delete/http_test.go
@@ -75,7 +75,6 @@ func TestAutolinkDeleter_Delete(t *testing.T) {
 					var httpErr cliapi.HTTPError
 					require.ErrorAs(t, err, &httpErr)
 					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
-					assert.Contains(t, err.Error(), "HTTP 500")
 				}
 			} else {
 				require.NoError(t, err)

--- a/pkg/cmd/repo/autolink/list/http.go
+++ b/pkg/cmd/repo/autolink/list/http.go
@@ -1,12 +1,11 @@
 package list
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
@@ -17,29 +16,21 @@ type AutolinkLister struct {
 }
 
 func (a *AutolinkLister) List(repo ghrepo.Interface) ([]shared.Autolink, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "autolinks")
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "autolinks")
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := a.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("error getting autolinks: HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", url)
-	} else if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
-	}
 	var autolinks []shared.Autolink
-	err = json.NewDecoder(resp.Body).Decode(&autolinks)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(a.HTTPClient).REST(repo.RepoHost(), http.MethodGet, path.String(), nil, &autolinks)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("error getting autolinks: HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", httpErr.RequestURL)
+		}
 		return nil, err
 	}
 

--- a/pkg/cmd/repo/autolink/list/http_test.go
+++ b/pkg/cmd/repo/autolink/list/http_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
 	"github.com/cli/cli/v2/pkg/httpmock"
@@ -14,16 +15,20 @@ import (
 
 func TestAutolinkLister_List(t *testing.T) {
 	tests := []struct {
-		name   string
-		repo   ghrepo.Interface
-		resp   []shared.Autolink
-		status int
+		name              string
+		repo              ghrepo.Interface
+		resp              any
+		status            int
+		expectedAutolinks []shared.Autolink
+		expectedErrMsg    string
+		expectedStatus    int
 	}{
 		{
-			name:   "no autolinks",
-			repo:   ghrepo.New("OWNER", "REPO"),
-			resp:   []shared.Autolink{},
-			status: http.StatusOK,
+			name:              "no autolinks",
+			repo:              ghrepo.New("OWNER", "REPO"),
+			resp:              []shared.Autolink{},
+			status:            http.StatusOK,
+			expectedAutolinks: []shared.Autolink{},
 		},
 		{
 			name: "two autolinks",
@@ -43,11 +48,39 @@ func TestAutolinkLister_List(t *testing.T) {
 				},
 			},
 			status: http.StatusOK,
+			expectedAutolinks: []shared.Autolink{
+				{
+					ID:             1,
+					IsAlphanumeric: true,
+					KeyPrefix:      "key",
+					URLTemplate:    "https://example.com",
+				},
+				{
+					ID:             2,
+					IsAlphanumeric: false,
+					KeyPrefix:      "key2",
+					URLTemplate:    "https://example2.com",
+				},
+			},
 		},
 		{
-			name:   "http error",
-			repo:   ghrepo.New("OWNER", "REPO"),
-			status: http.StatusNotFound,
+			name: "404 repo not found",
+			repo: ghrepo.New("OWNER", "REPO"),
+			resp: map[string]any{
+				"message": "Not Found",
+			},
+			status:         http.StatusNotFound,
+			expectedErrMsg: "error getting autolinks: HTTP 404: Perhaps you are missing admin rights to the repository? (https://api.github.com/repos/OWNER/REPO/autolinks)",
+		},
+		{
+			name: "500 unexpected error",
+			repo: ghrepo.New("OWNER", "REPO"),
+			resp: map[string]any{
+				"message": "arbitrary error",
+			},
+			status:         http.StatusInternalServerError,
+			expectedErrMsg: "HTTP 500: arbitrary error (https://api.github.com/repos/OWNER/REPO/autolinks)",
+			expectedStatus: http.StatusInternalServerError,
 		},
 	}
 
@@ -64,12 +97,17 @@ func TestAutolinkLister_List(t *testing.T) {
 				HTTPClient: &http.Client{Transport: reg},
 			}
 			autolinks, err := autolinkLister.List(tt.repo)
-			if tt.status == http.StatusNotFound {
-				require.Error(t, err)
-				assert.Equal(t, "error getting autolinks: HTTP 404: Perhaps you are missing admin rights to the repository? (https://api.github.com/repos/OWNER/REPO/autolinks)", err.Error())
+			if tt.expectedErrMsg != "" {
+				require.EqualError(t, err, tt.expectedErrMsg)
+				if tt.expectedStatus != 0 {
+					var httpErr api.HTTPError
+					require.ErrorAs(t, err, &httpErr)
+					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
+					assert.Contains(t, err.Error(), "HTTP 500")
+				}
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tt.resp, autolinks)
+				assert.Equal(t, tt.expectedAutolinks, autolinks)
 			}
 		})
 	}

--- a/pkg/cmd/repo/autolink/list/http_test.go
+++ b/pkg/cmd/repo/autolink/list/http_test.go
@@ -103,7 +103,6 @@ func TestAutolinkLister_List(t *testing.T) {
 					var httpErr api.HTTPError
 					require.ErrorAs(t, err, &httpErr)
 					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
-					assert.Contains(t, err.Error(), "HTTP 500")
 				}
 			} else {
 				require.NoError(t, err)

--- a/pkg/cmd/repo/autolink/view/http.go
+++ b/pkg/cmd/repo/autolink/view/http.go
@@ -1,12 +1,11 @@
 package view
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
@@ -17,31 +16,21 @@ type AutolinkViewer struct {
 }
 
 func (a *AutolinkViewer) View(repo ghrepo.Interface, id string) (*shared.Autolink, error) {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "autolinks", id)
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "autolinks", id)
 	if err != nil {
 		return nil, err
-	}
-	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := a.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", url)
-	} else if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
 	}
 
 	var autolink shared.Autolink
-	err = json.NewDecoder(resp.Body).Decode(&autolink)
-
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(a.HTTPClient).REST(repo.RepoHost(), http.MethodGet, path.String(), nil, &autolink)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("HTTP 404: Perhaps you are missing admin rights to the repository? (%s)", httpErr.RequestURL)
+		}
 		return nil, err
 	}
 

--- a/pkg/cmd/repo/autolink/view/http_test.go
+++ b/pkg/cmd/repo/autolink/view/http_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/repo/autolink/shared"
 	"github.com/cli/cli/v2/pkg/httpmock"
@@ -24,6 +25,7 @@ func TestAutolinkViewer_View(t *testing.T) {
 		expectedAutolink *shared.Autolink
 		expectErr        bool
 		expectedErrMsg   string
+		expectedStatus   int
 	}{
 		{
 			name:       "200 successful alphanumeric view",
@@ -71,6 +73,15 @@ func TestAutolinkViewer_View(t *testing.T) {
 			expectErr:      true,
 			expectedErrMsg: "HTTP 404: Perhaps you are missing admin rights to the repository? (https://api.github.com/repos/OWNER/REPO/autolinks/123)",
 		},
+		{
+			name:           "500 unexpected error",
+			id:             "123",
+			stubStatus:     http.StatusInternalServerError,
+			stubRespJSON:   `{"message":"arbitrary error"}`,
+			expectErr:      true,
+			expectedErrMsg: "HTTP 500 (https://api.github.com/repos/OWNER/REPO/autolinks/123)",
+			expectedStatus: http.StatusInternalServerError,
+		},
 	}
 
 	for _, tt := range tests {
@@ -93,6 +104,12 @@ func TestAutolinkViewer_View(t *testing.T) {
 
 			if tt.expectErr {
 				require.EqualError(t, err, tt.expectedErrMsg)
+				if tt.expectedStatus != 0 {
+					var httpErr api.HTTPError
+					require.ErrorAs(t, err, &httpErr)
+					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
+					assert.Contains(t, err.Error(), "HTTP 500")
+				}
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedAutolink, autolink)

--- a/pkg/cmd/repo/autolink/view/http_test.go
+++ b/pkg/cmd/repo/autolink/view/http_test.go
@@ -108,7 +108,6 @@ func TestAutolinkViewer_View(t *testing.T) {
 					var httpErr api.HTTPError
 					require.ErrorAs(t, err, &httpErr)
 					assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
-					assert.Contains(t, err.Error(), "HTTP 500")
 				}
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
## Description

Part of https://github.com/cli/cli/issues/13991

This PR migrates the `gh extension` repository and release lookups to use the `api.Client` for API interactions. There should be no user visible change.

Three call sites move across: `hasScript`, `fetchLatestRelease` and `fetchReleaseFromTag`. Three deliberately stay on the raw `http.Client`:

 * `repoExists` distinguishes exactly `200` (exists) from exactly `404` (does not exist) and treats every other status as an error, while ignoring the response body entirely.
 * `downloadAsset` streams the extension binary to disk and sends `Accept: application/octet-stream`.
 * `fetchCommitSHA` sends `Accept: application/vnd.github.v3.sha` and reads the body as a bare SHA.

`api.Client.REST` unmarshals every 2xx other than `204` and `205` as JSON, does not surface the response status on success, and offers no way to set a per-request header or to reach the raw response body. So none of those three can go through it as it stands: `repoExists` would start accepting unexpected 2xx statuses as "exists" and would reject a bodyless or non-JSON `200`, and the other two have no body it can decode. All three keep `safeurl.JoinPathWithHostPrefix`, since they still build the full URL themselves.

They are deferred rather than excluded. All three are GitHub API requests that should route through `api.Client` once it exposes a lower-level surface carrying request headers, response status and a streamable body without duplicating endpoint derivation. Each carries a `TODO(api-client-rollout)` comment recording its specific reason.

`hasScript` treats a 404 as a value rather than an error. Because `api.Client.REST` turns a 404 into an `api.HTTPError`, that is now expressed with `errors.As` instead of a status switch.

One detail changed. `hasScript` previously returned `true` without ever reading the body, whereas `api.Client.REST` reads it. The call passes `nil` as the response destination, so the body is not decoded into anything and its shape is irrelevant: the object returned for a file, the array returned for a directory listing, and the objects returned for symlinks and submodules all still yield `true`. What remains is that the body must be valid JSON at all, which required updating two stubs in `manager_test.go` that returned the bare string `script`. The real endpoint always returns JSON.

`pkg/cmd/extension/http.go` had no test file at all, so this PR adds one. It covers the three migrated functions and pins the behaviour of `repoExists` that kept it on raw HTTP: a `200` succeeds with a JSON, empty or non-JSON body, a `404` is `(false, nil)`, and `201` and `204` remain errors.

### Acceptance Test

The existing `extension.txtar` script covers create, install, exec, upgrade and remove for a script extension, which exercises both of the functions whose behaviour changed.

```
➜  williammartin-symmetrical-potato git:(williammartin-route-extension-http) GH_ACCEPTANCE_HOST=github.com \
GH_ACCEPTANCE_ORG=gh-acceptance-testing \
GH_ACCEPTANCE_TOKEN="$(gh auth token --hostname github.com)" \
GH_ACCEPTANCE_SCRIPT=extension.txtar \
go test -tags=acceptance -count=1 -v -run '^TestExtensions$' ./acceptance
=== RUN   TestExtensions
=== RUN   TestExtensions/extension
=== PAUSE TestExtensions/extension
=== CONT  TestExtensions/extension
    testscript.go:584: WORK=$WORK
        PATH=/var/folders/z7/869nt6ns29d77xln9h9bm8680000gn/T/testscript-main4114609494/bin:/Users/williammartin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/bin:/Users/williammartin/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/williammartin/.local/bin
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=extension
        GH_CONFIG_DIR=$WORK
        GH_HOST=github.com
        ORG=gh-acceptance-testing
        GH_TOKEN=gho_************************************
        RANDOM_STRING=uSPkADAHyR
        GH_TELEMETRY=false
        
        # Skip if Bash is not available given script extension (0.000s)
        > [!exec:bash] skip
        # Setup environment variables used for testscript (0.000s)
        > env EXT_NAME=${SCRIPT_NAME}-${RANDOM_STRING}
        > env EXT_SCRIPT=gh-${EXT_NAME}
        > env REPO=gh-${EXT_NAME}
        # Use gh as a credential helper (0.704s)
        > exec gh auth setup-git
        # Create local repository for extension (0.364s)
        > exec gh extension create $EXT_NAME
        > cd $REPO
        $WORK/gh-extension-uSPkADAHyR
        # Setup v1 executable baseline for extension (0.083s)
        > mv ../v1.sh $EXT_SCRIPT
        > chmod 777 $EXT_SCRIPT
        > exec git add $EXT_SCRIPT
        > exec git commit -m 'Setup extension as v1'
        [stdout]
        [master df71a47] Setup extension as v1
         1 file changed, 1 insertion(+), 31 deletions(-)
        # Upload local extension repository (3.913s)
        > exec gh repo create $ORG/$REPO --private --source . --push
        [stdout]
        https://github.com/gh-acceptance-testing/gh-extension-uSPkADAHyR
        branch 'master' set up to track 'origin/master'.
        [stderr]
        To https://github.com/gh-acceptance-testing/gh-extension-uSPkADAHyR.git
         * [new branch]      HEAD -> master
        # Defer repo cleanup (0.000s)
        > defer gh repo delete --yes $ORG/$REPO
        # Verify extension shows up in search, sleep for indexing (12.873s)
        > exec gh repo edit --add-topic gh-extension
        > sleep 10
        > exec gh extension search --owner $ORG $EXT_NAME
        [stdout]
                gh-acceptance-testing/gh-extension-uSPkADAHyR
        > stdout ${ORG}/${REPO}
        # Verify repository can be installed as extension (2.236s)
        > exec gh extension install $ORG/$REPO
        [stderr]
        Cloning into '$WORK/.local/share/gh/extensions/gh-extension-uSPkADAHyR'...
        > exec gh extension list
        [stdout]
        gh extension-uSPkADAHyR gh-acceptance-testing/gh-extension-uSPkADAHyR   df71a476
        > stdout ${ORG}/${REPO}
        # Verify v1 extension behavior before upgrade (0.368s)
        > exec gh extension exec $EXT_NAME
        [stdout]
        gh ext create v1
        > stdout 'gh ext create v1'
        # Setup v2 executable upgrade for extension (1.505s)
        > mv ../v2.sh $EXT_SCRIPT
        > chmod 777 $EXT_SCRIPT
        > exec git add $EXT_SCRIPT
        > exec git commit -m 'Upgrade extension to v2'
        [stdout]
        [master 3da95fb] Upgrade extension to v2
         1 file changed, 1 insertion(+), 2 deletions(-)
        > exec git push -u origin
        [stdout]
        branch 'master' set up to track 'origin/master'.
        [stderr]
        To https://github.com/gh-acceptance-testing/gh-extension-uSPkADAHyR.git
           df71a47..3da95fb  master -> master
        # Verify v2 extension upgrade (1.979s)
        > exec gh extension upgrade $EXT_NAME
        [stdout]
        [extension-uSPkADAHyR]: Updating df71a47..3da95fb
        Fast-forward
         gh-extension-uSPkADAHyR | 3 +--
         1 file changed, 1 insertion(+), 2 deletions(-)
        upgraded from df71a476 to 3da95fb2
        [stderr]
        From https://github.com/gh-acceptance-testing/gh-extension-uSPkADAHyR
           df71a47..3da95fb  master     -> origin/master
        > exec gh extension exec $EXT_NAME
        [stdout]
        gh ext upgrade v2
        > stdout 'gh ext upgrade v2'
        # Verify extension can be removed (0.056s)
        > exec gh extension remove $EXT_NAME
        > ! stdout ${ORG}/${REPO}
        PASS
        
--- PASS: TestExtensions (0.00s)
    --- PASS: TestExtensions/extension (24.71s)
PASS
ok      github.com/cli/cli/v2/acceptance        25.269s
```

### Notes

**This is a stacked PR.** It targets #14013.





