### PR TITLE
Route release creation through api.Client

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -535,7 +535,7 @@ func createRun(opts *CreateOptions) error {
 		if !draftWhileUploading {
 			return err
 		}
-		if cleanupErr := deleteRelease(httpClient, safeurl.NewImmutableSafeURL(newRelease.APIURL)); cleanupErr != nil {
+		if cleanupErr := deleteRelease(httpClient, baseRepo.RepoHost(), safeurl.NewImmutableSafeURL(newRelease.APIURL)); cleanupErr != nil {
 			return fmt.Errorf("%w\ncleaning up draft failed: %v", err, cleanupErr)
 		}
 		return err
@@ -555,7 +555,7 @@ func createRun(opts *CreateOptions) error {
 		}
 
 		if draftWhileUploading {
-			rel, err := publishRelease(httpClient, safeurl.NewImmutableSafeURL(newRelease.APIURL), opts.DiscussionCategory, opts.IsLatest)
+			rel, err := publishRelease(httpClient, baseRepo.RepoHost(), safeurl.NewImmutableSafeURL(newRelease.APIURL), opts.DiscussionCategory, opts.IsLatest)
 			if err != nil {
 				return cleanupDraftRelease(err)
 			}

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -119,6 +119,8 @@ func publishedReleaseExists(httpClient *http.Client, repo ghrepo.Interface, tagN
 		return false, err
 	}
 
+	// TODO(api-client-rollout)
+	// This has been deferred from moving to api.Client due to HEAD responses having no body while REST decodes non-204/205 2xx responses as JSON.
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return false, err

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -60,36 +59,17 @@ func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagName str
 }
 
 func getTags(httpClient *http.Client, repo ghrepo.Interface, limit int) ([]tag, error) {
-	u, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "tags")
+	u, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "tags")
 	if err != nil {
 		return nil, err
 	}
 	u.SetQuery("per_page", strconv.Itoa(limit))
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	success := resp.StatusCode >= 200 && resp.StatusCode < 300
-	if !success {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
 
 	var tags []tag
-	err = json.Unmarshal(b, &tags)
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), http.MethodGet, u.String(), nil, &tags)
 	return tags, err
 }
 
@@ -109,41 +89,24 @@ func generateReleaseNotes(httpClient *http.Client, repo ghrepo.Interface, tagNam
 		return nil, err
 	}
 
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "releases", "generate-notes")
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest("POST", url.String(), bytes.NewBuffer(bodyBytes))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == 404 {
-		return nil, notImplementedError
-	}
-
-	success := resp.StatusCode >= 200 && resp.StatusCode < 300
-	if !success {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "releases", "generate-notes")
 	if err != nil {
 		return nil, err
 	}
 
 	var rn releaseNotes
-	err = json.Unmarshal(b, &rn)
-	return &rn, err
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), http.MethodPost, path.String(), bytes.NewBuffer(bodyBytes), &rn)
+	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, notImplementedError
+		}
+		return nil, err
+	}
+	return &rn, nil
 }
 
 func publishedReleaseExists(httpClient *http.Client, repo ghrepo.Interface, tagName string) (bool, error) {
@@ -179,22 +142,10 @@ func createRelease(httpClient *http.Client, repo ghrepo.Interface, params map[st
 		return nil, err
 	}
 
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "releases")
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "releases")
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", url.String(), bytes.NewBuffer(bodyBytes))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
 
 	// Check if we received a 404 while attempting to create a release without
 	// the workflow scope, and if so, return an error message that explains a possible
@@ -207,29 +158,27 @@ func createRelease(httpClient *http.Client, repo ghrepo.Interface, params map[st
 	// beyond returning a 404.
 	//
 	// https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes
-	if resp.StatusCode == http.StatusNotFound && !tokenHasWorkflowScope(resp) {
-		normalizedHostname := ghauth.NormalizeHostname(resp.Request.URL.Hostname())
-		return nil, &errMissingRequiredWorkflowScope{
-			Hostname: normalizedHostname,
-		}
-	}
-
-	success := resp.StatusCode >= 200 && resp.StatusCode < 300
-	if !success {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
+	var newRelease shared.Release
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(repo.RepoHost(), http.MethodPost, path.String(), bytes.NewBuffer(bodyBytes), &newRelease)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) &&
+			httpErr.StatusCode == http.StatusNotFound &&
+			!tokenHasWorkflowScope(httpErr.Headers) {
+			normalizedHostname := ghauth.NormalizeHostname(httpErr.RequestURL.Hostname())
+			return nil, &errMissingRequiredWorkflowScope{
+				Hostname: normalizedHostname,
+			}
+		}
 		return nil, err
 	}
-
-	var newRelease shared.Release
-	err = json.Unmarshal(b, &newRelease)
-	return &newRelease, err
+	return &newRelease, nil
 }
 
-func publishRelease(httpClient *http.Client, releaseURL safeurl.SafeURL, discussionCategory string, isLatest *bool) (*shared.Release, error) {
+func publishRelease(httpClient *http.Client, host string, releaseURL safeurl.SafeURL, discussionCategory string, isLatest *bool) (*shared.Release, error) {
 	params := map[string]interface{}{"draft": false}
 	if discussionCategory != "" {
 		params["discussion_category_name"] = discussionCategory
@@ -243,62 +192,29 @@ func publishRelease(httpClient *http.Client, releaseURL safeurl.SafeURL, discuss
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("PATCH", releaseURL.String(), bytes.NewBuffer(bodyBytes))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-	if resp.StatusCode > 299 {
-		return nil, api.HandleHTTPError(resp)
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
 
 	var release shared.Release
-	err = json.Unmarshal(b, &release)
-	return &release, err
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodPatch, releaseURL.String(), bytes.NewBuffer(bodyBytes), &release)
+	if err != nil {
+		return nil, err
+	}
+	return &release, nil
 }
 
-func deleteRelease(httpClient *http.Client, releaseURL safeurl.SafeURL) error {
-	req, err := http.NewRequest("DELETE", releaseURL.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.Body != nil {
-		defer resp.Body.Close()
-	}
-
-	success := resp.StatusCode >= 200 && resp.StatusCode < 300
-	if !success {
-		return api.HandleHTTPError(resp)
-	}
-
-	if resp.StatusCode != 204 {
-		_, _ = io.Copy(io.Discard, resp.Body)
-	}
-	return nil
+func deleteRelease(httpClient *http.Client, host string, releaseURL safeurl.SafeURL) error {
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, releaseURL.String(), nil, nil)
 }
 
-// tokenHasWorkflowScope checks if the given http.Response's token has the workflow scope.
+// tokenHasWorkflowScope checks if the response token has the workflow scope.
 // Tokens that do not have OAuth scopes are assumed to have the workflow scope.
-func tokenHasWorkflowScope(resp *http.Response) bool {
-	scopes := resp.Header.Get("X-Oauth-Scopes")
+func tokenHasWorkflowScope(headers http.Header) bool {
+	scopes := headers.Get("X-Oauth-Scopes")
 
 	// Return true when no scopes are present - no scopes in this header
 	// means that the user is probably authenticating with a token type other

--- a/pkg/cmd/release/create/http_test.go
+++ b/pkg/cmd/release/create/http_test.go
@@ -1,11 +1,111 @@
 package create
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/safeurl"
+	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestGetTagsHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "repos/OWNER/REPO/tags"),
+		httpmock.StatusStringResponse(http.StatusInternalServerError, `{"message":"Internal Server Error"}`),
+	)
+
+	_, err := getTags(&http.Client{Transport: reg}, ghrepo.New("OWNER", "REPO"), 5)
+
+	requireAPIHTTPError(t, err, http.StatusInternalServerError)
+}
+
+func TestGenerateReleaseNotesNotImplemented(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/releases/generate-notes"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	_, err := generateReleaseNotes(&http.Client{Transport: reg}, ghrepo.New("OWNER", "REPO"), "v1.2.3", "", "")
+
+	assert.Same(t, notImplementedError, err)
+}
+
+func TestGenerateReleaseNotesHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/releases/generate-notes"),
+		httpmock.StatusStringResponse(http.StatusInternalServerError, `{"message":"Internal Server Error"}`),
+	)
+
+	_, err := generateReleaseNotes(&http.Client{Transport: reg}, ghrepo.New("OWNER", "REPO"), "v1.2.3", "", "")
+
+	requireAPIHTTPError(t, err, http.StatusInternalServerError)
+}
+
+func TestCreateReleaseMissingWorkflowScope(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/releases"),
+		httpmock.StatusScopesResponder(http.StatusNotFound, "repo,read:org"),
+	)
+
+	_, err := createRelease(&http.Client{Transport: reg}, ghrepo.New("OWNER", "REPO"), map[string]interface{}{"tag_name": "v1.2.3"})
+
+	var scopeErr *errMissingRequiredWorkflowScope
+	require.ErrorAs(t, err, &scopeErr)
+	assert.Equal(t, "github.com", scopeErr.Hostname)
+	assert.EqualError(t, err, "workflow scope may be required")
+}
+
+func TestCreateReleaseHTTPErrorWithoutScopesHeader(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/releases"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	_, err := createRelease(&http.Client{Transport: reg}, ghrepo.New("OWNER", "REPO"), map[string]interface{}{"tag_name": "v1.2.3"})
+
+	requireAPIHTTPError(t, err, http.StatusNotFound)
+}
+
+func TestPublishReleaseHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("PATCH", "releases/123"),
+		httpmock.StatusStringResponse(http.StatusInternalServerError, `{"message":"Internal Server Error"}`),
+	)
+
+	_, err := publishRelease(&http.Client{Transport: reg}, "github.com", safeurl.NewImmutableSafeURL("https://api.github.com/releases/123"), "", nil)
+
+	requireAPIHTTPError(t, err, http.StatusInternalServerError)
+}
+
+func TestDeleteReleaseHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("DELETE", "releases/123"),
+		httpmock.StatusStringResponse(http.StatusInternalServerError, `{"message":"Internal Server Error"}`),
+	)
+
+	err := deleteRelease(&http.Client{Transport: reg}, "github.com", safeurl.NewImmutableSafeURL("https://api.github.com/releases/123"))
+
+	requireAPIHTTPError(t, err, http.StatusInternalServerError)
+}
 
 func TestTokenHasWorkflowScope(t *testing.T) {
 	tests := []struct {
@@ -51,12 +151,21 @@ func TestTokenHasWorkflowScope(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp := &http.Response{Header: http.Header{}}
+			headers := http.Header{}
 			if tt.scopes != "" {
-				resp.Header.Set("X-Oauth-Scopes", tt.scopes)
+				headers.Set("X-Oauth-Scopes", tt.scopes)
 			}
 
-			assert.Equal(t, tt.want, tokenHasWorkflowScope(resp))
+			assert.Equal(t, tt.want, tokenHasWorkflowScope(headers))
 		})
 	}
+}
+
+func requireAPIHTTPError(t *testing.T, err error, statusCode int) {
+	t.Helper()
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, statusCode, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), fmt.Sprintf("HTTP %d", statusCode))
 }


### PR DESCRIPTION
## Description

Part of https://github.com/cli/cli/issues/13991

This PR migrates `gh release create` to use the `api.Client` for API interactions. There should be no user visible change.

Five call sites move across: `getTags`, `generateReleaseNotes`, `createRelease`, `publishRelease` and `deleteRelease`. `publishedReleaseExists` deliberately stays on the raw `http.Client`, because it issues a `HEAD` request and so has no response body to decode, while `api.Client.REST` unmarshals every 2xx other than `204` and `205` as JSON. It keeps `safeurl.JoinPathWithHostPrefix`, since it still builds the full URL itself, and carries a `TODO(api-client-rollout)` comment recording that reason.

`generateReleaseNotes` treats a 404 as "this host does not implement the endpoint" rather than as an error. Because `api.Client.REST` turns a 404 into an `api.HTTPError`, that is now expressed with `errors.As` instead of a status check.

`createRelease` does the same for its missing-workflow-scope case. It now reads the scopes header and the hostname off the `api.HTTPError` rather than off an `*http.Response`, so `tokenHasWorkflowScope` takes an `http.Header` instead of a `*http.Response`, and the hostname comes from `httpErr.RequestURL`. That field is populated from the request that produced the error, so it stays correct on GHES.

`publishRelease` and `deleteRelease` act on the release `APIURL` returned by the server, which is an absolute URL. `api.Client.REST` passes absolute URLs through untouched, so those two requests are unchanged on the wire. Both functions gain a host parameter, supplied by `baseRepo.RepoHost()`.

`pkg/cmd/release/create/http.go` had no test file, so this PR adds one covering the error paths of all five migrated functions. The success paths of `publishRelease` and `deleteRelease` were already exercised by the draft-while-uploading cases in `create_test.go`.

### Acceptance Test

```
  williammartin-supreme-barnacle git:(williammartin-supreme-barnacle) cd /Users/williammartin/workspace/work/copilot-worktrees/cli/williammartin-miniature-engine

GH_ACCEPTANCE_HOST=github.com \
GH_ACCEPTANCE_ORG=gh-acceptance-testing \
GH_ACCEPTANCE_TOKEN="$(gh auth token --hostname github.com)" \
go test -tags=acceptance -count=1 -v -run '^TestReleases$' ./acceptance
=== RUN   TestReleases
=== RUN   TestReleases/release-create
=== PAUSE TestReleases/release-create
=== RUN   TestReleases/release-list
=== PAUSE TestReleases/release-list
=== RUN   TestReleases/release-upload-download
=== PAUSE TestReleases/release-upload-download
=== RUN   TestReleases/release-view
=== PAUSE TestReleases/release-view
=== CONT  TestReleases/release-create
=== CONT  TestReleases/release-upload-download
=== CONT  TestReleases/release-list
=== CONT  TestReleases/release-view
=== NAME  TestReleases/release-create
    testscript.go:584: WORK=$WORK
        PATH=/var/folders/z7/869nt6ns29d77xln9h9bm8680000gn/T/testscript-main2967020520/bin:/Users/williammartin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/bin:/Users/williammartin/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/williammartin/.local/bin
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=release_create
        GH_CONFIG_DIR=$WORK
        GH_HOST=github.com
        ORG=gh-acceptance-testing
        GH_TOKEN=gho_************************************
        RANDOM_STRING=NLfizmpwCD
        GH_TELEMETRY=false
        
        # Create a repository with a file so it has a default branch (2.657s)
        > exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
        [stdout]
        https://github.com/gh-acceptance-testing/release_create-NLfizmpwCD
        # Defer repo cleanup (0.000s)
        > defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
        # Clone the repo (1.550s)
        > exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
        [stderr]
        Cloning into 'release_create-NLfizmpwCD'...
        # Create a release in the repo (0.855s)
        > cd $SCRIPT_NAME-$RANDOM_STRING
        $WORK/release_create-NLfizmpwCD
        > exec gh release create v1.2.3 --notes 'awesome release' --latest
        [stdout]
        https://github.com/gh-acceptance-testing/release_create-NLfizmpwCD/releases/tag/v1.2.3
        PASS
        
=== NAME  TestReleases/release-list
    testscript.go:584: WORK=$WORK
        PATH=/var/folders/z7/869nt6ns29d77xln9h9bm8680000gn/T/testscript-main2967020520/bin:/Users/williammartin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/bin:/Users/williammartin/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/williammartin/.local/bin
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=release_list
        GH_CONFIG_DIR=$WORK
        GH_HOST=github.com
        ORG=gh-acceptance-testing
        GH_TOKEN=gho_************************************
        RANDOM_STRING=CAoShJAykT
        GH_TELEMETRY=false
        
        # Create a repository with a file so it has a default branch (2.862s)
        > exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
        [stdout]
        https://github.com/gh-acceptance-testing/release_list-CAoShJAykT
        # Defer repo cleanup (0.000s)
        > defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
        # Clone the repo (1.355s)
        > exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
        [stderr]
        Cloning into 'release_list-CAoShJAykT'...
        # Create a release in the repo (0.844s)
        > cd $SCRIPT_NAME-$RANDOM_STRING
        $WORK/release_list-CAoShJAykT
        > exec gh release create v1.2.3 --notes 'awesome release' --latest
        [stdout]
        https://github.com/gh-acceptance-testing/release_list-CAoShJAykT/releases/tag/v1.2.3
        # List the releases (0.808s)
        > exec gh release list
        [stdout]
        v1.2.3  Latest  v1.2.3  2026-08-04T11:53:54Z
        > stdout 'v1.2.3'
        PASS
        
=== NAME  TestReleases/release-view
    testscript.go:584: WORK=$WORK
        PATH=/var/folders/z7/869nt6ns29d77xln9h9bm8680000gn/T/testscript-main2967020520/bin:/Users/williammartin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/bin:/Users/williammartin/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/williammartin/.local/bin
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=release_view
        GH_CONFIG_DIR=$WORK
        GH_HOST=github.com
        ORG=gh-acceptance-testing
        GH_TOKEN=gho_************************************
        RANDOM_STRING=xuHwqkhcxc
        GH_TELEMETRY=false
        
        # Create a repository with a file so it has a default branch (3.407s)
        > exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
        [stdout]
        https://github.com/gh-acceptance-testing/release_view-xuHwqkhcxc
        # Defer repo cleanup (0.000s)
        > defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
        # Clone the repo (1.323s)
        > exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
        [stderr]
        Cloning into 'release_view-xuHwqkhcxc'...
        # Create a release in the repo (0.864s)
        > cd $SCRIPT_NAME-$RANDOM_STRING
        $WORK/release_view-xuHwqkhcxc
        > exec gh release create v1.2.3 --notes 'awesome release' --latest
        [stdout]
        https://github.com/gh-acceptance-testing/release_view-xuHwqkhcxc/releases/tag/v1.2.3
        # View the release (0.370s)
        > exec gh release view v1.2.3
        [stdout]
        title:
        tag:    v1.2.3
        draft:  false
        prerelease:     false
        immutable:      false
        author: williammartin
        created:        2026-08-04T11:53:52Z
        published:      2026-08-04T11:53:55Z
        url:    https://github.com/gh-acceptance-testing/release_view-xuHwqkhcxc/releases/tag/v1.2.3
        --
        awesome release
        > stdout 'v1.2.3'
        PASS
        
=== NAME  TestReleases/release-upload-download
    testscript.go:584: WORK=$WORK
        PATH=/var/folders/z7/869nt6ns29d77xln9h9bm8680000gn/T/testscript-main2967020520/bin:/Users/williammartin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/bin:/Users/williammartin/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/williammartin/.local/bin
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=release_upload_download
        GH_CONFIG_DIR=$WORK
        GH_HOST=github.com
        ORG=gh-acceptance-testing
        GH_TOKEN=gho_************************************
        RANDOM_STRING=dZeeFMqCZT
        GH_TELEMETRY=false
        
        # Create a repository with a file so it has a default branch (3.082s)
        > exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
        [stdout]
        https://github.com/gh-acceptance-testing/release_upload_download-dZeeFMqCZT
        # Defer repo cleanup (0.000s)
        > defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
        # Clone the repo (1.323s)
        > exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
        [stderr]
        Cloning into 'release_upload_download-dZeeFMqCZT'...
        # Create a release in the repo (1.087s)
        > cd $SCRIPT_NAME-$RANDOM_STRING
        $WORK/release_upload_download-dZeeFMqCZT
        > exec gh release create v1.2.3 --notes 'awesome release' --latest
        [stdout]
        https://github.com/gh-acceptance-testing/release_upload_download-dZeeFMqCZT/releases/tag/v1.2.3
        # Upload an asset to the release (1.105s)
        > exec gh release upload v1.2.3 ../asset.txt
        # Download the asset from the release (0.732s)
        > exec gh release download v1.2.3
        > exists asset.txt
        # Download the asset in archive form (0.905s)
        > exec gh release download v1.2.3 --archive=zip
        > exists $SCRIPT_NAME-$RANDOM_STRING-1.2.3.zip
        PASS
        
--- PASS: TestReleases (0.00s)
    --- PASS: TestReleases/release-create (5.64s)
    --- PASS: TestReleases/release-list (6.44s)
    --- PASS: TestReleases/release-view (6.45s)
    --- PASS: TestReleases/release-upload-download (8.76s)
PASS
ok      github.com/cli/cli/v2/acceptance        9.392s
```

### Notes

**This is a stacked PR.** It targets #14059.

