### PR TITLE
Trim spaces when parsing X-Oauth-Scopes in `gh release create`

### DIFF
--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -1210,7 +1210,7 @@ func Test_createRun(t *testing.T) {
 				)
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/releases"),
-					httpmock.StatusScopesResponder(404, `repo,read:org`))
+					httpmock.StatusScopesResponder(404, `repo, read:org`))
 			},
 			wantStderr: heredoc.Doc(`
 				! Failed to create release, "workflow" scope may be required.
@@ -1236,7 +1236,7 @@ func Test_createRun(t *testing.T) {
 				)
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/releases"),
-					httpmock.StatusScopesResponder(404, `repo,read:org,workflow`))
+					httpmock.StatusScopesResponder(404, `gist, project, read:org, repo, user, workflow`))
 			},
 			wantErr: "HTTP 404 (https://api.github.com/repos/OWNER/REPO/releases)",
 		},

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -308,7 +307,14 @@ func tokenHasWorkflowScope(resp *http.Response) bool {
 		return true
 	}
 
-	return slices.Contains(strings.Split(scopes, ","), "workflow")
+	// The API returns scopes separated by a comma and a space, so each element
+	// must be trimmed before comparison.
+	for _, s := range strings.Split(scopes, ",") {
+		if strings.TrimSpace(s) == "workflow" {
+			return true
+		}
+	}
+	return false
 }
 
 // isNewRelease checks if there are new commits since the latest release.

--- a/pkg/cmd/release/create/http_test.go
+++ b/pkg/cmd/release/create/http_test.go
@@ -1,0 +1,62 @@
+package create
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenHasWorkflowScope(t *testing.T) {
+	tests := []struct {
+		name   string
+		scopes string
+		want   bool
+	}{
+		{
+			// The API separates scopes with a comma and a space, and lists them
+			// in sorted order, so workflow is almost never the first element.
+			name:   "realistically spaced scopes including workflow",
+			scopes: "gist, project, read:org, repo, user, workflow",
+			want:   true,
+		},
+		{
+			name:   "spaced scopes without workflow",
+			scopes: "repo, read:org",
+			want:   false,
+		},
+		{
+			name:   "workflow first",
+			scopes: "workflow, repo",
+			want:   true,
+		},
+		{
+			name:   "only workflow",
+			scopes: "workflow",
+			want:   true,
+		},
+		{
+			name:   "unspaced scopes including workflow",
+			scopes: "repo,read:org,workflow",
+			want:   true,
+		},
+		{
+			// An absent header means this is not an OAuth token, so we can't
+			// know its scopes and must assume workflow is present.
+			name:   "no scopes header",
+			scopes: "",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{Header: http.Header{}}
+			if tt.scopes != "" {
+				resp.Header.Set("X-Oauth-Scopes", tt.scopes)
+			}
+
+			assert.Equal(t, tt.want, tokenHasWorkflowScope(resp))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #14063

### Description

When `gh release create` gets an HTTP 404 back from the API, it tries to work out whether the token is missing the `workflow` scope. There is a real case where that matters: if the release's tag introduces changes to workflow files, the API returns a bare 404 and gives no other signal that the scope is the problem. So the command checks the `X-Oauth-Scopes` response header and, when `workflow` is absent, swaps the raw error for a hint telling the user to run `gh auth refresh -s workflow`.

The check was wrong. `X-Oauth-Scopes` is comma-**space** separated:

```
X-Oauth-Scopes: gist, project, read:org, repo, user, workflow
```

`tokenHasWorkflowScope` did `slices.Contains(strings.Split(scopes, ","), "workflow")`, which leaves a leading space on every element except the first: `["gist", " project", " read:org", " repo", " user", " workflow"]`. Only the first element can ever match a bare scope name, and the API returns scopes in sorted order, so `workflow` is essentially never first. The function returned false for every real OAuth token.

Two consequences, the second being the serious one:

1. Users who already have `workflow` were told to request it. Running `gh auth refresh -s workflow` changed nothing, so there was no way to make the message go away.
2. The guard never held, so **every** 404 from `POST /repos/{owner}/{repo}/releases` was rewritten into the scope hint. A typo in the repo name, a repo that does not exist, or missing push access all surfaced as a scope problem instead of `HTTP 404: Not Found`.

The fix trims each element before comparing, which is what `generateScopesSuggestion` in `api/client.go` already does.

### How did you test this change?

![gh release create against a nonexistent repo: before, the 404 is blamed on the workflow scope; after, the real 404 surfaces](https://github.com/user-attachments/assets/aa9576af-5a3b-4912-9a78-9e6474364b05)

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
