### PR TITLE
fix(ssh-key): allow deleting signing keys via fallback endpoint

### DIFF
--- a/pkg/cmd/ssh-key/delete/delete_test.go
+++ b/pkg/cmd/ssh-key/delete/delete_test.go
@@ -151,9 +151,10 @@ func Test_deleteRun(t *testing.T) {
 			opts: DeleteOptions{KeyID: "123"},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, "{\"message\":\"Not Found\"}"))
 			},
 			wantErr:    true,
-			wantErrMsg: "HTTP 404 (https://api.github.com/user/keys/123)",
+			wantErrMsg: "HTTP 404 (https://api.github.com/user/ssh_signing_keys/123)",
 		},
 		{
 			name: "delete no tty",
@@ -169,9 +170,10 @@ func Test_deleteRun(t *testing.T) {
 			opts: DeleteOptions{KeyID: "123", Confirmed: true},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, `{\"message\":\"Not Found\"}`))
 			},
 			wantErr:    true,
-			wantErrMsg: "HTTP 404 (https://api.github.com/user/keys/123)",
+			wantErrMsg: "HTTP 404 (https://api.github.com/user/ssh_signing_keys/123)",
 		},
 	}
 
@@ -219,6 +221,10 @@ func TestDeleteSSHKeyHTTPError(t *testing.T) {
 		httpmock.REST("DELETE", "user/keys/1234"),
 		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
 	)
+	reg.Register(
+		httpmock.REST("DELETE", "user/ssh_signing_keys/1234"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
 
 	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
 
@@ -228,15 +234,69 @@ func TestDeleteSSHKeyHTTPError(t *testing.T) {
 	assert.Contains(t, err.Error(), "HTTP 404")
 }
 
-func TestGetSSHKeyHTTPError(t *testing.T) {
+func TestDeleteSigningKeyFallback(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 	reg.Register(
-		httpmock.REST("GET", "user/keys/1234"),
+		httpmock.REST("DELETE", "user/keys/5678"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+	reg.Register(
+		httpmock.REST("DELETE", "user/ssh_signing_keys/5678"),
+		httpmock.StatusStringResponse(204, ""),
+	)
+
+	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
+
+	require.NoError(t, err)
+}
+
+func TestDeleteNon404AuthError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("DELETE", "user/keys/5678"),
+		httpmock.StatusStringResponse(http.StatusForbidden, `{"message":"Forbidden"}`),
+	)
+
+	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusForbidden, httpErr.StatusCode)
+}
+
+func TestGetSigningKeyFallback(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys/5678"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+	reg.Register(
+		httpmock.REST("GET", "user/ssh_signing_keys/5678"),
+		httpmock.StatusStringResponse(200, `{"title":"My Signing Key"}`),
+	)
+
+	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
+
+	require.NoError(t, err)
+	assert.Equal(t, "My Signing Key", key.Title)
+}
+
+func TestGetSigningKeyBothEndpointsNotFound(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys/5678"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+	reg.Register(
+		httpmock.REST("GET", "user/ssh_signing_keys/5678"),
 		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
 	)
 
-	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
+	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
 
 	assert.Nil(t, key)
 	var httpErr api.HTTPError

--- a/pkg/cmd/ssh-key/delete/http.go
+++ b/pkg/cmd/ssh-key/delete/http.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
@@ -19,7 +20,21 @@ func deleteSSHKey(httpClient *http.Client, host string, keyID string) error {
 	// TODO(api-client-rollout)
 	// This line of code is part of a mechanical roll out of the api client.
 	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
+	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
+	if err == nil {
+		return nil
+	}
+
+	var httpErr api.HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		path, err = safeurl.JoinPath("user", "ssh_signing_keys", keyID)
+		if err != nil {
+			return err
+		}
+		return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
+	}
+
+	return err
 }
 
 func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, error) {
@@ -29,12 +44,22 @@ func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, err
 		return nil, err
 	}
 	// TODO(api-client-rollout)
-	// This line of code is part of a mechanical roll out of the api client.
-	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
 	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodGet, path.String(), nil, &key)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		return &key, nil
 	}
 
-	return &key, nil
+	var httpErr api.HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		path, err = safeurl.JoinPath("user", "ssh_signing_keys", keyID)
+		if err != nil {
+			return nil, err
+		}
+		err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodGet, path.String(), nil, &key)
+		if err == nil {
+			return &key, nil
+		}
+	}
+
+	return nil, err
 }


### PR DESCRIPTION
## Problem

`gh ssh-key delete <id>` only operates on authentication keys. There is no way to delete an SSH signing key via the CLI, even though `gh ssh-key add --type signing` can create them and `gh ssh-key list` displays them.

Signing keys live behind a separate endpoint (`/user/ssh_signing_keys/{id}`) with an independent ID namespace. Passing a signing key ID returns HTTP 404 and the key is never removed.

## Fix

Try the auth-keys endpoint first; on 404, fall back to the signing-keys endpoint. Applies to both the GET (confirmation) and DELETE requests. Non-404 errors from the auth endpoint are surfaced immediately without attempting the fallback.

## Tests

- All existing tests updated for fallback behavior
- Added 4 new tests:
  - `TestDeleteSigningKeyFallback` -- verifies DELETE falls back to signing endpoint
  - `TestDeleteNon404AuthError` -- verifies non-404 errors are not retried
  - `TestGetSigningKeyFallback` -- verifies GET falls back to signing endpoint
  - `TestGetSigningKeyBothEndpointsNotFound` -- verifies proper 404 when both endpoints miss

Fixes #14064