### PR TITLE
Set GH_EXTENSION=1 when gh invokes an extension

### DIFF
--- a/acceptance/testdata/extension/extension-env.txtar
+++ b/acceptance/testdata/extension/extension-env.txtar
@@ -1,0 +1,38 @@
+# Verify that gh tells an extension when it is being run as an extension
+
+# Skip if Bash is not available given script extension
+[!exec:bash] skip
+
+# Setup environment variables used for testscript
+env EXT_NAME=printenv-${RANDOM_STRING}
+env EXT_DIR=gh-${EXT_NAME}
+
+# Setup a local extension that reports the value of GH_EXTENSION
+mkdir $EXT_DIR
+mv print-env.sh $EXT_DIR/$EXT_DIR
+chmod 777 $EXT_DIR/$EXT_DIR
+
+# Install the local extension, gh extension install only supports the working directory
+cd $EXT_DIR
+exec gh extension install .
+defer gh extension remove $EXT_NAME
+
+# Verify GH_EXTENSION is set when the extension is run as gh <extension>
+exec gh $EXT_NAME
+stdout 'GH_EXTENSION=1'
+
+# Verify GH_EXTENSION is set when the extension is run via gh extension exec
+exec gh extension exec $EXT_NAME
+stdout 'GH_EXTENSION=1'
+
+# Verify GH_EXTENSION is absent when the extension is run standalone
+exec ./$EXT_DIR
+stdout 'GH_EXTENSION=0'
+
+# Verify GH_EXTENSION is documented
+exec gh help environment
+stdout 'GH_EXTENSION`: set to `1` by gh when it invokes an extension'
+
+-- print-env.sh --
+#!/usr/bin/env bash
+echo "GH_EXTENSION=${GH_EXTENSION:-0}"

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -128,6 +128,10 @@ func (m *Manager) Dispatch(args []string, stdin io.Reader, stdout, stderr io.Wri
 		forwardArgs = append([]string{"-c", `command "$@"`, "--", exe}, forwardArgs...)
 		externalCmd = m.newCommand(shExe, forwardArgs...)
 	}
+	// Signal to the extension that it is being run by gh rather than standalone, so it can
+	// adjust things like usage strings.
+	externalCmd.Env = append(externalCmd.Environ(), "GH_EXTENSION=1")
+
 	externalCmd.Stdin = stdin
 	externalCmd.Stdout = stdout
 	externalCmd.Stderr = stderr

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -29,6 +29,13 @@ func TestHelperProcess(t *testing.T) {
 		return
 	}
 	if err := func(args []string) error {
+		// Dispatch tests use this marker argument to inspect the environment gh handed to
+		// the extension, rather than echoing the arguments back.
+		if len(args) > 0 && args[len(args)-1] == "print-env" {
+			fmt.Fprintf(os.Stdout, "GH_EXTENSION=%s\n", os.Getenv("GH_EXTENSION"))
+			fmt.Fprintf(os.Stdout, "GH_HELPER_INHERITED=%s\n", os.Getenv("GH_HELPER_INHERITED"))
+			return nil
+		}
 		fmt.Fprintf(os.Stdout, "%v\n", args)
 		return nil
 	}(os.Args[3:]); err != nil {
@@ -38,7 +45,7 @@ func TestHelperProcess(t *testing.T) {
 	os.Exit(0)
 }
 
-func newTestManager(dataDir, updateDir string, client *http.Client, gitClient gitClient, ios *iostreams.IOStreams) *Manager {
+func newTestManager(dataDir, updateDir string, client *http.Client, gitClient gitClient, ios *iostreams.IOStreams, extraEnv ...string) *Manager {
 	return &Manager{
 		dataDir:   func() string { return dataDir },
 		updateDir: func() string { return updateDir },
@@ -51,7 +58,7 @@ func newTestManager(dataDir, updateDir string, client *http.Client, gitClient gi
 				cmd.Stdout = ios.Out
 				cmd.Stderr = ios.ErrOut
 			}
-			cmd.Env = []string{"GH_WANT_HELPER_PROCESS=1"}
+			cmd.Env = append([]string{"GH_WANT_HELPER_PROCESS=1"}, extraEnv...)
 			return cmd
 		},
 		config:    config.NewBlankConfig(),
@@ -189,6 +196,75 @@ func TestManager_Dispatch_binary(t *testing.T) {
 
 	assert.Equal(t, fmt.Sprintf("[%s one two]\n", exePath), stdout.String())
 	assert.Equal(t, "", stderr.String())
+}
+
+func TestManager_Dispatch_ghExtensionEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		extraEnv []string
+		wantOut  string
+	}{
+		{
+			name:    "sets GH_EXTENSION",
+			wantOut: "GH_EXTENSION=1\nGH_HELPER_INHERITED=\n",
+		},
+		{
+			name:     "preserves the rest of the environment",
+			extraEnv: []string{"GH_HELPER_INHERITED=yes"},
+			wantOut:  "GH_EXTENSION=1\nGH_HELPER_INHERITED=yes\n",
+		},
+		{
+			name:     "overrides an inherited GH_EXTENSION",
+			extraEnv: []string{"GH_EXTENSION=0", "GH_HELPER_INHERITED=yes"},
+			wantOut:  "GH_EXTENSION=1\nGH_HELPER_INHERITED=yes\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("script extension: "+tt.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			updateDir := t.TempDir()
+			extDir := filepath.Join(dataDir, "extensions", "gh-hello")
+			require.NoError(t, stubExtension(filepath.Join(extDir, "gh-hello")))
+
+			gc, gcOne := &mockGitClient{}, &mockGitClient{}
+			gc.On("ForRepo", extDir).Return(gcOne).Once()
+
+			m := newTestManager(dataDir, updateDir, nil, gc, nil, tt.extraEnv...)
+
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			found, err := m.Dispatch([]string{"hello", "print-env"}, nil, stdout, stderr)
+			require.NoError(t, err)
+			require.True(t, found)
+
+			assert.Equal(t, tt.wantOut, stdout.String())
+			assert.Equal(t, "", stderr.String())
+		})
+
+		t.Run("binary extension: "+tt.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			updateDir := t.TempDir()
+			extDir := filepath.Join(dataDir, "extensions", "gh-hello")
+			require.NoError(t, stubBinaryExtension(extDir, binManifest{
+				Owner: "owner",
+				Name:  "gh-hello",
+				Host:  "github.com",
+				Tag:   "v1.0.0",
+			}))
+
+			m := newTestManager(dataDir, updateDir, nil, nil, nil, tt.extraEnv...)
+
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			found, err := m.Dispatch([]string{"hello", "print-env"}, nil, stdout, stderr)
+			require.NoError(t, err)
+			require.True(t, found)
+
+			assert.Equal(t, tt.wantOut, stdout.String())
+			assert.Equal(t, "", stderr.String())
+		})
+	}
 }
 
 func TestManager_Remove(t *testing.T) {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -99,6 +99,9 @@ var HelpTopics = []helpTopic{
 			When an extension is executed, gh checks for new versions for the executed extension once every 24 hours.
 			If a newer version was found, an upgrade notice is displayed on standard error.
 
+			%[1]sGH_EXTENSION%[1]s: set to %[1]s1%[1]s by gh when it invokes an extension, allowing an extension to
+			tell whether it was run as %[1]sgh <extension>%[1]s or directly as a standalone program.
+
 			%[1]sGH_CONFIG_DIR%[1]s: the directory where gh will store configuration files. If not specified,
 			the default value will be one of the following paths (in order of precedence):
 			  - %[1]s$XDG_CONFIG_HOME/gh%[1]s (if %[1]s$XDG_CONFIG_HOME%[1]s is set),


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Closes #14071

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

A `gh` extension is just an executable named `gh-something`. Once installed, it can be invoked two ways: as `gh something`, where `gh` finds it and runs it as a subprocess, or directly as `./gh-something`, like any other program on your machine. Extension authors may want to tell these two cases apart, for example in providing usage strings: if someone runs `gh label --help`, the examples should read `gh label list`, but if they ran `./gh-label --help` the examples should read `./gh-label list`. Today the extension has no easy way to know which happened.

This adds a signal. When `gh` runs an extension, it now sets `GH_EXTENSION=1` in that subprocess's environment. An extension checks for it and adjusts. Running the binary directly means no `gh` in the picture, so the variable is simply absent.

### How did you test this change?

<!--
Demonstrate the code is solid, and how you know it solves the problem in the description.
Give the exact commands you ran and their output.
If this changes command output, show it before and after. Screenshot images are preferred over pasted text.

If you leave this empty, your pull request will very likely be closed.
-->

I wrote a throwaway extension that reports how it was invoked, then ran it both ways against a locally built `gh`:

![Terminal recording: cat gh-whoami-am-i shows a script that branches on GH_EXTENSION. Running ./gh-whoami-am-i prints "I am running standalone. Usage: ./gh-whoami-am-i". Running gh whoami-am-i prints "I am running as a gh extension. Usage: gh whoami-am-i".](https://github.com/user-attachments/assets/54031e55-96d3-449d-9aa3-10ac603c6277)

The same four behaviours are pinned down by a new acceptance script, `acceptance/testdata/extension/extension-env.txtar`.

<details>
<summary>Acceptance test run</summary>

```console
$ GH_ACCEPTANCE_SCRIPT=extension-env.txtar \
  GH_ACCEPTANCE_HOST=github.com \
  GH_ACCEPTANCE_ORG=gh-acceptance-testing \
  GH_ACCEPTANCE_TOKEN=$(gh auth token) \
  go test -tags=acceptance -run '^TestExtensions$' -v ./acceptance
=== RUN   TestExtensions
=== RUN   TestExtensions/extension-env
=== PAUSE TestExtensions/extension-env
=== CONT  TestExtensions/extension-env
    testscript.go:584: WORK=$WORK

        [testscript environment preamble trimmed]

        SCRIPT_NAME=extension_env
        GH_CONFIG_DIR=$WORK
        GH_HOST=github.com
        ORG=gh-acceptance-testing
        RANDOM_STRING=wfmyBekyHn
        GH_TELEMETRY=false

        # Verify that gh tells an extension when it is being run as an extension
        # Skip if Bash is not available given script extension (0.000s)
        > [!exec:bash] skip
        # Setup environment variables used for testscript (0.000s)
        > env EXT_NAME=printenv-${RANDOM_STRING}
        > env EXT_DIR=gh-${EXT_NAME}
        # Setup a local extension that reports the value of GH_EXTENSION (0.002s)
        > mkdir $EXT_DIR
        > mv print-env.sh $EXT_DIR/$EXT_DIR
        > chmod 777 $EXT_DIR/$EXT_DIR
        # Install the local extension, gh extension install only supports the working directory (0.530s)
        > cd $EXT_DIR
        $WORK/gh-printenv-wfmyBekyHn
        > exec gh extension install .
        > defer gh extension remove $EXT_NAME
        # Verify GH_EXTENSION is set when the extension is run as gh <extension> (0.364s)
        > exec gh $EXT_NAME
        [stdout]
        GH_EXTENSION=1
        > stdout 'GH_EXTENSION=1'
        # Verify GH_EXTENSION is set when the extension is run via gh extension exec (0.055s)
        > exec gh extension exec $EXT_NAME
        [stdout]
        GH_EXTENSION=1
        > stdout 'GH_EXTENSION=1'
        # Verify GH_EXTENSION is absent when the extension is run standalone (0.014s)
        > exec ./$EXT_DIR
        [stdout]
        GH_EXTENSION=0
        > stdout 'GH_EXTENSION=0'
        # Verify GH_EXTENSION is documented (0.025s)
        > exec gh help environment
        [stdout]

        [preceding entries trimmed]

        `GH_NO_EXTENSION_UPDATE_NOTIFIER`: set to any value to disable GitHub CLI extension update notifications.
        When an extension is executed, gh checks for new versions for the executed extension once every 24 hours.
        If a newer version was found, an upgrade notice is displayed on standard error.

        `GH_EXTENSION`: set to `1` by gh when it invokes an extension, allowing an extension to
        tell whether it was run as `gh <extension>` or directly as a standalone program.

        `GH_CONFIG_DIR`: the directory where gh will store configuration files. If not specified,
        the default value will be one of the following paths (in order of precedence):
          - `$XDG_CONFIG_HOME/gh` (if `$XDG_CONFIG_HOME` is set),
          - `$AppData/GitHub CLI` (on Windows if `$AppData` is set), or
          - `$HOME/.config/gh`.

        [remaining entries trimmed]

        > stdout 'GH_EXTENSION`: set to `1` by gh when it invokes an extension'
        PASS

--- PASS: TestExtensions (0.00s)
    --- PASS: TestExtensions/extension-env (1.03s)
PASS
ok      github.com/cli/cli/v2/acceptance        1.615s
```

</details>

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

None

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with the acceptance test, and read it from top to bottom.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.