### PR TITLE
Curate the error when the sync target is checked out in another worktree

### DIFF
--- a/acceptance/testdata/repo/repo-sync-worktree.txtar
+++ b/acceptance/testdata/repo/repo-sync-worktree.txtar
@@ -1,0 +1,45 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create and clone a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private --clone
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Advance the default branch on the remote, then rewind the local branch so a sync is required
+cd $SCRIPT_NAME-$RANDOM_STRING
+mv ../asset.txt asset.txt
+exec git add .
+exec git commit -m 'Add asset.txt'
+exec git push
+exec git reset --hard HEAD~1
+! exists asset.txt
+exec git rev-parse HEAD
+stdout2env PRIMARY_HEAD
+
+# Add a linked worktree on a different branch, leaving the default branch checked out in the primary worktree
+exec git worktree add -b topic ../topic-worktree
+exec git branch --show-current
+stdout '^main$'
+
+# Syncing from the linked worktree must refuse rather than silently move the default branch ref
+cd ../topic-worktree
+! exec gh repo sync
+stderr 'can''t sync "main" because it''s checked out in another worktree at .*'$SCRIPT_NAME'-'$RANDOM_STRING'$'
+stderr 'tip: run `gh repo sync` from that worktree instead'
+
+# The primary worktree's branch and working tree are left untouched
+cd ../$SCRIPT_NAME-$RANDOM_STRING
+exec git rev-parse HEAD
+stdout $PRIMARY_HEAD
+exec git status --porcelain
+! stdout .
+! exists asset.txt
+
+# Syncing from the primary worktree, where the default branch is actually checked out, still works
+exec gh repo sync
+exists asset.txt
+
+-- asset.txt --
+Hello, world!

--- a/pkg/cmd/repo/sync/git.go
+++ b/pkg/cmd/repo/sync/git.go
@@ -2,11 +2,13 @@ package sync
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cli/cli/v2/git"
 )
 
 type gitClient interface {
+	BranchWorktreePath(string) (string, error)
 	CurrentBranch() (string, error)
 	UpdateBranch(string, string) error
 	CreateBranch(string, string, string) error
@@ -22,6 +24,11 @@ type gitExecuter struct {
 	client *git.Client
 }
 
+// UpdateBranch moves branch to ref. It uses `git branch --force` rather than
+// `git update-ref` because update-ref will happily move a branch that is checked out in
+// another worktree, leaving that worktree's index and working tree stale. Callers should
+// use BranchWorktreePath to detect and explain that case first; this is the safety net
+// for states that check can't see, such as an in-progress bisect.
 func (g *gitExecuter) UpdateBranch(branch, ref string) error {
 	cmd, err := g.client.Command(context.Background(), "branch", "--force", "--", branch, ref)
 	if err != nil {
@@ -29,6 +36,37 @@ func (g *gitExecuter) UpdateBranch(branch, ref string) error {
 	}
 	_, err = cmd.Output()
 	return err
+}
+
+// BranchWorktreePath returns the path of the worktree in which branch is checked out,
+// or an empty string when no worktree has it checked out.
+func (g *gitExecuter) BranchWorktreePath(branch string) (string, error) {
+	cmd, err := g.client.Command(context.Background(), "worktree", "list", "--porcelain")
+	if err != nil {
+		return "", err
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return worktreePathForBranch(string(out), branch), nil
+}
+
+// worktreePathForBranch parses `git worktree list --porcelain` output, which lists each
+// worktree as a `worktree <path>` line followed by attributes such as `branch <ref>`.
+func worktreePathForBranch(porcelain, branch string) string {
+	wantRef := "refs/heads/" + branch
+
+	var path string
+	for _, line := range strings.Split(porcelain, "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if rest, ok := strings.CutPrefix(line, "worktree "); ok {
+			path = rest
+		} else if rest, ok := strings.CutPrefix(line, "branch "); ok && rest == wantRef {
+			return path
+		}
+	}
+	return ""
 }
 
 func (g *gitExecuter) CreateBranch(branch, ref, upstream string) error {

--- a/pkg/cmd/repo/sync/git_test.go
+++ b/pkg/cmd/repo/sync/git_test.go
@@ -1,0 +1,79 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_worktreePathForBranch(t *testing.T) {
+	// Representative `git worktree list --porcelain` output covering a bare main
+	// worktree, a detached worktree, and a branch whose name prefixes another.
+	porcelain := heredoc.Doc(`
+		worktree /repos/project.git
+		bare
+
+		worktree /repos/primary
+		HEAD 8f0dc4bbde2d1d10e73b0cd0b1d3f7c1f1f5b0aa
+		branch refs/heads/trunk
+
+		worktree /repos/detached
+		HEAD 3c1d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d
+		detached
+
+		worktree /repos/feature work
+		HEAD 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
+		branch refs/heads/feature/one
+	`)
+
+	tests := []struct {
+		name      string
+		porcelain string
+		branch    string
+		want      string
+	}{
+		{
+			name:      "branch checked out in a worktree",
+			porcelain: porcelain,
+			branch:    "trunk",
+			want:      "/repos/primary",
+		},
+		{
+			name:      "branch with slashes and a path containing a space",
+			porcelain: porcelain,
+			branch:    "feature/one",
+			want:      "/repos/feature work",
+		},
+		{
+			name:      "branch not checked out anywhere",
+			porcelain: porcelain,
+			branch:    "other",
+			want:      "",
+		},
+		{
+			name:      "branch name that only prefixes a checked out branch",
+			porcelain: porcelain,
+			branch:    "feature",
+			want:      "",
+		},
+		{
+			name:      "no worktrees reported",
+			porcelain: "",
+			branch:    "trunk",
+			want:      "",
+		},
+		{
+			name:      "windows line endings",
+			porcelain: "worktree /repos/primary\r\nHEAD 8f0dc4b\r\nbranch refs/heads/trunk\r\n",
+			branch:    "trunk",
+			want:      "/repos/primary",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, worktreePathForBranch(tt.porcelain, tt.branch))
+		})
+	}
+}

--- a/pkg/cmd/repo/sync/mocks.go
+++ b/pkg/cmd/repo/sync/mocks.go
@@ -13,6 +13,11 @@ func (g *mockGitClient) UpdateBranch(b, r string) error {
 	return args.Error(0)
 }
 
+func (g *mockGitClient) BranchWorktreePath(b string) (string, error) {
+	args := g.Called(b)
+	return args.String(0), args.Error(1)
+}
+
 func (g *mockGitClient) CreateBranch(b, r, u string) error {
 	args := g.Called(b, r, u)
 	return args.Error(0)

--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -258,6 +258,15 @@ func executeLocalRepoSync(srcRepo ghrepo.Interface, remote string, opts *SyncOpt
 		}
 	} else {
 		if hasLocalBranch {
+			// Updating a branch checked out in another worktree would leave that
+			// worktree's index and working tree stale, so refuse and point the user at it.
+			worktreePath, err := git.BranchWorktreePath(branch)
+			if err != nil {
+				return err
+			}
+			if worktreePath != "" {
+				return fmt.Errorf("can't sync %q because it's checked out in another worktree at %s\ntip: run `gh repo sync` from that worktree instead", branch, worktreePath)
+			}
 			if err := git.UpdateBranch(branch, "FETCH_HEAD"); err != nil {
 				return err
 			}

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -133,7 +133,11 @@ func TestExecuteLocalRepoSyncBranchCheckedOutInOtherWorktree(t *testing.T) {
 	}
 
 	err := executeLocalRepoSync(ghrepo.New("OWNER", "REPO"), "origin", opts)
-	require.Error(t, err)
+	require.ErrorContains(t, err, `can't sync "trunk" because it's checked out in another worktree at `)
+	// Assert on the directory name rather than the full path because git reports the
+	// symlink-resolved path, which differs from t.TempDir() on macOS.
+	require.ErrorContains(t, err, filepath.Base(worktreeDir))
+	require.ErrorContains(t, err, "tip: run `gh repo sync` from that worktree instead")
 	require.Equal(t, originalBranch, runGit(t, repoDir, "rev-parse", "trunk"))
 	require.Empty(t, runGit(t, worktreeDir, "status", "--porcelain"))
 }
@@ -389,9 +393,26 @@ func Test_SyncRun(t *testing.T) {
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("test", nil).Once()
+				mgc.On("BranchWorktreePath", "trunk").Return("", nil).Once()
 				mgc.On("UpdateBranch", "trunk", "FETCH_HEAD").Return(nil).Once()
 			},
 			wantStdout: "✓ Synced the \"trunk\" branch from \"OWNER/REPO\" to local repository\n",
+		},
+		{
+			name: "sync local repo with parent - existing branch checked out in another worktree",
+			tty:  true,
+			opts: &SyncOptions{
+				Branch: "trunk",
+			},
+			gitStubs: func(mgc *mockGitClient) {
+				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
+				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
+				mgc.On("CurrentBranch").Return("test", nil).Once()
+				mgc.On("BranchWorktreePath", "trunk").Return("/path/to/worktree", nil).Once()
+			},
+			wantErr: true,
+			errMsg:  "can't sync \"trunk\" because it's checked out in another worktree at /path/to/worktree\ntip: run `gh repo sync` from that worktree instead",
 		},
 		{
 			name: "sync local repo with parent - create new branch",


### PR DESCRIPTION
Follow-up to #14060, which fixes #12927. Targets `12927-fix-repo-sync-worktree` so @sergiou87 can take it or leave it.

### Description

A git repository can have more than one working directory attached to it, via `git worktree`. Each one has its own checked-out branch, its own index, and its own files on disk, but they all share one set of branch refs.

`gh repo sync` updates your local branch to match the remote. When the branch you're syncing isn't the one you currently have checked out, it can't merge into your working directory, so it moves the branch ref directly instead. #12927 reported that this silently corrupts things: if some *other* worktree has that branch checked out, moving the ref leaves that worktree's index and files pointing at the old commit, so everything shows up as staged changes.

#14060 fixes that by switching from `git update-ref` to `git branch --force`. Git itself refuses to move a branch another worktree is using, so silent corruption becomes a hard failure. That's the right call. The gap is what the user sees:

```
failed to run git: fatal: cannot force update the branch 'main' used by worktree at '/path/to/worktree'
```

That's a raw git error with a doubled `failed to run git: fatal:` prefix. It's also inconsistent with what `gh repo sync` does six lines away in the same function, where a dirty working directory produces a curated message and a tip:

```
refusing to sync due to uncommitted/untracked local changes
tip: use `git stash --all` before retrying the sync and run `git stash pop` afterwards
```

This PR detects the worktree case before attempting the update and gives it the same treatment:

```
can't sync "main" because it's checked out in another worktree at /path/to/worktree
tip: run `gh repo sync` from that worktree instead
```

Detection runs `git worktree list --porcelain` and looks for a worktree holding `refs/heads/<branch>`. `git branch --force` stays in place as the safety net.

### How did you test this change?

```
$ GH_ACCEPTANCE_SCRIPT=repo-sync-worktree.txtar GH_ACCEPTANCE_HOST=github.com \
  GH_ACCEPTANCE_ORG=gh-acceptance-testing GH_ACCEPTANCE_TOKEN=$(gh auth token) \
  go test -tags=acceptance -run ^TestRepo$ ./acceptance -v
```

```
# Syncing from the linked worktree must refuse rather than silently move the default branch ref (1.287s)
> cd ../topic-worktree
> ! exec gh repo sync
[stderr]
can't sync "main" because it's checked out in another worktree at $WORK/repo_sync_worktree-SBHtlzxkHD
tip: run `gh repo sync` from that worktree instead
[exit status 1]
> stderr 'can''t sync "main" because it''s checked out in another worktree at .*'$SCRIPT_NAME'-'$RANDOM_STRING'$'
> stderr 'tip: run `gh repo sync` from that worktree instead'
# The primary worktree's branch and working tree are left untouched (0.025s)
> exec git status --porcelain
> ! stdout .
> ! exists asset.txt
# Syncing from the primary worktree, where the default branch is actually checked out, still works (1.308s)
> exec gh repo sync
> exists asset.txt
PASS

--- PASS: TestRepo/repo-sync-worktree (8.73s)
```

I also ran that acceptance test against `trunk` to confirm it's a real regression test and not just a test that agrees with the new code. It fails there, because `update-ref` silently succeeds:

```
> ! exec gh repo sync
FAIL: testdata/repo/repo-sync-worktree.txtar:28: unexpected command success
```

### Key points

We use the porcelain output to avoid matching on the git error message which I believe version and locale dependent. This does introduce a small potential race, but it seems like a reasonable first step.

### Notes for reviewers

None

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
