### PR TITLE
Route release deletions through api.Client

### DIFF
--- a/acceptance/testdata/release/release-delete.txtar
+++ b/acceptance/testdata/release/release-delete.txtar
@@ -24,9 +24,6 @@ stderr 'no assets to download'
 # Delete the release and its tag
 exec gh release delete v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --yes --cleanup-tag
 
-# Give the tag cleanup time to propagate
-sleep 5
-
 # Verify the release is gone
 ! exec gh release view v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING
 

--- a/acceptance/testdata/release/release-delete.txtar
+++ b/acceptance/testdata/release/release-delete.txtar
@@ -26,6 +26,7 @@ exec gh release delete v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --yes --cl
 
 # Verify the release is gone
 ! exec gh release view v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING
+stderr 'release not found'
 
 # Verify the tag is gone
 ! exec gh api repos/$ORG/$SCRIPT_NAME-$RANDOM_STRING/git/ref/tags/v1.2.3

--- a/acceptance/testdata/release/release-delete.txtar
+++ b/acceptance/testdata/release/release-delete.txtar
@@ -1,0 +1,38 @@
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Create a release in the repo
+exec gh release create v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --notes 'awesome release' --latest
+
+# Upload an asset to the release
+exec gh release upload v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING asset.txt
+
+# Delete the asset from the release
+exec gh release delete-asset v1.2.3 asset.txt --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --yes
+
+# Verify the release has no assets
+exec gh release view v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --json assets --jq '.assets | length'
+stdout '0'
+
+# Downloading the deleted asset should fail
+! exec gh release download v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING
+stderr 'no assets to download'
+
+# Delete the release and its tag
+exec gh release delete v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --yes --cleanup-tag
+
+# Give the tag cleanup time to propagate
+sleep 5
+
+# Verify the release is gone
+! exec gh release view v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Verify the tag is gone
+! exec gh api repos/$ORG/$SCRIPT_NAME-$RANDOM_STRING/git/ref/tags/v1.2.3
+stderr 'Not Found'
+
+-- asset.txt --
+Hello, world!

--- a/acceptance/testdata/release/release-delete.txtar
+++ b/acceptance/testdata/release/release-delete.txtar
@@ -24,6 +24,9 @@ stderr 'no assets to download'
 # Delete the release and its tag
 exec gh release delete v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING --yes --cleanup-tag
 
+# Wait for tag deletion to become visible through the ref lookup
+sleep 5
+
 # Verify the release is gone
 ! exec gh release view v1.2.3 --repo $ORG/$SCRIPT_NAME-$RANDOM_STRING
 stderr 'release not found'

--- a/pkg/cmd/release/delete-asset/delete_asset.go
+++ b/pkg/cmd/release/delete-asset/delete_asset.go
@@ -97,7 +97,7 @@ func deleteAssetRun(opts *DeleteAssetOptions) error {
 		return fmt.Errorf("asset %s not found in release %s", opts.AssetName, release.TagName)
 	}
 
-	err = deleteAsset(httpClient, safeurl.NewImmutableSafeURL(assetURL))
+	err = deleteAsset(httpClient, baseRepo.RepoHost(), safeurl.NewImmutableSafeURL(assetURL))
 	if err != nil {
 		return err
 	}
@@ -112,20 +112,9 @@ func deleteAssetRun(opts *DeleteAssetOptions) error {
 	return nil
 }
 
-func deleteAsset(httpClient *http.Client, assetURL safeurl.SafeURL) error {
-	req, err := http.NewRequest("DELETE", assetURL.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
-	}
-	return nil
+func deleteAsset(httpClient *http.Client, host string, assetURL safeurl.SafeURL) error {
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	return api.NewClientFromHTTP(httpClient).REST(host, "DELETE", assetURL.String(), nil, nil)
 }

--- a/pkg/cmd/release/delete-asset/delete_asset.go
+++ b/pkg/cmd/release/delete-asset/delete_asset.go
@@ -116,5 +116,5 @@ func deleteAsset(httpClient *http.Client, host string, assetURL safeurl.SafeURL)
 	// TODO(api-client-rollout)
 	// This line of code is part of a mechanical roll out of the api client.
 	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	return api.NewClientFromHTTP(httpClient).REST(host, "DELETE", assetURL.String(), nil, nil)
+	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, assetURL.String(), nil, nil)
 }

--- a/pkg/cmd/release/delete-asset/delete_asset_test.go
+++ b/pkg/cmd/release/delete-asset/delete_asset_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
@@ -198,4 +200,25 @@ func Test_deleteAssetRun(t *testing.T) {
 			assert.Equal(t, tt.wantStderr, stderr.String())
 		})
 	}
+}
+
+func Test_deleteAsset_httpError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		func(req *http.Request) bool {
+			return req.Method == http.MethodDelete &&
+				req.URL.EscapedPath() == "/repos/OWNER/REPO/releases/assets/1" &&
+				req.URL.Host == "api.github.com"
+		},
+		httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
+	)
+
+	httpClient := &http.Client{Transport: reg}
+	err := deleteAsset(httpClient, "example.com", safeurl.NewImmutableSafeURL("https://api.github.com/repos/OWNER/REPO/releases/assets/1"))
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
 }

--- a/pkg/cmd/release/delete/delete.go
+++ b/pkg/cmd/release/delete/delete.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
@@ -93,7 +92,7 @@ func deleteRun(opts *DeleteOptions) error {
 		}
 	}
 
-	err = deleteRelease(httpClient, safeurl.NewImmutableSafeURL(release.APIURL))
+	err = deleteRelease(httpClient, baseRepo.RepoHost(), safeurl.NewImmutableSafeURL(release.APIURL))
 	if err != nil {
 		return err
 	}
@@ -122,42 +121,20 @@ func deleteRun(opts *DeleteOptions) error {
 	return nil
 }
 
-func deleteRelease(httpClient *http.Client, releaseURL safeurl.SafeURL) error {
-	req, err := http.NewRequest("DELETE", releaseURL.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
-	}
-	return nil
+func deleteRelease(httpClient *http.Client, host string, releaseURL safeurl.SafeURL) error {
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	return api.NewClientFromHTTP(httpClient).REST(host, "DELETE", releaseURL.String(), nil, nil)
 }
 
 func deleteTag(httpClient *http.Client, baseRepo ghrepo.Interface, tagName string) error {
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(baseRepo.RepoHost()), "repos", baseRepo.RepoOwner(), baseRepo.RepoName(), "git", "refs", fmt.Sprintf("tags/%s", tagName))
+	path, err := safeurl.JoinPath("repos", baseRepo.RepoOwner(), baseRepo.RepoName(), "git", "refs", fmt.Sprintf("tags/%s", tagName))
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("DELETE", url.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
-	}
-	return nil
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	return api.NewClientFromHTTP(httpClient).REST(baseRepo.RepoHost(), "DELETE", path.String(), nil, nil)
 }

--- a/pkg/cmd/release/delete/delete.go
+++ b/pkg/cmd/release/delete/delete.go
@@ -125,7 +125,7 @@ func deleteRelease(httpClient *http.Client, host string, releaseURL safeurl.Safe
 	// TODO(api-client-rollout)
 	// This line of code is part of a mechanical roll out of the api client.
 	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	return api.NewClientFromHTTP(httpClient).REST(host, "DELETE", releaseURL.String(), nil, nil)
+	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, releaseURL.String(), nil, nil)
 }
 
 func deleteTag(httpClient *http.Client, baseRepo ghrepo.Interface, tagName string) error {
@@ -136,5 +136,5 @@ func deleteTag(httpClient *http.Client, baseRepo ghrepo.Interface, tagName strin
 	// TODO(api-client-rollout)
 	// This line of code is part of a mechanical roll out of the api client.
 	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	return api.NewClientFromHTTP(httpClient).REST(baseRepo.RepoHost(), "DELETE", path.String(), nil, nil)
+	return api.NewClientFromHTTP(httpClient).REST(baseRepo.RepoHost(), http.MethodDelete, path.String(), nil, nil)
 }

--- a/pkg/cmd/release/delete/delete_test.go
+++ b/pkg/cmd/release/delete/delete_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/internal/run"
+	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
@@ -240,4 +242,43 @@ func Test_deleteRun(t *testing.T) {
 			assert.Equal(t, tt.wantStderr, stderr.String())
 		})
 	}
+}
+
+func Test_deleteRelease_httpError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		func(req *http.Request) bool {
+			return req.Method == http.MethodDelete &&
+				req.URL.EscapedPath() == "/repos/OWNER/REPO/releases/23456" &&
+				req.URL.Host == "api.github.com"
+		},
+		httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
+	)
+
+	httpClient := &http.Client{Transport: reg}
+	err := deleteRelease(httpClient, "example.com", safeurl.NewImmutableSafeURL("https://api.github.com/repos/OWNER/REPO/releases/23456"))
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+func Test_deleteTag_httpError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("DELETE", "repos/OWNER/REPO/git/refs/tags%2Fv1.2.3"),
+		httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
+	)
+
+	httpClient := &http.Client{Transport: reg}
+	baseRepo, _ := ghrepo.FromFullName("OWNER/REPO")
+	err := deleteTag(httpClient, baseRepo, "v1.2.3")
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
 }

--- a/pkg/cmd/release/edit/edit_test.go
+++ b/pkg/cmd/release/edit/edit_test.go
@@ -446,8 +446,7 @@ func Test_editRun(t *testing.T) {
 			defer fakeHTTP.Verify(t)
 			shared.StubFetchRelease(t, fakeHTTP, "OWNER", "REPO", "v1.2.3", `{
 				"id": 12345,
-				"tag_name": "v1.2.3",
-				"url": "https://api.github.com/repos/OWNER/REPO/releases/12345"
+				"tag_name": "v1.2.3"
 			}`)
 			if tt.httpStubs != nil {
 				tt.httpStubs(t, fakeHTTP)

--- a/pkg/cmd/release/edit/edit_test.go
+++ b/pkg/cmd/release/edit/edit_test.go
@@ -2,12 +2,14 @@ package edit
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -444,7 +446,8 @@ func Test_editRun(t *testing.T) {
 			defer fakeHTTP.Verify(t)
 			shared.StubFetchRelease(t, fakeHTTP, "OWNER", "REPO", "v1.2.3", `{
 				"id": 12345,
-				"tag_name": "v1.2.3"
+				"tag_name": "v1.2.3",
+				"url": "https://api.github.com/repos/OWNER/REPO/releases/12345"
 			}`)
 			if tt.httpStubs != nil {
 				tt.httpStubs(t, fakeHTTP)
@@ -479,6 +482,99 @@ func mockSuccessfulEditResponse(reg *httpmock.Registry, cb func(params map[strin
 	}`, cb)
 	reg.Register(matcher, responder)
 }
+
+func Test_editRelease_httpError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		func(req *http.Request) bool {
+			return req.Method == http.MethodPatch &&
+				req.URL.EscapedPath() == "/repos/OWNER/REPO/releases/12345" &&
+				req.URL.Host == "api.github.com"
+		},
+		httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
+	)
+
+	httpClient := &http.Client{Transport: reg}
+	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]interface{}{"tag_name": "v1.2.3"})
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
+	assert.Nil(t, release)
+}
+
+func Test_editRelease_decodeError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		func(req *http.Request) bool {
+			return req.Method == http.MethodPatch &&
+				req.URL.EscapedPath() == "/repos/OWNER/REPO/releases/12345" &&
+				req.URL.Host == "api.github.com"
+		},
+		httpmock.StatusStringResponse(200, `{`),
+	)
+
+	httpClient := &http.Client{Transport: reg}
+	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]interface{}{"tag_name": "v1.2.3"})
+
+	require.Error(t, err)
+	assert.NotNil(t, release) // decode was attempted - non-nil pointer even on decode error
+}
+
+func Test_editRelease_204(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		func(req *http.Request) bool {
+			return req.Method == http.MethodPatch &&
+				req.URL.EscapedPath() == "/repos/OWNER/REPO/releases/12345" &&
+				req.URL.Host == "api.github.com"
+		},
+		httpmock.StatusStringResponse(204, ""),
+	)
+
+	httpClient := &http.Client{Transport: reg}
+	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]interface{}{"tag_name": "v1.2.3"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected end of JSON input")
+	assert.NotNil(t, release)
+}
+
+func Test_editRelease_bodyReadError(t *testing.T) {
+	readErr := errors.New("read: connection reset by peer")
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		func(req *http.Request) bool {
+			return req.Method == http.MethodPatch &&
+				req.URL.EscapedPath() == "/repos/OWNER/REPO/releases/12345" &&
+				req.URL.Host == "api.github.com"
+		},
+		func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(errorReader{err: readErr}),
+				Header:     http.Header{},
+			}, nil
+		},
+	)
+
+	httpClient := &http.Client{Transport: reg}
+	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]interface{}{"tag_name": "v1.2.3"})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, readErr)
+	assert.Nil(t, release)
+}
+
+// errorReader always returns the given error on Read, used to simulate body read failures.
+type errorReader struct{ err error }
+
+func (e errorReader) Read(_ []byte) (int, error) { return 0, e.err }
 
 func boolPtr(b bool) *bool {
 	return &b

--- a/pkg/cmd/release/edit/http.go
+++ b/pkg/cmd/release/edit/http.go
@@ -9,12 +9,47 @@ import (
 	"strconv"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
 	"github.com/shurcooL/githubv4"
 )
+
+// responseTracker is a http.RoundTripper that records the status code of each
+// response and wraps the body to catch non-EOF read errors. editRelease uses it
+// to restore the phase-dependent return shape (nil pointer for pre-decode errors,
+// non-nil for any post-response outcome) without bypassing the shared REST client.
+type responseTracker struct {
+	transport   http.RoundTripper
+	statusCode  int
+	bodyReadErr error
+}
+
+func (t *responseTracker) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.transport.RoundTrip(req)
+	if resp != nil {
+		t.statusCode = resp.StatusCode
+		t.bodyReadErr = nil
+		if resp.Body != nil {
+			resp.Body = &bodyReadTracker{ReadCloser: resp.Body, tracker: t}
+		}
+	}
+	return resp, err
+}
+
+// bodyReadTracker wraps a response body and records the most recent non-EOF read error.
+type bodyReadTracker struct {
+	io.ReadCloser
+	tracker *responseTracker
+}
+
+func (b *bodyReadTracker) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if err != nil && err != io.EOF {
+		b.tracker.bodyReadErr = err
+	}
+	return n, err
+}
 
 func editRelease(httpClient *http.Client, repo ghrepo.Interface, releaseID int64, params map[string]interface{}) (*shared.Release, error) {
 	bodyBytes, err := json.Marshal(params)
@@ -22,36 +57,33 @@ func editRelease(httpClient *http.Client, repo ghrepo.Interface, releaseID int64
 		return nil, err
 	}
 
-	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "releases", strconv.FormatInt(releaseID, 10))
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequest("PATCH", url.String(), bytes.NewBuffer(bodyBytes))
+	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "releases", strconv.FormatInt(releaseID, 10))
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	transport := httpClient.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	tracker := &responseTracker{transport: transport}
+	clone := *httpClient
+	clone.Transport = tracker
 
-	resp, err := httpClient.Do(req)
-	if err != nil {
+	newRelease := &shared.Release{}
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(&clone).REST(repo.RepoHost(), "PATCH", path.String(), bytes.NewReader(bodyBytes), newRelease)
+	// Return nil only when there is an actual error AND no 2xx response was decoded.
+	// status 0 + nil error (impossible in practice) falls through to non-nil release.
+	if err != nil && (tracker.statusCode == 0 || tracker.statusCode < 200 || tracker.statusCode >= 300 || tracker.bodyReadErr != nil) {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	success := resp.StatusCode >= 200 && resp.StatusCode < 300
-	if !success {
-		return nil, api.HandleHTTPError(resp)
+	if tracker.statusCode == http.StatusNoContent || tracker.statusCode == http.StatusResetContent {
+		return newRelease, json.Unmarshal(nil, newRelease)
 	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var newRelease shared.Release
-	err = json.Unmarshal(b, &newRelease)
-	return &newRelease, err
+	return newRelease, err
 }
 
 func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagName string) (bool, error) {

--- a/pkg/cmd/release/edit/http.go
+++ b/pkg/cmd/release/edit/http.go
@@ -9,47 +9,12 @@ import (
 	"strconv"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
 	"github.com/shurcooL/githubv4"
 )
-
-// responseTracker is a http.RoundTripper that records the status code of each
-// response and wraps the body to catch non-EOF read errors. editRelease uses it
-// to restore the phase-dependent return shape (nil pointer for pre-decode errors,
-// non-nil for any post-response outcome) without bypassing the shared REST client.
-type responseTracker struct {
-	transport   http.RoundTripper
-	statusCode  int
-	bodyReadErr error
-}
-
-func (t *responseTracker) RoundTrip(req *http.Request) (*http.Response, error) {
-	resp, err := t.transport.RoundTrip(req)
-	if resp != nil {
-		t.statusCode = resp.StatusCode
-		t.bodyReadErr = nil
-		if resp.Body != nil {
-			resp.Body = &bodyReadTracker{ReadCloser: resp.Body, tracker: t}
-		}
-	}
-	return resp, err
-}
-
-// bodyReadTracker wraps a response body and records the most recent non-EOF read error.
-type bodyReadTracker struct {
-	io.ReadCloser
-	tracker *responseTracker
-}
-
-func (b *bodyReadTracker) Read(p []byte) (int, error) {
-	n, err := b.ReadCloser.Read(p)
-	if err != nil && err != io.EOF {
-		b.tracker.bodyReadErr = err
-	}
-	return n, err
-}
 
 func editRelease(httpClient *http.Client, repo ghrepo.Interface, releaseID int64, params map[string]interface{}) (*shared.Release, error) {
 	bodyBytes, err := json.Marshal(params)
@@ -57,33 +22,38 @@ func editRelease(httpClient *http.Client, repo ghrepo.Interface, releaseID int64
 		return nil, err
 	}
 
-	path, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "releases", strconv.FormatInt(releaseID, 10))
+	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(repo.RepoHost()), "repos", repo.RepoOwner(), repo.RepoName(), "releases", strconv.FormatInt(releaseID, 10))
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("PATCH", url.String(), bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		return nil, err
 	}
 
-	transport := httpClient.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-	tracker := &responseTracker{transport: transport}
-	clone := *httpClient
-	clone.Transport = tracker
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
-	newRelease := &shared.Release{}
 	// TODO(api-client-rollout)
-	// This line of code is part of a mechanical roll out of the api client.
-	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	err = api.NewClientFromHTTP(&clone).REST(repo.RepoHost(), "PATCH", path.String(), bytes.NewReader(bodyBytes), newRelease)
-	// Return nil only when there is an actual error AND no 2xx response was decoded.
-	// status 0 + nil error (impossible in practice) falls through to non-nil release.
-	if err != nil && (tracker.statusCode == 0 || tracker.statusCode < 200 || tracker.statusCode >= 300 || tracker.bodyReadErr != nil) {
+	// This has been deferred from moving to api.Client because its return shape depends on the response status code, which api.Client.REST does not expose on success.
+	resp, err := httpClient.Do(req)
+	if err != nil {
 		return nil, err
 	}
-	if tracker.statusCode == http.StatusNoContent || tracker.statusCode == http.StatusResetContent {
-		return newRelease, json.Unmarshal(nil, newRelease)
+	defer resp.Body.Close()
+
+	success := resp.StatusCode >= 200 && resp.StatusCode < 300
+	if !success {
+		return nil, api.HandleHTTPError(resp)
 	}
-	return newRelease, err
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var newRelease shared.Release
+	err = json.Unmarshal(b, &newRelease)
+	return &newRelease, err
 }
 
 func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagName string) (bool, error) {

--- a/pkg/cmd/run/download/http.go
+++ b/pkg/cmd/run/download/http.go
@@ -29,6 +29,8 @@ func (p *apiPlatform) Download(url safeurl.SafeURL, dir safepaths.Absolute) erro
 }
 
 func downloadArtifact(httpClient *http.Client, url safeurl.SafeURL, destDir safepaths.Absolute) error {
+	// TODO(api-client-rollout)
+	// This has been deferred from moving to api.Client due to streaming the artifact ZIP response body to disk instead of decoding JSON.
 	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
 		return err

--- a/pkg/cmd/run/shared/artifacts.go
+++ b/pkg/cmd/run/shared/artifacts.go
@@ -1,13 +1,10 @@
 package shared
 
 import (
-	"encoding/json"
 	"net/http"
-	"regexp"
 	"strconv"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safeurl"
 )
@@ -26,14 +23,13 @@ type artifactsPayload struct {
 func ListArtifacts(httpClient *http.Client, repo ghrepo.Interface, runID string) ([]Artifact, error) {
 	var results []Artifact
 
-	restPrefix := ghinstance.RESTPrefix(repo.RepoHost())
 	perPage := 100
-	u, err := safeurl.JoinPathWithHostPrefix(restPrefix, "repos", repo.RepoOwner(), repo.RepoName(), "actions", "artifacts")
+	u, err := safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "actions", "artifacts")
 	if err != nil {
 		return nil, err
 	}
 	if runID != "" {
-		u, err = safeurl.JoinPathWithHostPrefix(restPrefix, "repos", repo.RepoOwner(), repo.RepoName(), "actions", "runs", runID, "artifacts")
+		u, err = safeurl.JoinPath("repos", repo.RepoOwner(), repo.RepoName(), "actions", "runs", runID, "artifacts")
 		if err != nil {
 			return nil, err
 		}
@@ -41,9 +37,14 @@ func ListArtifacts(httpClient *http.Client, repo ghrepo.Interface, runID string)
 	u.SetQuery("per_page", strconv.Itoa(perPage))
 	var pageURL safeurl.SafeURL = u
 
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	client := api.NewClientFromHTTP(httpClient)
+
 	for {
 		var payload artifactsPayload
-		nextURL, err := apiGet(httpClient, pageURL, &payload)
+		nextURL, err := client.RESTWithNext(repo.RepoHost(), http.MethodGet, pageURL.String(), nil, &payload)
 		if err != nil {
 			return nil, err
 		}
@@ -56,39 +57,4 @@ func ListArtifacts(httpClient *http.Client, repo ghrepo.Interface, runID string)
 	}
 
 	return results, nil
-}
-
-func apiGet(httpClient *http.Client, url safeurl.SafeURL, data interface{}) (string, error) {
-	req, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return "", err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		return "", api.HandleHTTPError(resp)
-	}
-
-	dec := json.NewDecoder(resp.Body)
-	if err := dec.Decode(data); err != nil {
-		return "", err
-	}
-
-	return findNextPage(resp), nil
-}
-
-var linkRE = regexp.MustCompile(`<([^>]+)>;\s*rel="([^"]+)"`)
-
-func findNextPage(resp *http.Response) string {
-	for _, m := range linkRE.FindAllStringSubmatch(resp.Header.Get("Link"), -1) {
-		if len(m) > 2 && m[2] == "next" {
-			return m[1]
-		}
-	}
-	return ""
 }

--- a/pkg/cmd/run/shared/artifacts_test.go
+++ b/pkg/cmd/run/shared/artifacts_test.go
@@ -6,9 +6,11 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDownloadWorkflowArtifactsPageinates(t *testing.T) {
@@ -63,4 +65,25 @@ func TestDownloadWorkflowArtifactsPageinates(t *testing.T) {
 	result, err := ListArtifacts(httpClient, repo, testRunId)
 	assert.NoError(t, err)
 	assert.Equal(t, []Artifact{firstArtifact, secondArtifact}, result)
+}
+
+func TestListArtifactsReturnsAPIErrorMessage(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.QueryMatcher(
+			"GET",
+			"repos/OWNER/REPO/actions/artifacts",
+			url.Values{"per_page": []string{"100"}},
+		),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	_, err := ListArtifacts(&http.Client{Transport: reg}, ghrepo.New("OWNER", "REPO"), "")
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	require.EqualError(t, err, "HTTP 404 (https://api.github.com/repos/OWNER/REPO/actions/artifacts?per_page=100)")
 }

--- a/pkg/cmd/run/view/logs.go
+++ b/pkg/cmd/run/view/logs.go
@@ -45,6 +45,8 @@ func (f *apiLogFetcher) GetLog() (io.ReadCloser, error) {
 		return nil, err
 	}
 
+	// TODO(api-client-rollout)
+	// This has been deferred from moving to api.Client due to returning the job log response body as an io.ReadCloser instead of decoding JSON.
 	req, err := http.NewRequest("GET", logURL.String(), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -471,6 +471,8 @@ func shouldFetchJobs(opts *ViewOptions) bool {
 }
 
 func getLog(httpClient *http.Client, logURL safeurl.SafeURL) (io.ReadCloser, error) {
+	// TODO(api-client-rollout)
+	// This has been deferred from moving to api.Client due to streaming the run log ZIP response body for archive processing instead of decoding JSON.
 	req, err := http.NewRequest("GET", logURL.String(), nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Part of https://github.com/cli/cli/issues/13991

### Description

This PR migrates the deletion paths of `gh release` to use `api.Client` for API interactions. There is no intended user-visible change.

Three call sites move across: `deleteRelease` and `deleteTag` in `gh release delete`, and `deleteAsset` in `gh release delete-asset`. All three issued a `DELETE`, checked `resp.StatusCode > 299`, and returned `api.HandleHTTPError(resp)` on failure, which is what `api.Client.REST` does. Each is now a single `REST` call with a nil response target.

`deleteRelease` and `deleteAsset` act on absolute `APIURL` values returned by the server. `api.Client.REST` passes absolute URLs through untouched, so those requests are unchanged on the wire. Both functions receive the repository host from `baseRepo.RepoHost()`.

`deleteTag` previously built an absolute URL with `safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(...), ...)`. Since `api.Client.REST` resolves relative paths against its host argument, this now uses `safeurl.JoinPath` and no longer needs `ghinstance` in that package.

`editRelease` in `gh release edit` deliberately remains on raw `http.Client` and carries a `TODO(api-client-rollout)` explaining why. Its return shape depends on the successful response status, which `api.Client.REST` does not expose. Characterization tests preserve its existing 204, decode-error, body-read-error, and HTTP-error behavior.

### How did you test this change?

```console
$ GH_ACCEPTANCE_HOST=github.com \
  GH_ACCEPTANCE_ORG=gh-acceptance-testing \
  GH_ACCEPTANCE_TOKEN="$(gh auth token --hostname github.com)" \
  go test -tags=acceptance -count=1 -v -run '^TestReleases$' ./acceptance
--- PASS: TestReleases (0.00s)
    --- PASS: TestReleases/release-view (6.67s)
    --- PASS: TestReleases/release-list (7.12s)
    --- PASS: TestReleases/release-create (7.74s)
    --- PASS: TestReleases/release-upload-download (8.92s)
    --- PASS: TestReleases/release-delete (14.92s)
PASS
ok      github.com/cli/cli/v2/acceptance        15.478s
```

### Key points

- The standalone `release-delete` acceptance scenario exercises asset deletion, release deletion, and `--cleanup-tag`, and verifies that the asset, release, and tag are gone.
- Release edit remains outside acceptance coverage because its migration was deferred; focused characterization tests cover its existing behavior.

### Notes for reviewers

This is a stacked PR. It targets `trunk`, and #14078 is stacked on top of it.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @williammartin will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.