### PR TITLE
Add `gh uptime` to report GitHub service status

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -44,6 +44,7 @@ import (
 	skillsCmd "github.com/cli/cli/v2/pkg/cmd/skills"
 	sshKeyCmd "github.com/cli/cli/v2/pkg/cmd/ssh-key"
 	statusCmd "github.com/cli/cli/v2/pkg/cmd/status"
+	uptimeCmd "github.com/cli/cli/v2/pkg/cmd/uptime"
 	variableCmd "github.com/cli/cli/v2/pkg/cmd/variable"
 	versionCmd "github.com/cli/cli/v2/pkg/cmd/version"
 	workflowCmd "github.com/cli/cli/v2/pkg/cmd/workflow"
@@ -155,6 +156,7 @@ func NewCmdRoot(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, versi
 	// Root commands with standalone functionality and no subcommands
 	cmd.AddCommand(copilotCmd.NewCmdCopilot(f, telemetry, nil))
 	cmd.AddCommand(statusCmd.NewCmdStatus(f, nil))
+	cmd.AddCommand(uptimeCmd.NewCmdUptime(f, nil))
 	cmd.AddCommand(creditsCmd.NewCmdCredits(f, nil))
 	cmd.AddCommand(licensesCmd.NewCmdLicenses(f))
 	cmd.AddCommand(sendTelemetryCmd.NewCmdSendTelemetry(f))

--- a/pkg/cmd/uptime/render.go
+++ b/pkg/cmd/uptime/render.go
@@ -1,0 +1,131 @@
+package uptime
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+// uptimeFields are the columns available to --json.
+var uptimeFields = []string{
+	"indicator",
+	"description",
+	"component",
+	"status",
+	"operational",
+	"components",
+}
+
+// exportedComponent is the per-component JSON shape.
+type exportedComponent struct {
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	Operational bool   `json:"operational"`
+}
+
+// exportShape builds the object returned by --json/--jq. When a single
+// component is requested the top-level status/operational reflect just that
+// component, so `gh uptime -c Actions --json operational` is a clean boolean.
+func exportShape(s *summary, name string) map[string]interface{} {
+	comps := leafComponents(s)
+	exported := make([]exportedComponent, 0, len(comps))
+	for _, c := range comps {
+		exported = append(exported, exportedComponent{
+			Name:        c.Name,
+			Status:      c.Status,
+			Operational: c.Status == "operational",
+		})
+	}
+
+	out := map[string]interface{}{
+		"indicator":   s.Status.Indicator,
+		"description": s.Status.Description,
+		"components":  exported,
+		"operational": targetOperational(s, name),
+	}
+
+	if name != "" {
+		out["component"] = name
+		status := "unknown"
+		for _, c := range comps {
+			if strings.EqualFold(c.Name, name) {
+				status = c.Status
+				break
+			}
+		}
+		out["status"] = status
+	} else {
+		out["component"] = nil
+		out["status"] = s.Status.Indicator
+	}
+
+	return out
+}
+
+// render prints the human-readable report.
+func render(io *iostreams.IOStreams, s *summary, name string) error {
+	cs := io.ColorScheme()
+	out := io.Out
+
+	// Single-component view.
+	if name != "" {
+		for _, c := range leafComponents(s) {
+			if strings.EqualFold(c.Name, name) {
+				fmt.Fprintf(out, "%s %s %s\n", statusIcon(cs, c.Status), c.Name, statusText(cs, c.Status))
+				return nil
+			}
+		}
+		return fmt.Errorf("no such GitHub component %q; run `gh uptime` to list components", name)
+	}
+
+	// Overall banner.
+	fmt.Fprintf(out, "%s %s\n", overallIcon(cs, s.Status.Indicator), cs.Bold(s.Status.Description))
+
+	if !io.IsStdoutTTY() {
+		// Non-TTY: keep the per-line output stable and unstyled-ish for scripts
+		// that grep it (colour is auto-disabled by the ColorScheme already).
+	}
+
+	fmt.Fprintln(out)
+	for _, c := range leafComponents(s) {
+		fmt.Fprintf(out, "  %s %-22s %s\n", statusIcon(cs, c.Status), c.Name, statusText(cs, c.Status))
+	}
+	return nil
+}
+
+func overallIcon(cs *iostreams.ColorScheme, indicator string) string {
+	switch indicator {
+	case "none":
+		return cs.SuccessIcon()
+	case "minor":
+		return cs.WarningIcon()
+	default: // major, critical
+		return cs.FailureIcon()
+	}
+}
+
+func statusIcon(cs *iostreams.ColorScheme, status string) string {
+	switch status {
+	case "operational":
+		return cs.SuccessIcon()
+	case "degraded_performance", "partial_outage":
+		return cs.WarningIcon()
+	default: // major_outage, unknown
+		return cs.FailureIcon()
+	}
+}
+
+// statusText renders the human label (e.g. "major_outage" -> "major outage")
+// in a colour matching severity.
+func statusText(cs *iostreams.ColorScheme, status string) string {
+	label := strings.ReplaceAll(status, "_", " ")
+	switch status {
+	case "operational":
+		return cs.Green(label)
+	case "degraded_performance", "partial_outage":
+		return cs.Yellow(label)
+	default:
+		return cs.Red(label)
+	}
+}

--- a/pkg/cmd/uptime/uptime.go
+++ b/pkg/cmd/uptime/uptime.go
@@ -1,0 +1,227 @@
+package uptime
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+// statusURL is the public GitHub Status (Statuspage) summary endpoint. It is
+// deliberately NOT api.github.com and requires no authentication, so this
+// command never sends the user's GitHub token to a third-party host.
+const statusURL = "https://www.githubstatus.com/api/v2/summary.json"
+
+// componentOrder pins the display order to the grouping used on
+// githubstatus.com; anything unlisted sorts alphabetically after these.
+var componentOrder = map[string]int{
+	"Git Operations":     0,
+	"API Requests":       1,
+	"Webhooks":           2,
+	"Issues":             3,
+	"Pull Requests":      4,
+	"Actions":            5,
+	"Packages":           6,
+	"Pages":              7,
+	"Codespaces":         8,
+	"Copilot":            9,
+	"Copilot Extensions": 10,
+}
+
+type summary struct {
+	Status struct {
+		Indicator   string `json:"indicator"`   // none | minor | major | critical
+		Description string `json:"description"` // e.g. "All Systems Operational"
+	} `json:"status"`
+	Components []component `json:"components"`
+}
+
+type component struct {
+	Name   string `json:"name"`
+	Status string `json:"status"` // operational | degraded_performance | partial_outage | major_outage
+	Group  bool   `json:"group"`
+}
+
+// UptimeOptions holds the resolved dependencies + flags for `gh uptime`.
+type UptimeOptions struct {
+	HTTPClient func() *http.Client
+	IO         *iostreams.IOStreams
+	Exporter   cmdutil.Exporter
+
+	Component string
+	Watch     bool
+	Interval  time.Duration
+	ExitCode  bool
+}
+
+func NewCmdUptime(f *cmdutil.Factory, runF func(*UptimeOptions) error) *cobra.Command {
+	opts := &UptimeOptions{
+		IO: f.IOStreams,
+		// A plain client — the factory's HttpClient injects the gh auth token,
+		// which must never be sent to githubstatus.com.
+		HTTPClient: func() *http.Client {
+			return &http.Client{Timeout: 15 * time.Second}
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "uptime",
+		Short: "Show the operational status of GitHub services",
+		Long: heredoc.Docf(`
+			Report the current operational status of GitHub's services, as published
+			at <https://www.githubstatus.com>.
+
+			This queries the public GitHub Status page (not api.github.com) and sends
+			no authentication, so it works even when your token is unset or when the
+			API itself is degraded.
+
+			With %[1]s--watch%[1]s the command polls until GitHub (or a single named
+			%[1]s--component%[1]s) returns to operational — useful for holding a script
+			until an incident clears. Combined with %[1]s--exit-code%[1]s it composes
+			directly into automation:
+
+			    # wait out an Actions outage, then kick off a workflow
+			    gh uptime --component Actions --watch && gh workflow run ci.yml
+		`, "`"),
+		Args: cobra.NoArgs,
+		Example: heredoc.Doc(`
+			# current status of every GitHub service
+			$ gh uptime
+
+			# just Actions, machine-readable, for a polling loop
+			$ gh uptime --component Actions --json component,status,indicator
+
+			# fail (non-zero exit) if anything is degraded — gate a deploy
+			$ gh uptime --exit-code || echo "GitHub degraded; holding"
+
+			# block until Actions recovers, checking every 30s
+			$ gh uptime --component Actions --watch --interval 30s
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Interval < 5*time.Second {
+				return cmdutil.FlagErrorf("--interval must be at least 5s to respect the status page")
+			}
+			if runF != nil {
+				return runF(opts)
+			}
+			return uptimeRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Component, "component", "c", "", "Report a single component by name (e.g. \"Actions\")")
+	cmd.Flags().BoolVarP(&opts.Watch, "watch", "w", false, "Poll until the target is operational")
+	cmd.Flags().DurationVarP(&opts.Interval, "interval", "i", 30*time.Second, "Polling interval for --watch")
+	cmd.Flags().BoolVar(&opts.ExitCode, "exit-code", false, "Exit non-zero when the target is not operational")
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, uptimeFields)
+
+	// No GitHub auth needed to read a public status page.
+	cmdutil.DisableAuthCheck(cmd)
+
+	return cmd
+}
+
+func uptimeRun(opts *UptimeOptions) error {
+	client := opts.HTTPClient()
+
+	for {
+		s, err := fetchSummary(client)
+		if err != nil {
+			return err
+		}
+
+		operational := targetOperational(s, opts.Component)
+
+		// In watch mode, keep polling silently until operational, then render once.
+		if opts.Watch && !operational {
+			time.Sleep(opts.Interval)
+			continue
+		}
+
+		if opts.Exporter != nil {
+			if err := opts.Exporter.Write(opts.IO, exportShape(s, opts.Component)); err != nil {
+				return err
+			}
+		} else if err := render(opts.IO, s, opts.Component); err != nil {
+			return err
+		}
+
+		if opts.ExitCode && !operational {
+			return cmdutil.SilentError
+		}
+		return nil
+	}
+}
+
+func fetchSummary(client *http.Client) (*summary, error) {
+	req, err := http.NewRequest(http.MethodGet, statusURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not reach the GitHub status page: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub status page returned %s", resp.Status)
+	}
+	var s summary
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return nil, fmt.Errorf("could not parse the GitHub status page response: %w", err)
+	}
+	return &s, nil
+}
+
+// targetOperational reports whether the whole platform (component == "") or a
+// single named component is currently operational.
+func targetOperational(s *summary, name string) bool {
+	if name == "" {
+		return s.Status.Indicator == "none"
+	}
+	for _, c := range s.Components {
+		if c.Group {
+			continue
+		}
+		if strings.EqualFold(c.Name, name) {
+			return c.Status == "operational"
+		}
+	}
+	return false
+}
+
+// leafComponents returns the real, non-group service components in a stable
+// display order. The status page carries a couple of non-service rows (e.g. a
+// "Visit www.githubstatus.com for more information" link) as components; those
+// are dropped so callers only ever see actual GitHub services.
+func leafComponents(s *summary) []component {
+	out := make([]component, 0, len(s.Components))
+	for _, c := range s.Components {
+		if c.Group {
+			continue
+		}
+		if strings.HasPrefix(c.Name, "Visit ") || strings.Contains(c.Name, "githubstatus.com") {
+			continue
+		}
+		out = append(out, c)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		oi, iok := componentOrder[out[i].Name]
+		oj, jok := componentOrder[out[j].Name]
+		if iok && jok {
+			return oi < oj
+		}
+		if iok != jok {
+			return iok
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/pkg/cmd/uptime/uptime_test.go
+++ b/pkg/cmd/uptime/uptime_test.go
@@ -1,0 +1,215 @@
+package uptime
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixture builds a githubstatus summary.json body for the given overall
+// indicator/description and component name->status pairs.
+func fixture(indicator, description string, comps [][2]string) string {
+	body := map[string]interface{}{
+		"status": map[string]string{"indicator": indicator, "description": description},
+	}
+	list := make([]map[string]interface{}, 0, len(comps))
+	for _, c := range comps {
+		list = append(list, map[string]interface{}{"name": c[0], "status": c[1], "group": false})
+	}
+	body["components"] = list
+	b, _ := json.Marshal(body)
+	return string(b)
+}
+
+func TestNewCmdUptime(t *testing.T) {
+	tests := []struct {
+		name    string
+		cli     string
+		wantErr string
+		want    UptimeOptions
+	}{
+		{
+			name: "no args",
+			cli:  "",
+			want: UptimeOptions{Interval: 30 * time.Second},
+		},
+		{
+			name: "component + json",
+			cli:  "--component Actions --json status",
+			want: UptimeOptions{Component: "Actions", Interval: 30 * time.Second},
+		},
+		{
+			name: "watch with interval",
+			cli:  "--watch --interval 45s",
+			want: UptimeOptions{Watch: true, Interval: 45 * time.Second},
+		},
+		{
+			name:    "interval too small",
+			cli:     "--watch --interval 1s",
+			wantErr: "--interval must be at least 5s to respect the status page",
+		},
+		{
+			name:    "rejects positional args",
+			cli:     "Actions",
+			wantErr: `unknown command "Actions" for "uptime"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{IOStreams: ios}
+
+			var gotOpts *UptimeOptions
+			cmd := NewCmdUptime(f, func(o *UptimeOptions) error {
+				gotOpts = o
+				return nil
+			})
+
+			argv, err := shlex.Split(tt.cli)
+			require.NoError(t, err)
+			cmd.SetArgs(argv)
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.Component, gotOpts.Component)
+			assert.Equal(t, tt.want.Watch, gotOpts.Watch)
+			assert.Equal(t, tt.want.Interval, gotOpts.Interval)
+		})
+	}
+}
+
+func runWith(t *testing.T, opts *UptimeOptions, body string) (stdout string, err error) {
+	t.Helper()
+	reg := &httpmock.Registry{}
+	reg.Register(
+		httpmock.REST(http.MethodGet, "api/v2/summary.json"),
+		httpmock.StringResponse(body),
+	)
+	ios, _, stdoutBuf, _ := iostreams.Test()
+	opts.IO = ios
+	opts.HTTPClient = func() *http.Client {
+		return &http.Client{Transport: reg}
+	}
+	err = uptimeRun(opts)
+	return stdoutBuf.String(), err
+}
+
+func TestUptimeRun_AllOperational(t *testing.T) {
+	body := fixture("none", "All Systems Operational", [][2]string{
+		{"Git Operations", "operational"},
+		{"Actions", "operational"},
+	})
+	out, err := runWith(t, &UptimeOptions{Interval: 30 * time.Second}, body)
+	require.NoError(t, err)
+	assert.Contains(t, out, "All Systems Operational")
+	assert.Contains(t, out, "Git Operations")
+	assert.Contains(t, out, "Actions")
+}
+
+func TestUptimeRun_ExitCodeWhenDegraded(t *testing.T) {
+	body := fixture("major", "Partial System Outage", [][2]string{
+		{"Actions", "major_outage"},
+		{"Git Operations", "operational"},
+	})
+	// Without --exit-code: reports but returns nil.
+	out, err := runWith(t, &UptimeOptions{Interval: 30 * time.Second}, body)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Partial System Outage")
+
+	// With --exit-code: SilentError (exit 1) because the platform is degraded.
+	_, err = runWith(t, &UptimeOptions{Interval: 30 * time.Second, ExitCode: true}, body)
+	assert.ErrorIs(t, err, cmdutil.SilentError)
+}
+
+func TestUptimeRun_ComponentExitCode(t *testing.T) {
+	body := fixture("major", "Partial System Outage", [][2]string{
+		{"Actions", "major_outage"},
+		{"Git Operations", "operational"},
+	})
+	// A degraded component we don't care about must not trip --exit-code when we
+	// scope to a healthy one.
+	_, err := runWith(t, &UptimeOptions{Component: "Git Operations", Interval: 30 * time.Second, ExitCode: true}, body)
+	require.NoError(t, err, "scoped to an operational component, exit code should be clean")
+
+	// Scoped to the outaged component, --exit-code must fail.
+	_, err = runWith(t, &UptimeOptions{Component: "Actions", Interval: 30 * time.Second, ExitCode: true}, body)
+	assert.ErrorIs(t, err, cmdutil.SilentError)
+}
+
+func TestUptimeRun_UnknownComponent(t *testing.T) {
+	body := fixture("none", "All Systems Operational", [][2]string{
+		{"Actions", "operational"},
+	})
+	_, err := runWith(t, &UptimeOptions{Component: "Nope", Interval: 30 * time.Second}, body)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such GitHub component")
+}
+
+func TestUptimeRun_JSONExport(t *testing.T) {
+	body := fixture("major", "Partial System Outage", [][2]string{
+		{"Actions", "major_outage"},
+		{"Git Operations", "operational"},
+	})
+	exporter := cmdutil.NewJSONExporter()
+	exporter.SetFields([]string{"operational", "status", "component"})
+	out, err := runWith(t, &UptimeOptions{Component: "Actions", Interval: 30 * time.Second, Exporter: exporter}, body)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, false, got["operational"])
+	assert.Equal(t, "major_outage", got["status"])
+	assert.Equal(t, "Actions", got["component"])
+}
+
+func TestLeafComponents_DropsNonServiceRows(t *testing.T) {
+	s := &summary{}
+	s.Components = []component{
+		{Name: "Actions", Status: "operational"},
+		{Name: "Visit www.githubstatus.com for more information", Status: "operational"},
+		{Name: "Some Group", Status: "operational", Group: true},
+	}
+	got := leafComponents(s)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Actions", got[0].Name)
+}
+
+func TestTargetOperational(t *testing.T) {
+	s := &summary{Components: []component{
+		{Name: "Actions", Status: "major_outage"},
+		{Name: "Git Operations", Status: "operational"},
+	}}
+	s.Status.Indicator = "major"
+
+	assert.False(t, targetOperational(s, ""), "platform indicator major => not operational")
+	assert.False(t, targetOperational(s, "Actions"))
+	assert.True(t, targetOperational(s, "git operations"), "component match is case-insensitive")
+	assert.False(t, targetOperational(s, "Missing"), "unknown component is treated as not operational")
+}
+
+// ensure the fields list advertised to --json stays in sync with what we emit.
+func TestUptimeFieldsCoverExport(t *testing.T) {
+	shape := exportShape(&summary{}, "Actions")
+	for _, f := range []string{"operational", "status", "component", "indicator", "description", "components"} {
+		_, ok := shape[f]
+		assert.True(t, ok, "export shape missing advertised field %q", f)
+		assert.Contains(t, strings.Join(uptimeFields, ","), f)
+	}
+}


### PR DESCRIPTION
## What

Adds `gh uptime`: a command that reports the operational status of GitHub's
services from the public status page (<https://www.githubstatus.com>).

```
$ gh uptime
✓ All Systems Operational

  ✓ Git Operations         operational
  ✓ API Requests           operational
  ✓ Actions                operational
  ...
```

It queries the Statuspage summary API — **not** `api.github.com` — and sends no
authentication, so it works when your token is unset, and (the point) when the
API itself is degraded. The gh auth token is never sent to the third-party host.

## Why

Partly for fun, but there's a real use case: **holding automation until an
incident clears, then resuming.** During an Actions outage you currently have to
poll `githubstatus.com` by hand. With this you can let a script wait it out:

```sh
# wait out an Actions outage, then kick off a workflow
gh uptime --component Actions --watch && gh workflow run ci.yml
```

Flags aimed at scripting:

- `--json` / `--jq` — machine-readable output (`gh uptime -c Actions --jq .operational` → a bare bool)
- `--component <name>` — scope to a single service (e.g. `Actions`)
- `--exit-code` — non-zero exit when the target is not operational, so it composes with `&&`
- `--watch` / `--interval` — poll until the target returns to operational (min 5s to respect the status page)

## Notes

- No new dependencies; uses the existing `cmdutil`/`iostreams`/`httpmock` machinery.
- Auth is disabled for the command (`DisableAuthCheck`) since the status page is public.
- Non-service rows the status page carries (e.g. the "Visit www.githubstatus.com…" link) are filtered out.
- Unit tests cover flag parsing, all-operational vs degraded rendering, `--exit-code`, component scoping, unknown component, and `--json` export — all via `httpmock`, no network.

Happy to adjust naming/scope — I picked `uptime` to avoid colliding with the existing `gh status` (notifications/activity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
