### PR TITLE
Add a scheduled tech debt burndown skill

### DIFF
--- a/.experiments/tech-debt-burndown/memory.md
+++ b/.experiments/tech-debt-burndown/memory.md
@@ -1,8 +1,8 @@
 # Tech debt burndown: agent memory
 
-Standing corrections for the `tech-debt-burndown` skill. This file is loaded at
-the start of every run and is binding. Keep it short: every line here costs
-context on every future run.
+Standing corrections for the [`tech-debt-burndown` skill](../../.github/skills/tech-debt-burndown/SKILL.md).
+This file is loaded at the start of every run and is binding. Keep it short:
+every line here costs context on every future run.
 
 Add an entry when a run produces knowledge a future run would otherwise have to
 rediscover. Consolidate entries that say the same thing.
@@ -43,3 +43,23 @@ None yet.
 ## Failed approaches
 
 None yet.
+
+## Baseline noise on this machine
+
+Two failures are pre-existing and unrelated to any fix; confirmed against a
+clean tree. Do not try to fix them and do not treat them as validation failures:
+
+- `make lint` reports 3 `govet` issues in vendored/toolchain source.
+- `git/...` tests fail with `safe.bareRepository is 'explicit'`, a local git
+  config setting, not a code defect.
+
+## Staticcheck shape
+
+Repo-wide staticcheck has **no `SA` (correctness) findings**. It is all style:
+QF1008 (70), QF1012 (50), ST1005 (29), QF1003 (24), ST1012 (16), rest single
+digits. So staticcheck targets are mechanical and safe, but pick a package that
+goes fully to zero rather than fixing scattered instances.
+
+Packages with the most staticcheck issues: `pkg/cmd/pr/edit` (23),
+`pkg/cmd/issue/edit` (19), `pkg/cmd/auth/status` (16), `pkg/cmd/extension` (11).
+`pkg/cmd/alias/imports` is now clean (2026-08-06).

--- a/.experiments/tech-debt-burndown/memory.md
+++ b/.experiments/tech-debt-burndown/memory.md
@@ -1,43 +1,60 @@
 # Tech debt burndown: agent memory
 
 Standing corrections for the [`tech-debt-burndown` skill](../../.github/skills/tech-debt-burndown/SKILL.md).
-This file is loaded at the start of every run and is binding. Keep it short:
-every line here costs context on every future run.
+This file is loaded at the start of every run and is binding.
 
 Both humans and agent runs write here, and nothing distinguishes the two once
 written. Assume any entry may be an unreviewed conclusion from a previous run.
 Entries are binding on what to avoid; factual claims in them should be
-re-verified before you lean on them, and corrected when stale.
+re-verified before you lean on them, and corrected when stale. Date-stamp
+anything you add.
 
-Add an entry when a run produces knowledge a future run would otherwise have to
-rediscover. Consolidate entries that say the same thing.
+**Budget: 100 lines.** This file costs context on every future run. If an append
+would exceed the budget, consolidate existing entries first, in the same pull
+request.
+
+## Current focus
+
+**Human-owned. Agent runs must not edit this section.** Propose changes in the
+pull request body instead.
+
+Empty. With no focus set, runs fall back to the tier order in the skill.
+
+<!-- Examples of what can go here:
+     - "Work on pkg/cmd/pr/edit until staticcheck is clean, then add the exclusion."
+     - "Prefer skipped tests and stale nolints over linter findings for now."
+     - "Leave staticcheck alone, it is all cosmetic. Focus on errcheck." -->
 
 ## Off limits
 
 - Generated code and mocks. See the Never touch section of the skill.
 - Removing a feature-detection gate (`// TODO <cleanupIdentifier>`). Whether a
   gate can come out depends on the supported GHES version window, which is not
-  discoverable from the repo. Ask.
+  discoverable from the repo and cannot be resolved unattended.
 
 ## Known scale of the linter backlog
 
 Counts measured by an agent run on 2026-08-06 against `trunk`, not verified by a
-human, and stale the moment anyone lands a fix. Use them to choose between
-linters, not as a target count. Command:
-`--no-config --default=none --max-issues-per-linter=0 --max-same-issues=0`, so
-this repo's exclusions are *not* applied and these are upper bounds:
+human, and stale as soon as anything lands. Use them to choose between linters,
+not as a target count. Command: `--no-config --default=none
+--max-issues-per-linter=0 --max-same-issues=0`, so this repo's exclusions are
+*not* applied and these are upper bounds: errcheck 1245, staticcheck 221,
+gosec 435.
 
-| Linter | Issues |
-| --- | --- |
-| errcheck | 1245 |
-| staticcheck | 221 |
-| gosec | 435 |
+`gosec` is the least tractable, because `.golangci.yml` already excludes G110,
+G204, G301, G302, G304, G307, and G404, plus all `gosec` findings in `_test.go`
+files, and a `--no-config` run reports all of those anyway. Always cross-check
+`gosec` output against `.golangci.yml` before acting on it.
 
-`staticcheck` is the most tractable of the three. `gosec` is the least, because
-`.golangci.yml` already excludes G110, G204, G301, G302, G304, G307, and G404,
-plus all `gosec` findings in `_test.go` files, and a `--no-config` run will
-report all of those anyway. Always cross-check `gosec` output against
-`.golangci.yml` before acting on it.
+## Staticcheck shape
+
+2026-08-06: repo-wide staticcheck has **no `SA` (correctness) findings**. It is
+all style: QF1008 (70), QF1012 (50), ST1005 (29), QF1003 (24), ST1012 (16), rest
+single digits. Staticcheck targets are mechanical and safe, but low value.
+
+Most-affected packages: `pkg/cmd/pr/edit` (23), `pkg/cmd/issue/edit` (19),
+`pkg/cmd/auth/status` (16), `pkg/cmd/extension` (11). `pkg/cmd/alias/imports` was
+cleared 2026-08-06.
 
 ## Rejected targets
 
@@ -47,26 +64,6 @@ None yet.
 
 None yet.
 
-## Failed approaches
+## Failed attempts
 
 None yet.
-
-## Baseline noise on this machine
-
-Two failures are pre-existing and unrelated to any fix; confirmed against a
-clean tree. Do not try to fix them and do not treat them as validation failures:
-
-- `make lint` reports 3 `govet` issues in vendored/toolchain source.
-- `git/...` tests fail with `safe.bareRepository is 'explicit'`, a local git
-  config setting, not a code defect.
-
-## Staticcheck shape
-
-Repo-wide staticcheck has **no `SA` (correctness) findings**. It is all style:
-QF1008 (70), QF1012 (50), ST1005 (29), QF1003 (24), ST1012 (16), rest single
-digits. So staticcheck targets are mechanical and safe, but pick a package that
-goes fully to zero rather than fixing scattered instances.
-
-Packages with the most staticcheck issues: `pkg/cmd/pr/edit` (23),
-`pkg/cmd/issue/edit` (19), `pkg/cmd/auth/status` (16), `pkg/cmd/extension` (11).
-`pkg/cmd/alias/imports` is now clean (2026-08-06).

--- a/.experiments/tech-debt-burndown/memory.md
+++ b/.experiments/tech-debt-burndown/memory.md
@@ -4,6 +4,11 @@ Standing corrections for the [`tech-debt-burndown` skill](../../.github/skills/t
 This file is loaded at the start of every run and is binding. Keep it short:
 every line here costs context on every future run.
 
+Both humans and agent runs write here, and nothing distinguishes the two once
+written. Assume any entry may be an unreviewed conclusion from a previous run.
+Entries are binding on what to avoid; factual claims in them should be
+re-verified before you lean on them, and corrected when stale.
+
 Add an entry when a run produces knowledge a future run would otherwise have to
 rediscover. Consolidate entries that say the same thing.
 
@@ -16,9 +21,11 @@ rediscover. Consolidate entries that say the same thing.
 
 ## Known scale of the linter backlog
 
-Measured 2026-08-06 against `trunk` with `--no-config --default=none
---max-issues-per-linter=0 --max-same-issues=0`, so this repo's exclusions are
-*not* applied and these are upper bounds:
+Counts measured by an agent run on 2026-08-06 against `trunk`, not verified by a
+human, and stale the moment anyone lands a fix. Use them to choose between
+linters, not as a target count. Command:
+`--no-config --default=none --max-issues-per-linter=0 --max-same-issues=0`, so
+this repo's exclusions are *not* applied and these are upper bounds:
 
 | Linter | Issues |
 | --- | --- |

--- a/.experiments/tech-debt-burndown/memory.md
+++ b/.experiments/tech-debt-burndown/memory.md
@@ -2,16 +2,20 @@
 
 Standing corrections for the [`tech-debt-burndown` skill](../../.github/skills/tech-debt-burndown/SKILL.md).
 This file is loaded at the start of every run and is binding.
-
 Both humans and agent runs write here, and nothing distinguishes the two once
 written. Assume any entry may be an unreviewed conclusion from a previous run.
 Entries are binding on what to avoid; factual claims in them should be
 re-verified before you lean on them, and corrected when stale. Date-stamp
 anything you add.
 
-**Budget: 100 lines.** This file costs context on every future run. If an append
-would exceed the budget, consolidate existing entries first, in the same pull
-request.
+**Budget: 150 lines of entries**, counted from the end of Current focus to the end
+of the file. The header and Current focus do not count, and must never be trimmed
+to get under budget: they are instructions, not findings. If an append would
+exceed the budget, consolidate existing entries first, in the same pull request.
+
+The budget exists so this file stays worth reading, not to save tokens - the
+skill file is several times longer. A memory file that has become a run log is
+one nobody reads carefully, including you.
 
 ## Current focus
 

--- a/.github/agent-memory/tech-debt.md
+++ b/.github/agent-memory/tech-debt.md
@@ -1,0 +1,45 @@
+# Tech debt burndown: agent memory
+
+Standing corrections for the `tech-debt-burndown` skill. This file is loaded at
+the start of every run and is binding. Keep it short: every line here costs
+context on every future run.
+
+Add an entry when a run produces knowledge a future run would otherwise have to
+rediscover. Consolidate entries that say the same thing.
+
+## Off limits
+
+- Generated code and mocks. See the Never touch section of the skill.
+- Removing a feature-detection gate (`// TODO <cleanupIdentifier>`). Whether a
+  gate can come out depends on the supported GHES version window, which is not
+  discoverable from the repo. Ask.
+
+## Known scale of the linter backlog
+
+Measured 2026-08-06 against `trunk` with `--no-config --default=none
+--max-issues-per-linter=0 --max-same-issues=0`, so this repo's exclusions are
+*not* applied and these are upper bounds:
+
+| Linter | Issues |
+| --- | --- |
+| errcheck | 1245 |
+| staticcheck | 221 |
+| gosec | 435 |
+
+`staticcheck` is the most tractable of the three. `gosec` is the least, because
+`.golangci.yml` already excludes G110, G204, G301, G302, G304, G307, and G404,
+plus all `gosec` findings in `_test.go` files, and a `--no-config` run will
+report all of those anyway. Always cross-check `gosec` output against
+`.golangci.yml` before acting on it.
+
+## Rejected targets
+
+None yet.
+
+## False positives
+
+None yet.
+
+## Failed approaches
+
+None yet.

--- a/.github/skills/tech-debt-burndown/SKILL.md
+++ b/.github/skills/tech-debt-burndown/SKILL.md
@@ -400,11 +400,18 @@ focus should change, say so in the pull request body and leave the section alone
 A run that rewrites its own instructions and then obeys them is a loop with no
 human in it at all.
 
-**Keep the file under 100 lines.** It is loaded into context on every run, so
-length is a tax on all future work. If your append would push it over, first
+**Keep the entries under 150 lines.** That budget covers everything below the
+Current focus section. The header and Current focus are excluded and must never
+be trimmed to get under budget - they are instructions, not findings, and an
+agent that deletes its own guardrails to satisfy a line count has done the worst
+possible thing with this rule. If your append would exceed the budget, first
 consolidate existing entries so the total still fits. That consolidation lands in
 the same reviewable pull request, so a human can object if it dropped something
 that mattered.
+
+Consolidation is lossy, so it should be rare. If you find yourself consolidating
+on most runs, the entries are too verbose: say what to avoid and why in one or
+two lines, and drop the narrative.
 
 ## When to stop
 

--- a/.github/skills/tech-debt-burndown/SKILL.md
+++ b/.github/skills/tech-debt-burndown/SKILL.md
@@ -57,33 +57,34 @@ Read these, in this order:
    codebase, and several debt categories below exist precisely because code
    predates a rule in it.
 
-Then get onto a clean working branch. The tree must be clean before you start,
-so your diff contains only your change:
+Then check where you are. This skill only runs from `trunk`:
 
 ```bash
 git status --porcelain          # must be empty
+git branch --show-current       # must be trunk
 ```
 
-Where you branch from depends on where you already are:
+**If either check fails, stop and tell the human. Do not fix it yourself.**
 
-- **On `trunk`**: branch from an up to date `trunk`.
+A dirty tree means your diff would carry someone else's work, and the commit
+stops being reviewable in two minutes. Do not stash, reset, or clean: that
+working tree belongs to a human and may hold hours of unsaved work.
 
-  ```bash
-  git fetch origin && git switch -c tech-debt/<short-slug> origin/trunk
-  ```
+Being on another branch means the code you are about to reason about is not the
+code that will be reviewed. A fix built on a feature branch inherits that
+branch's changes, needs rebasing before it can land, and can be invalidated by
+work the branch itself is doing. Do not switch to `trunk` to satisfy the check,
+because that abandons whatever the human was doing without asking.
 
-- **Already on a working branch**: branch from `HEAD`, not from `origin/trunk`.
+Report what you found and let the human decide. They may want the work
+committed, or may genuinely want a run from that branch, which is their call to
+make explicitly and not yours to assume.
 
-  ```bash
-  git switch -c tech-debt/<short-slug>
-  ```
+Once both checks pass, branch from an up to date `trunk`:
 
-  Switching to `origin/trunk` would discard whatever that branch carries,
-  including possibly this skill itself, and would silently change the code you
-  are reasoning about.
-
-  Say in your report which commit you branched from, so the human knows the fix
-  may need rebasing before it can land.
+```bash
+git fetch origin && git switch -c tech-debt/<short-slug> origin/trunk
+```
 
 Work on the branch from the first edit. Do not commit to `trunk`.
 
@@ -277,8 +278,8 @@ Do not push. Do not open a pull request. The human takes it from here.
 Keep it short enough to read on a phone. State:
 
 - **Target**: what you picked and why, in one line.
-- **Base**: the branch and commit you branched from, and whether the fix will
-  need rebasing onto `trunk`.
+- **Base**: the `origin/trunk` commit you branched from, so the human knows how
+  fresh the fix is.
 - **Before and after**: the sensor output either side of the change. This is the
   core of the report. It is what makes the change reviewable in two minutes.
 - **The change**: what you altered and what the new test proves.
@@ -307,6 +308,8 @@ and when several entries say the same thing, consolidate them into one.
 
 Stop, leave the code unchanged, and hand back to the human when:
 
+- the working tree is dirty, or you are not on `trunk`, as described in
+  [Before you start](#before-you-start)
 - the fix requires changing an exported signature or an interface
 - the fix touches the non-interactive output contract in any way, meaning stdout
   and stderr routing, `--json` fields, exit codes, error message text, flag

--- a/.github/skills/tech-debt-burndown/SKILL.md
+++ b/.github/skills/tech-debt-burndown/SKILL.md
@@ -38,7 +38,7 @@ it back. See [When to stop](#when-to-stop).
 
 Read these, in this order:
 
-1. `.github/agent-memory/tech-debt.md` in this repo. It carries standing
+1. `.experiments/tech-debt-burndown/memory.md` in this repo. It carries standing
    corrections from previous runs: areas that are off limits, approaches that
    were rejected, targets already considered and declined. Treat it as binding.
    If it contradicts this skill, it wins, because a human wrote it in response
@@ -275,14 +275,14 @@ Keep it short enough to read on a phone. State:
 - **Validation**: that `go test ./...` and `make lint` both passed.
 - **Left alone**: anything you noticed and deliberately did not touch. Be
   specific, because this is the seed of the next run.
-- **Memory updates**: anything you added to `.github/agent-memory/tech-debt.md`.
+- **Memory updates**: anything you added to `.experiments/tech-debt-burndown/memory.md`.
 
 If you accepted or escalated instead of fixing, say so plainly at the top. Do not
 bury it.
 
 ## Update the memory file
 
-Append to `.github/agent-memory/tech-debt.md` when a run produces knowledge a
+Append to `.experiments/tech-debt-burndown/memory.md` when a run produces knowledge a
 future run would otherwise have to rediscover:
 
 - a target you considered and rejected, and why, so it is not re-proposed

--- a/.github/skills/tech-debt-burndown/SKILL.md
+++ b/.github/skills/tech-debt-burndown/SKILL.md
@@ -39,10 +39,20 @@ it back. See [When to stop](#when-to-stop).
 Read these, in this order:
 
 1. `.experiments/tech-debt-burndown/memory.md` in this repo. It carries standing
-   corrections from previous runs: areas that are off limits, approaches that
-   were rejected, targets already considered and declined. Treat it as binding.
-   If it contradicts this skill, it wins, because a human wrote it in response
-   to something a previous run got wrong.
+   corrections: areas that are off limits, approaches that were rejected,
+   targets already considered and declined. Treat it as binding. If it
+   contradicts this skill, it wins, because it is the more specific and more
+   recent of the two, and it is the channel a human uses to correct a run
+   without editing the skill.
+
+   Entries come from two places, and they are not equally trustworthy. A human
+   may edit the file directly, and previous runs append to it. So an entry may
+   be nothing more than a previous run's conclusion that no human has checked.
+   Treat an entry as binding on what to *avoid*, since the cost of skipping a
+   viable target is one wasted run. Do not treat it as license to skip
+   verification: if an entry claims a fact you are about to rely on, such as a
+   count, a failure being pre-existing, or a target being clean, re-run the
+   command and confirm. Correct the entry when it has drifted.
 2. `AGENTS.md` at the repo root. It is the authoritative convention set for this
    codebase, and several debt categories below exist precisely because code
    predates a rule in it.

--- a/.github/skills/tech-debt-burndown/SKILL.md
+++ b/.github/skills/tech-debt-burndown/SKILL.md
@@ -82,7 +82,7 @@ try to make a failing check pass.
 
 ```bash
 git status --porcelain          # must be empty
-gh pr list --state open --json headRefName \
+gh pr list --state open --limit 1000 --json headRefName \
   --jq '[.[] | select(.headRefName | startswith("tech-debt/"))] | length'
 ```
 

--- a/.github/skills/tech-debt-burndown/SKILL.md
+++ b/.github/skills/tech-debt-burndown/SKILL.md
@@ -77,34 +77,36 @@ Read these, in this order:
 
 ### Check the preconditions
 
-Three checks, all of which must pass. If any fails, stop and say why. Do not try
-to make a failing check pass.
+Two checks, both of which must pass. If either fails, stop and say why. Do not
+try to make a failing check pass.
 
 ```bash
 git status --porcelain          # must be empty
-git branch --show-current       # must be trunk
 gh pr list --state open --json headRefName \
   --jq '[.[] | select(.headRefName | startswith("tech-debt/"))] | length'
 ```
 
-**A dirty tree** means your diff would carry someone else's work, and the change
-stops being reviewable in two minutes. Do not stash, reset, or clean: that
-working tree belongs to a human and may hold hours of unsaved work.
-
-**Being on another branch** means the code you are about to reason about is not
-the code that will be reviewed. Do not switch to `trunk` to satisfy the check,
-because that abandons whatever the human was doing without asking.
+**A dirty tree** means uncommitted work would follow you onto the new branch and
+end up in your diff, and the change stops being reviewable in two minutes. Do not
+stash, reset, or clean: that working tree belongs to a human and may hold hours
+of unsaved work.
 
 **An open `tech-debt/*` pull request** means the previous run's work is still
 waiting on a human. Stop: do not open a second one. This is the backpressure that
 keeps the loop from outrunning the reviewer, and it is deliberate that a stalled
 pull request halts production rather than letting work pile up behind it.
 
-Once all three pass, branch from an up to date `trunk`:
+Which branch is currently checked out does not matter, because you branch from
+`origin/trunk` explicitly rather than from wherever `HEAD` happens to be:
 
 ```bash
 git fetch origin && git switch -c tech-debt/<short-slug> origin/trunk
 ```
+
+Note the side effect: this leaves the checkout on the new branch. On a scheduled
+runner that is irrelevant. If you were invoked by hand from some other branch,
+switch back to it once the pull request is open, so the run does not quietly move
+a human off their work.
 
 Work on the branch from the first edit. Do not commit to `trunk`.
 
@@ -428,8 +430,8 @@ Abandon the current attempt and move to the next when:
   test that already pins the behavior exactly
 - the diff has grown past what reviews in two minutes
 
-Stop the whole run, changing nothing, when a precondition fails: dirty tree, not
-on `trunk`, or a `tech-debt/*` pull request already open.
+Stop the whole run, changing nothing, when a precondition fails: a dirty working
+tree, or a `tech-debt/*` pull request already open.
 
 Stopping is cheap. A bad pull request in a queue a human trusts is expensive,
 because the cost is not the pull request, it is the human deciding they can no

--- a/.github/skills/tech-debt-burndown/SKILL.md
+++ b/.github/skills/tech-debt-burndown/SKILL.md
@@ -1,48 +1,66 @@
 ---
 name: tech-debt-burndown
 description: >
-  Pays down exactly one small piece of tech debt in the GitHub CLI codebase per
-  run and leaves a validated commit on a branch for human review. Picks a target
-  from a menu of verified debt signals, fixes one instance, proves the fix with
-  the same tool that found it plus the full test and lint suite, and records what
-  it learned. Never merges, never pushes, never widens scope.
+  Pays down one small piece of tech debt in the GitHub CLI codebase per run and
+  opens a ready-to-review pull request. Designed to run unattended on a schedule:
+  it picks a target, tries up to three, proves the one that lands with the same
+  tool that found it, and records what it learned. Never merges, never pushes to
+  an existing branch, never widens scope.
 ---
 
 # Tech Debt Burndown
 
 You pay down tech debt in the GitHub CLI (`gh`), one small piece at a time.
 
-Each run does one thing: pick a single target, fix it, prove the fix, commit it
-on a branch. A human reads the result. The value of this skill is not throughput,
-it is producing a change so small and so obviously correct that reviewing it
-takes two minutes.
+Each run picks a target, fixes it, proves the fix, and opens a pull request that
+is ready for a human to review. The value of this skill is not throughput, it is
+producing a change so small and so obviously correct that reviewing it takes two
+minutes.
 
 You are not here to improve the codebase in general. You are here to close one
 specific, verifiable gap and stop.
 
+## Assume nobody is watching
+
+This skill is built to run unattended, on a schedule, in a loop. Write every step
+as though no human will see it until the pull request exists.
+
+That has consequences you must respect:
+
+- **Never ask a question.** There is nobody to answer. If a target needs a human
+  decision, abandon that target and try the next one.
+- **Never treat silence as approval.** If you need a fact, look it up. If you
+  cannot, that is a reason to abandon the target, not to guess.
+- **Do not behave differently when a human happens to be present.** A run
+  invoked by hand and a run invoked by a scheduler must do the same thing, or
+  what you tested by hand is not what runs on the schedule.
+
+The steering channel is the memory file, not conversation. See
+[Before you start](#before-you-start).
+
 ## The rule that matters most
 
-**One thing per run. Only one thing.**
+**One landed change per pull request. Only one.**
 
 The moment you find a second problem while fixing the first, you have a choice,
 and the answer is always the same: note it, leave it, keep going on the original
-target. A commit that fixes one `errcheck` violation gets merged. A commit that
+target. A pull request that fixes one `errcheck` violation gets merged. One that
 fixes one `errcheck` violation and also renames a helper, reorders some imports,
 and tidies up while it is in there gets bounced, and the original fix dies with
 it.
 
-If the fix you are making turns out to require a design decision, stop and hand
-it back. See [When to stop](#when-to-stop).
+You may *attempt* up to three targets in a run. Only one of them ends up in the
+pull request. See [Three attempts](#three-attempts).
 
 ## Before you start
 
 Read these, in this order:
 
 1. `.experiments/tech-debt-burndown/memory.md` in this repo. It carries standing
-   corrections: areas that are off limits, approaches that were rejected,
-   targets already considered and declined. Treat it as binding. If it
-   contradicts this skill, it wins, because it is the more specific and more
-   recent of the two, and it is the channel a human uses to correct a run
+   corrections: what to work on now, areas that are off limits, approaches that
+   were rejected, targets already considered and declined. Treat it as binding.
+   If it contradicts this skill, it wins, because it is the more specific and
+   more recent of the two, and it is the channel a human uses to steer a run
    without editing the skill.
 
    Entries come from two places, and they are not equally trustworthy. A human
@@ -57,30 +75,32 @@ Read these, in this order:
    codebase, and several debt categories below exist precisely because code
    predates a rule in it.
 
-Then check where you are. This skill only runs from `trunk`:
+### Check the preconditions
+
+Three checks, all of which must pass. If any fails, stop and say why. Do not try
+to make a failing check pass.
 
 ```bash
 git status --porcelain          # must be empty
 git branch --show-current       # must be trunk
+gh pr list --state open --json headRefName \
+  --jq '[.[] | select(.headRefName | startswith("tech-debt/"))] | length'
 ```
 
-**If either check fails, stop and tell the human. Do not fix it yourself.**
-
-A dirty tree means your diff would carry someone else's work, and the commit
+**A dirty tree** means your diff would carry someone else's work, and the change
 stops being reviewable in two minutes. Do not stash, reset, or clean: that
 working tree belongs to a human and may hold hours of unsaved work.
 
-Being on another branch means the code you are about to reason about is not the
-code that will be reviewed. A fix built on a feature branch inherits that
-branch's changes, needs rebasing before it can land, and can be invalidated by
-work the branch itself is doing. Do not switch to `trunk` to satisfy the check,
+**Being on another branch** means the code you are about to reason about is not
+the code that will be reviewed. Do not switch to `trunk` to satisfy the check,
 because that abandons whatever the human was doing without asking.
 
-Report what you found and let the human decide. They may want the work
-committed, or may genuinely want a run from that branch, which is their call to
-make explicitly and not yours to assume.
+**An open `tech-debt/*` pull request** means the previous run's work is still
+waiting on a human. Stop: do not open a second one. This is the backpressure that
+keeps the loop from outrunning the reviewer, and it is deliberate that a stalled
+pull request halts production rather than letting work pile up behind it.
 
-Once both checks pass, branch from an up to date `trunk`:
+Once all three pass, branch from an up to date `trunk`:
 
 ```bash
 git fetch origin && git switch -c tech-debt/<short-slug> origin/trunk
@@ -88,16 +108,40 @@ git fetch origin && git switch -c tech-debt/<short-slug> origin/trunk
 
 Work on the branch from the first edit. Do not commit to `trunk`.
 
+### Establish the validation baseline
+
+Before making any edit, record what already fails on clean `trunk`:
+
+```bash
+go test ./... 2>&1 | tee /tmp/baseline-test.txt
+make lint 2>&1 | tee /tmp/baseline-lint.txt
+```
+
+Do not require these to be green, and do not try to fix what they report. Their
+purpose is to tell your failures apart from failures that were already there.
+Environments differ: a failure on a maintainer's laptop caused by local git
+config will not appear in CI, and CI has failures a laptop does not. A run that
+demands green aborts forever in one environment; a run that ignores failures
+misses the ones it caused.
+
+Capture this **once per run** and reuse it for all three attempts, since every
+attempt starts from this same clean `trunk`.
+
 ## Pick one target
 
-If the human named a target, use it and skip the menu.
+If you were invoked with an explicit target, use it and skip the menu.
 
-Otherwise choose from the signals below. They are ordered by how good their
-oracle is, meaning how cheaply and how conclusively a machine can confirm the
-fix worked. Prefer a target near the top. A weak oracle means a human has to
-think hard to review your change, which is the thing this skill exists to avoid.
+Otherwise, the memory file's **Current focus** section decides. It is set by a
+human and says what matters right now: an area, a category of debt, or a specific
+package. Follow it. If it is empty, fall back to the menu below.
 
-Each command below is verified to work in this repository.
+The menu is ordered by how good each signal's oracle is, meaning how cheaply and
+how conclusively a machine can confirm the fix worked. Prefer a target near the
+top. A weak oracle means a human has to think hard to review your change, which
+is the thing this skill exists to avoid.
+
+Each command below is verified to work in this repository. The counts were true
+when written and drift as work lands, so treat them as rough.
 
 ### Tier 1: a tool reports it, and the same tool confirms the fix
 
@@ -112,19 +156,19 @@ issues". That backlog is large but finite, and it shrinks package by package:
 golangci-lint run --no-config --default=none --enable=errcheck ./pkg/cmd/<pkg>/...
 ```
 
-Swap in `staticcheck` or `gosec`. Scope to one package per run, never the whole
-tree. Note that `--no-config` skips this repo's `gosec` exclusions and its
-test-file rules, so cross-check anything `gosec` reports against the `exclusions`
-and `settings` blocks in `.golangci.yml` before acting on it. Some of what it
-reports is already deliberately excluded.
+Swap in `staticcheck` or `gosec`. Scope to one package, never the whole tree.
+Note that `--no-config` skips this repo's `gosec` exclusions and its test-file
+rules, so cross-check anything `gosec` reports against the `exclusions` and
+`settings` blocks in `.golangci.yml` before acting on it. Some of what it reports
+is already deliberately excluded.
 
-The endgame here is real: when a package is clean it can be held clean with a
-scoped exclusion rule, and when enough packages are clean the linter comes off
-the disabled list entirely. Mention progress toward that in your report where it
-is relevant.
+When a package goes clean, you may add a scoped exclusion to `.golangci.yml` that
+holds it clean, in the same pull request. That is a ratchet: without it the
+package silently regresses and the work is lost. Adding an exclusion is the only
+edit to that file you may make. Never disable a linter, widen an existing
+exclusion, or add a blanket rule.
 
-**Suppressions that may no longer be needed.** There are 31 `//nolint`
-directives:
+**Suppressions that may no longer be needed.** Around 31 `//nolint` directives:
 
 ```bash
 grep -rn "//nolint" --include=*.go .
@@ -135,7 +179,7 @@ suppression was stale and deleting it is a clean win. If it does, either fix the
 underlying issue or leave the directive alone and add the reason to it. Do not
 delete a suppression by silencing the linter some other way.
 
-**Skipped tests.** There are 9 `t.Skip` calls:
+**Skipped tests.** Around 9 `t.Skip` calls:
 
 ```bash
 grep -rn "t.Skip(" --include=*_test.go .
@@ -151,22 +195,21 @@ The oracle is the grep going to zero for that pattern, plus tests passing.
 
 **`ghinstance.Default()` call sites.** `AGENTS.md` says to use
 `cfg.Authentication().DefaultHost()` instead, because `ghinstance.Default()`
-always returns `github.com` and so is wrong for GitHub Enterprise Server. There
-are 5:
+always returns `github.com` and so is wrong for GitHub Enterprise Server:
 
 ```bash
 grep -rn "ghinstance.Default()" --include=*.go .
 ```
 
-Fix one call site per run. Each needs a test proving the non-`github.com` host is
-now respected, otherwise you have moved code around without proving anything.
-Some of these call sites have no config in scope and cannot be fixed without a
-signature change, which is a design decision. See [When to stop](#when-to-stop).
+Fix one call site. Each needs a test proving the non-`github.com` host is now
+respected, otherwise you have moved code around without proving anything. Some
+call sites have no config in scope and cannot be fixed without changing an
+exported signature, which is a design decision: abandon that attempt.
 
-### Tier 3: needs judgement, so bring a human in early
+### Tier 3: only when Current focus names it
 
-These are legitimate debt but the oracle is weak. Only take one of these when the
-human explicitly picks it, and expect to ask a question partway through.
+The oracle is weak, so these are not eligible by default. Take one only when the
+memory file's Current focus explicitly points at it.
 
 **Feature detection cleanups.** `AGENTS.md` requires a `// TODO <cleanupIdentifier>`
 comment above each feature-detection branch. The identifier groups every site that
@@ -176,21 +219,33 @@ must be removed together once the API is GA on all supported GHES versions:
 grep -rhoE "// TODO [a-zA-Z][a-zA-Z0-9_-]+" --include=*.go . | sort | uniq -c | sort -rn
 ```
 
-The largest groups are `advancedIssueSearchCleanup` (33), `ApiActorsSupported`
-(31), and `projectsV1Deprecation` (15). **Never remove one of these on your own
-initiative.** Whether a gate can come out depends on the supported GHES version
-window, which is external knowledge you do not have. What you can do without
-asking is verify a group is internally consistent and complete, and report a
-group whose sites have drifted apart.
+**Never remove one of these.** Whether a gate can come out depends on the
+supported GHES version window, which is external knowledge you do not have and
+cannot obtain unattended. What you may do is verify a group is internally
+consistent and complete, and report a group whose sites have drifted apart.
 
-**Bare TODO, FIXME, and HACK markers.** There are roughly 240. Most are not
-actionable and some are older than the code around them. Treat these as a last
-resort, and only when the marker states a concrete, checkable action.
+**Bare TODO, FIXME, and HACK markers.** Roughly 240. Most are not actionable and
+some are older than the code around them. Only when the marker states a concrete,
+checkable action.
 
-## Never touch
+## What you may change
 
-Generated code and mocks. Changes here are overwritten by the next `go generate`
-and reviewing them wastes a human's time:
+**You may edit any `.go` file**, subject to the exclusions below. Everything else
+in the repository is off limits, which is what keeps a run from quietly relaxing
+its own constraints: the workflows that schedule it, this skill file, `go.mod`,
+and CODEOWNERS are all outside the allow-list by construction.
+
+Two carve-outs, because the design needs them:
+
+- appending to `.experiments/tech-debt-burndown/memory.md`, below the Current
+  focus section;
+- adding a scoped exclusion to `.golangci.yml` when a package goes clean, as
+  described in Tier 1.
+
+### Never touch
+
+Generated code and mocks, even though they are `.go` files. Changes here are
+overwritten by the next `go generate` and reviewing them wastes a human's time:
 
 - any file containing `// Code generated ... DO NOT EDIT.`
 - `**/*.pb.go`, `**/*.twirp.go`, `**/*_mock.go`
@@ -203,8 +258,9 @@ Also never touch anything the memory file lists as off limits.
 ### Record the failure first
 
 Before you change a single line, run the sensor and save its output. You need the
-before state to prove the after state means anything, and to paste both into your
-report. A fix you cannot demonstrate was needed is indistinguishable from churn.
+before state to prove the after state means anything, and to paste both into the
+pull request. A fix you cannot demonstrate was needed is indistinguishable from
+churn.
 
 ### Make the smallest change that closes the gap
 
@@ -222,29 +278,17 @@ Follow the patterns in `AGENTS.md`: table-driven tests, `httpmock` for HTTP,
 
 An unchecked error you now handle needs a test that exercises the error path. A
 `ghinstance.Default()` call site you fix needs a test with a non-`github.com`
-host. If you cannot write a test that fails before your change and passes after,
-that is strong evidence the change is not worth making. Say so and stop.
+host.
 
-### Three honest outcomes
-
-Not every target should be fixed, and pretending otherwise is how loops produce
-bad code. You have three legitimate options:
-
-- **Fix it.** The change is small, tested, and validated.
-- **Accept it.** The reported issue is a false positive, or the current code is
-  correct for a reason the tool cannot see. Record the reason in the memory file
-  so no future run re-proposes it, and where the tool supports it add a scoped
-  suppression with that reason attached. Do not add a bare `//nolint`.
-- **Escalate it.** The fix needs a decision you should not make alone. Leave the
-  code untouched and report what the decision is.
-
-Choosing accept or escalate is a successful run. Forcing a fix to avoid an
-empty-handed report is a failed one.
+The exception is a change with no new behavior at all, where an existing test
+already asserts the exact output byte for byte. Say so explicitly in the pull
+request and name the test, so a reviewer can check the claim rather than take it
+on trust. If you can neither write a failing test nor point at one, that is
+strong evidence the change is not worth making: abandon the attempt.
 
 ## Prove it
 
-Run all three, in this order, and do not skip the middle one because the first
-passed:
+Re-run the sensor, then the full suite and the linter:
 
 ```bash
 <the sensor command from your target, re-run>   # now reports the issue gone
@@ -252,73 +296,134 @@ go test ./...
 make lint
 ```
 
+Compare the last two against the baseline you captured on clean `trunk`. **Any
+failure present now and absent from the baseline is yours**, and the attempt has
+failed. Failures present in both are pre-existing: do not fix them, and report
+them in the pull request so a reviewer is not left wondering.
+
 The full suite matters because the cheapest way to break this codebase is a
 change that looks local and is not.
 
 **Never make a check pass by weakening it.** Do not skip a test, loosen an
 assertion, add a suppression to quiet a linter you were not asked to quiet, or
-narrow a lint scope. If a check fails and you cannot fix it honestly, revert your
-change and report the attempt. A run that ends in "I tried this and it broke
-these four tests, here is why" is genuinely useful. A run that ends in a green
-build achieved by deleting a test is worse than no run at all.
+narrow a lint scope. If a check fails and you cannot fix it honestly, revert and
+move to the next attempt. A green build achieved by deleting a test is worse than
+an empty-handed run.
 
-## Commit
+## Three attempts
 
-One commit, on the branch, containing only the fix and its test.
+An unattended run that stops at its first difficulty produces nothing and the
+whole tick is wasted. So you get three attempts at finding something that lands.
+
+For each attempt, in order:
+
+1. Pick a target, respecting Current focus and everything the memory file rules
+   out. Do not re-pick a target an earlier attempt in this run already abandoned.
+2. Record the sensor's before state.
+3. Fix it, with a test.
+4. Prove it against the baseline.
+
+**The first attempt that passes wins. Stop attempting and open the pull request.**
+
+If an attempt fails at any step, revert completely before starting the next one:
+
+```bash
+git checkout -- . && git clean -fd && git status --porcelain   # must be empty
+```
+
+A half-reverted attempt contaminating the next one is the single worst outcome
+available here, because it produces a pull request whose diff nobody can explain.
+
+Keep a short note of why each failed attempt failed. Those notes are the most
+valuable thing an unlucky run produces, and they go into the memory file of
+whichever attempt eventually lands.
+
+If all three fail, stop. Do not open a pull request, do not open an issue, do not
+comment anywhere. The run is simply silent, and the absence of a pull request is
+the signal. Anything noisier turns a bad hour into a notification storm.
+
+## Commit and open the pull request
+
+One commit containing the fix, its test, and the memory file update.
 
 Follow this repository's commit style: a short imperative sentence in sentence
 case, no type prefix, describing the effect rather than the mechanics. Read
 `git log --oneline` if unsure. "Check the error from the token write" reads
 better than "fix errcheck in auth.go".
 
-Do not push. Do not open a pull request. The human takes it from here.
+Push the branch and open the pull request **ready for review, not as a draft**.
+Ready is the signal that a human's turn has begun.
 
-## Report
+Use `.github/PULL_REQUEST_TEMPLATE.md` as the body. Keep its headings and HTML
+comments and fill in every section, writing "N/A" rather than deleting one:
 
-Keep it short enough to read on a phone. State:
+- **Description**: the target, and why it was picked. One short paragraph.
+- **How did you test this change?**: the sensor output before and after. This is
+  the core of the pull request and what makes it reviewable in two minutes. Also
+  state the baseline comparison result, naming any pre-existing failures you
+  found so nobody mistakes them for yours.
+- **Key points**: the attempts that did not land and why. A reviewer reading two
+  abandoned attempts understands that the small diff was the best available
+  option, not the laziest.
+- **Notes for reviewers**: where to start, and anything you are unsure about.
 
-- **Target**: what you picked and why, in one line.
-- **Base**: the `origin/trunk` commit you branched from, so the human knows how
-  fresh the fix is.
-- **Before and after**: the sensor output either side of the change. This is the
-  core of the report. It is what makes the change reviewable in two minutes.
-- **The change**: what you altered and what the new test proves.
-- **Validation**: that `go test ./...` and `make lint` both passed.
-- **Left alone**: anything you noticed and deliberately did not touch. Be
-  specific, because this is the seed of the next run.
-- **Memory updates**: anything you added to `.experiments/tech-debt-burndown/memory.md`.
+The template's authorship block requires answers a human has explicitly chosen.
+Those choices have been made, and they are:
 
-If you accepted or escalated instead of fixing, say so plainly at the top. Do not
-bury it.
+- Who wrote this: **"An agent wrote it independently, and no human has guided the
+  implementation beyond the initial prompt."**
+- Who answers review comments: **"@williammartin will read and reply directly."**
+
+Apply the `tech-debt` label so these are filterable.
+
+Then stop. Do not merge, do not request review beyond opening the pull request,
+and do not act on any review comments that arrive. A human decides what happens
+next, and the next scheduled run will not start while this one is open.
 
 ## Update the memory file
 
-Append to `.experiments/tech-debt-burndown/memory.md` when a run produces knowledge a
-future run would otherwise have to rediscover:
+The memory file update rides along in the same commit as the fix, which is what
+makes it reviewable. A run that lands nothing records nothing.
+
+Append when a run produces knowledge a future run would otherwise have to
+rediscover:
 
 - a target you considered and rejected, and why, so it is not re-proposed
+- an attempt that failed validation, and how it failed
 - a false positive and why it is one
-- a fix approach that failed validation, and how it failed
 
-Do not append a running log of every run. This file is loaded into context at the
-start of every future run, so it has to stay worth reading. Keep entries short,
-and when several entries say the same thing, consolidate them into one.
+Date-stamp every entry, because a claim that was true in March may be false now
+and there is no other way to tell.
+
+**Never edit the Current focus section.** A human owns it. If you believe the
+focus should change, say so in the pull request body and leave the section alone.
+A run that rewrites its own instructions and then obeys them is a loop with no
+human in it at all.
+
+**Keep the file under 100 lines.** It is loaded into context on every run, so
+length is a tax on all future work. If your append would push it over, first
+consolidate existing entries so the total still fits. That consolidation lands in
+the same reviewable pull request, so a human can object if it dropped something
+that mattered.
 
 ## When to stop
 
-Stop, leave the code unchanged, and hand back to the human when:
+Abandon the current attempt and move to the next when:
 
-- the working tree is dirty, or you are not on `trunk`, as described in
-  [Before you start](#before-you-start)
 - the fix requires changing an exported signature or an interface
+- the fix requires editing anything outside the allow-list
 - the fix touches the non-interactive output contract in any way, meaning stdout
   and stderr routing, `--json` fields, exit codes, error message text, flag
   names, or default values on the non-TTY path, all of which are breaking changes
 - the fix requires deciding whether a feature-detection gate can be removed
 - validation fails and the honest fix is larger than the original target
-- you cannot write a test that fails before your change
-- you have been going long enough that the diff no longer reviews in two minutes
+- you can neither write a test that fails before your change nor name an existing
+  test that already pins the behavior exactly
+- the diff has grown past what reviews in two minutes
 
-Stopping is cheap. A bad commit in a queue a human trusts is expensive, because
-the cost is not the commit, it is the human deciding they can no longer skim
-these.
+Stop the whole run, changing nothing, when a precondition fails: dirty tree, not
+on `trunk`, or a `tech-debt/*` pull request already open.
+
+Stopping is cheap. A bad pull request in a queue a human trusts is expensive,
+because the cost is not the pull request, it is the human deciding they can no
+longer skim these.

--- a/.github/skills/tech-debt-burndown/SKILL.md
+++ b/.github/skills/tech-debt-burndown/SKILL.md
@@ -155,8 +155,21 @@ before your change and does not list it after.
 issues". That backlog is large but finite, and it shrinks package by package:
 
 ```bash
-golangci-lint run --no-config --default=none --enable=errcheck ./pkg/cmd/<pkg>/...
+golangci-lint run --no-config --default=none --enable=errcheck \
+  --max-issues-per-linter=0 --max-same-issues=0 ./pkg/cmd/<pkg>/...
 ```
+
+**Both limit flags are mandatory, and every sensor command in this skill must
+carry them.** `golangci-lint` defaults to `--max-issues-per-linter=50` and
+`--max-same-issues=3`, so without them the output is silently truncated:
+`pkg/cmd/auth/status` reports 3 findings by default and 16 with the flags.
+
+That truncation does not merely undercount, it inverts the oracle. Fix the 3
+findings you were shown, re-run, and the tool displays the next 3 that were
+hidden before. Before: 3 issues. After: 3 issues. A correct fix looks like a
+failed one, so the attempt gets reverted and the target abandoned - and this
+happens on every package with more than three findings of one kind, which is most
+of them. Do not drop these flags to shorten the command.
 
 Swap in `staticcheck` or `gosec`. Scope to one package, never the whole tree.
 Note that `--no-config` skips this repo's `gosec` exclusions and its test-file

--- a/.github/skills/tech-debt-burndown/SKILL.md
+++ b/.github/skills/tech-debt-burndown/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: tech-debt-burndown
+description: >
+  Pays down exactly one small piece of tech debt in the GitHub CLI codebase per
+  run and leaves a validated commit on a branch for human review. Picks a target
+  from a menu of verified debt signals, fixes one instance, proves the fix with
+  the same tool that found it plus the full test and lint suite, and records what
+  it learned. Never merges, never pushes, never widens scope.
+---
+
+# Tech Debt Burndown
+
+You pay down tech debt in the GitHub CLI (`gh`), one small piece at a time.
+
+Each run does one thing: pick a single target, fix it, prove the fix, commit it
+on a branch. A human reads the result. The value of this skill is not throughput,
+it is producing a change so small and so obviously correct that reviewing it
+takes two minutes.
+
+You are not here to improve the codebase in general. You are here to close one
+specific, verifiable gap and stop.
+
+## The rule that matters most
+
+**One thing per run. Only one thing.**
+
+The moment you find a second problem while fixing the first, you have a choice,
+and the answer is always the same: note it, leave it, keep going on the original
+target. A commit that fixes one `errcheck` violation gets merged. A commit that
+fixes one `errcheck` violation and also renames a helper, reorders some imports,
+and tidies up while it is in there gets bounced, and the original fix dies with
+it.
+
+If the fix you are making turns out to require a design decision, stop and hand
+it back. See [When to stop](#when-to-stop).
+
+## Before you start
+
+Read these, in this order:
+
+1. `.github/agent-memory/tech-debt.md` in this repo. It carries standing
+   corrections from previous runs: areas that are off limits, approaches that
+   were rejected, targets already considered and declined. Treat it as binding.
+   If it contradicts this skill, it wins, because a human wrote it in response
+   to something a previous run got wrong.
+2. `AGENTS.md` at the repo root. It is the authoritative convention set for this
+   codebase, and several debt categories below exist precisely because code
+   predates a rule in it.
+
+Then confirm you are starting from a clean tree on an up to date `trunk`:
+
+```bash
+git status --porcelain          # must be empty
+git fetch origin && git switch -c tech-debt/<short-slug> origin/trunk
+```
+
+Work on the branch from the first edit. Do not commit to `trunk`.
+
+## Pick one target
+
+If the human named a target, use it and skip the menu.
+
+Otherwise choose from the signals below. They are ordered by how good their
+oracle is, meaning how cheaply and how conclusively a machine can confirm the
+fix worked. Prefer a target near the top. A weak oracle means a human has to
+think hard to review your change, which is the thing this skill exists to avoid.
+
+Each command below is verified to work in this repository.
+
+### Tier 1: a tool reports it, and the same tool confirms the fix
+
+These are the best targets. Success is unambiguous: the tool listed the problem
+before your change and does not list it after.
+
+**Linters disabled for backlog reasons.** `.golangci.yml` disables `errcheck`,
+`staticcheck`, and `gosec` with the comment "To enable later due to too many
+issues". That backlog is large but finite, and it shrinks package by package:
+
+```bash
+golangci-lint run --no-config --default=none --enable=errcheck ./pkg/cmd/<pkg>/...
+```
+
+Swap in `staticcheck` or `gosec`. Scope to one package per run, never the whole
+tree. Note that `--no-config` skips this repo's `gosec` exclusions and its
+test-file rules, so cross-check anything `gosec` reports against the `exclusions`
+and `settings` blocks in `.golangci.yml` before acting on it. Some of what it
+reports is already deliberately excluded.
+
+The endgame here is real: when a package is clean it can be held clean with a
+scoped exclusion rule, and when enough packages are clean the linter comes off
+the disabled list entirely. Mention progress toward that in your report where it
+is relevant.
+
+**Suppressions that may no longer be needed.** There are 31 `//nolint`
+directives:
+
+```bash
+grep -rn "//nolint" --include=*.go .
+```
+
+Remove one, run the linter, and see if it still complains. If it does not, the
+suppression was stale and deleting it is a clean win. If it does, either fix the
+underlying issue or leave the directive alone and add the reason to it. Do not
+delete a suppression by silencing the linter some other way.
+
+**Skipped tests.** There are 9 `t.Skip` calls:
+
+```bash
+grep -rn "t.Skip(" --include=*_test.go .
+```
+
+Read why it was skipped. If the reason no longer holds, unskip it and make it
+pass. If the reason still holds but is undocumented, documenting it is a smaller
+but still real improvement.
+
+### Tier 2: a rule says it, and a grep finds every violation
+
+The oracle is the grep going to zero for that pattern, plus tests passing.
+
+**`ghinstance.Default()` call sites.** `AGENTS.md` says to use
+`cfg.Authentication().DefaultHost()` instead, because `ghinstance.Default()`
+always returns `github.com` and so is wrong for GitHub Enterprise Server. There
+are 5:
+
+```bash
+grep -rn "ghinstance.Default()" --include=*.go .
+```
+
+Fix one call site per run. Each needs a test proving the non-`github.com` host is
+now respected, otherwise you have moved code around without proving anything.
+Some of these call sites have no config in scope and cannot be fixed without a
+signature change, which is a design decision. See [When to stop](#when-to-stop).
+
+### Tier 3: needs judgement, so bring a human in early
+
+These are legitimate debt but the oracle is weak. Only take one of these when the
+human explicitly picks it, and expect to ask a question partway through.
+
+**Feature detection cleanups.** `AGENTS.md` requires a `// TODO <cleanupIdentifier>`
+comment above each feature-detection branch. The identifier groups every site that
+must be removed together once the API is GA on all supported GHES versions:
+
+```bash
+grep -rhoE "// TODO [a-zA-Z][a-zA-Z0-9_-]+" --include=*.go . | sort | uniq -c | sort -rn
+```
+
+The largest groups are `advancedIssueSearchCleanup` (33), `ApiActorsSupported`
+(31), and `projectsV1Deprecation` (15). **Never remove one of these on your own
+initiative.** Whether a gate can come out depends on the supported GHES version
+window, which is external knowledge you do not have. What you can do without
+asking is verify a group is internally consistent and complete, and report a
+group whose sites have drifted apart.
+
+**Bare TODO, FIXME, and HACK markers.** There are roughly 240. Most are not
+actionable and some are older than the code around them. Treat these as a last
+resort, and only when the marker states a concrete, checkable action.
+
+## Never touch
+
+Generated code and mocks. Changes here are overwritten by the next `go generate`
+and reviewing them wastes a human's time:
+
+- any file containing `// Code generated ... DO NOT EDIT.`
+- `**/*.pb.go`, `**/*.twirp.go`, `**/*_mock.go`
+- `pkg/cmd/codespace/mock_api.go`, `mock_prompter.go`
+
+Also never touch anything the memory file lists as off limits.
+
+## Fix it
+
+### Record the failure first
+
+Before you change a single line, run the sensor and save its output. You need the
+before state to prove the after state means anything, and to paste both into your
+report. A fix you cannot demonstrate was needed is indistinguishable from churn.
+
+### Make the smallest change that closes the gap
+
+Fix the one instance. Match the surrounding code's style rather than importing
+your own. If a fix needs a helper, check for an existing one first: the command
+set's `shared` package, then top level `api` and `git`, then `internal` helpers
+such as `internal/text`, then the standard library.
+
+### Cover it with a test
+
+New behavior needs a test. This applies even when the change looks trivial,
+because trivial is exactly the category of change that silently breaks something.
+Follow the patterns in `AGENTS.md`: table-driven tests, `httpmock` for HTTP,
+`require` for error assertions, `iostreams.Test()` for output.
+
+An unchecked error you now handle needs a test that exercises the error path. A
+`ghinstance.Default()` call site you fix needs a test with a non-`github.com`
+host. If you cannot write a test that fails before your change and passes after,
+that is strong evidence the change is not worth making. Say so and stop.
+
+### Three honest outcomes
+
+Not every target should be fixed, and pretending otherwise is how loops produce
+bad code. You have three legitimate options:
+
+- **Fix it.** The change is small, tested, and validated.
+- **Accept it.** The reported issue is a false positive, or the current code is
+  correct for a reason the tool cannot see. Record the reason in the memory file
+  so no future run re-proposes it, and where the tool supports it add a scoped
+  suppression with that reason attached. Do not add a bare `//nolint`.
+- **Escalate it.** The fix needs a decision you should not make alone. Leave the
+  code untouched and report what the decision is.
+
+Choosing accept or escalate is a successful run. Forcing a fix to avoid an
+empty-handed report is a failed one.
+
+## Prove it
+
+Run all three, in this order, and do not skip the middle one because the first
+passed:
+
+```bash
+<the sensor command from your target, re-run>   # now reports the issue gone
+go test ./...
+make lint
+```
+
+The full suite matters because the cheapest way to break this codebase is a
+change that looks local and is not.
+
+**Never make a check pass by weakening it.** Do not skip a test, loosen an
+assertion, add a suppression to quiet a linter you were not asked to quiet, or
+narrow a lint scope. If a check fails and you cannot fix it honestly, revert your
+change and report the attempt. A run that ends in "I tried this and it broke
+these four tests, here is why" is genuinely useful. A run that ends in a green
+build achieved by deleting a test is worse than no run at all.
+
+## Commit
+
+One commit, on the branch, containing only the fix and its test.
+
+Follow this repository's commit style: a short imperative sentence in sentence
+case, no type prefix, describing the effect rather than the mechanics. Read
+`git log --oneline` if unsure. "Check the error from the token write" reads
+better than "fix errcheck in auth.go".
+
+Do not push. Do not open a pull request. The human takes it from here.
+
+## Report
+
+Keep it short enough to read on a phone. State:
+
+- **Target**: what you picked and why, in one line.
+- **Before and after**: the sensor output either side of the change. This is the
+  core of the report. It is what makes the change reviewable in two minutes.
+- **The change**: what you altered and what the new test proves.
+- **Validation**: that `go test ./...` and `make lint` both passed.
+- **Left alone**: anything you noticed and deliberately did not touch. Be
+  specific, because this is the seed of the next run.
+- **Memory updates**: anything you added to `.github/agent-memory/tech-debt.md`.
+
+If you accepted or escalated instead of fixing, say so plainly at the top. Do not
+bury it.
+
+## Update the memory file
+
+Append to `.github/agent-memory/tech-debt.md` when a run produces knowledge a
+future run would otherwise have to rediscover:
+
+- a target you considered and rejected, and why, so it is not re-proposed
+- a false positive and why it is one
+- a fix approach that failed validation, and how it failed
+
+Do not append a running log of every run. This file is loaded into context at the
+start of every future run, so it has to stay worth reading. Keep entries short,
+and when several entries say the same thing, consolidate them into one.
+
+## When to stop
+
+Stop, leave the code unchanged, and hand back to the human when:
+
+- the fix requires changing an exported signature or an interface
+- the fix touches the non-interactive output contract in any way, meaning stdout
+  and stderr routing, `--json` fields, exit codes, error message text, flag
+  names, or default values on the non-TTY path, all of which are breaking changes
+- the fix requires deciding whether a feature-detection gate can be removed
+- validation fails and the honest fix is larger than the original target
+- you cannot write a test that fails before your change
+- you have been going long enough that the diff no longer reviews in two minutes
+
+Stopping is cheap. A bad commit in a queue a human trusts is expensive, because
+the cost is not the commit, it is the human deciding they can no longer skim
+these.

--- a/.github/skills/tech-debt-burndown/SKILL.md
+++ b/.github/skills/tech-debt-burndown/SKILL.md
@@ -47,12 +47,33 @@ Read these, in this order:
    codebase, and several debt categories below exist precisely because code
    predates a rule in it.
 
-Then confirm you are starting from a clean tree on an up to date `trunk`:
+Then get onto a clean working branch. The tree must be clean before you start,
+so your diff contains only your change:
 
 ```bash
 git status --porcelain          # must be empty
-git fetch origin && git switch -c tech-debt/<short-slug> origin/trunk
 ```
+
+Where you branch from depends on where you already are:
+
+- **On `trunk`**: branch from an up to date `trunk`.
+
+  ```bash
+  git fetch origin && git switch -c tech-debt/<short-slug> origin/trunk
+  ```
+
+- **Already on a working branch**: branch from `HEAD`, not from `origin/trunk`.
+
+  ```bash
+  git switch -c tech-debt/<short-slug>
+  ```
+
+  Switching to `origin/trunk` would discard whatever that branch carries,
+  including possibly this skill itself, and would silently change the code you
+  are reasoning about.
+
+  Say in your report which commit you branched from, so the human knows the fix
+  may need rebasing before it can land.
 
 Work on the branch from the first edit. Do not commit to `trunk`.
 
@@ -246,6 +267,8 @@ Do not push. Do not open a pull request. The human takes it from here.
 Keep it short enough to read on a phone. State:
 
 - **Target**: what you picked and why, in one line.
+- **Base**: the branch and commit you branched from, and whether the fix will
+  need rebasing onto `trunk`.
 - **Before and after**: the sensor output either side of the change. This is the
   core of the report. It is what makes the change reviewable in two minutes.
 - **The change**: what you altered and what the new test proves.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,4 +195,4 @@ Review pull requests with the [`cli-code-reviewer` skill](.github/skills/cli-cod
 
 ## Tech Debt
 
-Pay down tech debt with the [`tech-debt-burndown` skill](.github/skills/tech-debt-burndown/SKILL.md). It fixes one small, verifiable piece per run and leaves a validated commit on a branch for review.
+Pay down tech debt with the [`tech-debt-burndown` skill](.github/skills/tech-debt-burndown/SKILL.md). It fixes one small, verifiable piece per run and opens a ready-to-review pull request. It is built to run unattended on a schedule, so it never asks questions and only runs from a clean `trunk` with no other burndown pull request open.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,4 +195,4 @@ Review pull requests with the [`cli-code-reviewer` skill](.github/skills/cli-cod
 
 ## Tech Debt
 
-Pay down tech debt with the [`tech-debt-burndown` skill](.github/skills/tech-debt-burndown/SKILL.md). It fixes one small, verifiable piece per run and opens a ready-to-review pull request. It is built to run unattended on a schedule, so it never asks questions and only runs from a clean `trunk` with no other burndown pull request open.
+Pay down tech debt with the [`tech-debt-burndown` skill](.github/skills/tech-debt-burndown/SKILL.md). It fixes one small, verifiable piece per run and opens a ready-to-review pull request. It is built to run unattended on a schedule, so it never asks questions, and it declines to run when the working tree is dirty or another burndown pull request is already open.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,3 +192,7 @@ Read [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) and 
 ## Code Review
 
 Review pull requests with the [`cli-code-reviewer` skill](.github/skills/cli-code-reviewer/SKILL.md).
+
+## Tech Debt
+
+Pay down tech debt with the [`tech-debt-burndown` skill](.github/skills/tech-debt-burndown/SKILL.md). It fixes one small, verifiable piece per run and leaves a validated commit on a branch for review.

--- a/pkg/cmd/alias/imports/import.go
+++ b/pkg/cmd/alias/imports/import.go
@@ -129,21 +129,17 @@ func importRun(opts *ImportOptions) error {
 
 		if !opts.validAliasName(alias) {
 			if !existingAlias {
-				msg.WriteString(
-					fmt.Sprintf("%s Could not import alias %s: already a gh command or extension\n",
-						cs.FailureIcon(),
-						cs.Bold(alias),
-					),
+				fmt.Fprintf(&msg, "%s Could not import alias %s: already a gh command or extension\n",
+					cs.FailureIcon(),
+					cs.Bold(alias),
 				)
 				continue
 			}
 
 			if existingAlias && !opts.OverwriteExisting {
-				msg.WriteString(
-					fmt.Sprintf("%s Could not import alias %s: name already taken\n",
-						cs.FailureIcon(),
-						cs.Bold(alias),
-					),
+				fmt.Fprintf(&msg, "%s Could not import alias %s: name already taken\n",
+					cs.FailureIcon(),
+					cs.Bold(alias),
 				)
 				continue
 			}
@@ -152,11 +148,9 @@ func importRun(opts *ImportOptions) error {
 		expansion := aliasMap[alias]
 
 		if !opts.validAliasExpansion(expansion) {
-			msg.WriteString(
-				fmt.Sprintf("%s Could not import alias %s: expansion does not correspond to a gh command, extension, or alias\n",
-					cs.FailureIcon(),
-					cs.Bold(alias),
-				),
+			fmt.Fprintf(&msg, "%s Could not import alias %s: expansion does not correspond to a gh command, extension, or alias\n",
+				cs.FailureIcon(),
+				cs.Bold(alias),
 			)
 			continue
 		}
@@ -164,18 +158,14 @@ func importRun(opts *ImportOptions) error {
 		aliasCfg.Add(alias, expansion)
 
 		if existingAlias && opts.OverwriteExisting {
-			msg.WriteString(
-				fmt.Sprintf("%s Changed alias %s\n",
-					cs.WarningIcon(),
-					cs.Bold(alias),
-				),
+			fmt.Fprintf(&msg, "%s Changed alias %s\n",
+				cs.WarningIcon(),
+				cs.Bold(alias),
 			)
 		} else {
-			msg.WriteString(
-				fmt.Sprintf("%s Added alias %s\n",
-					cs.SuccessIcon(),
-					cs.Bold(alias),
-				),
+			fmt.Fprintf(&msg, "%s Added alias %s\n",
+				cs.SuccessIcon(),
+				cs.Bold(alias),
 			)
 		}
 	}


### PR DESCRIPTION
<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

N/A - no related issue.

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

`.golangci.yml` disables `errcheck`, `staticcheck`, and `gosec` with the comment "To enable later due to too many issues". The backlog behind that comment is roughly 1900 findings. Nobody is going to clear it in one sitting, and a sweeping cleanup PR would be unreviewable, so it just sits there.

This adds a `tech-debt-burndown` skill designed to run **unattended on a schedule**. Each run picks one target, fixes it, validates it, and opens a ready-to-review pull request. The binding constraint is that the resulting PR must be reviewable in about two minutes - throughput is explicitly not the goal, because the bottleneck is human review attention, not an agent's ability to generate diffs.

Three properties do most of the work:

- **One open burndown PR at a time.** A run stops immediately if a `tech-debt/*` PR is already open. This is the backpressure: the loop cannot outrun the reviewer, and a stalled PR halts production rather than piling more behind it.
- **Three attempts, one landing.** An unattended run that gives up at its first difficulty wastes the whole tick, so a run may attempt up to three targets, reverting fully between them. The first that validates becomes the PR; the others' failure reasons ride along in the memory file, so the loop learns from bad luck instead of repeating it.
- **Allow-list of `.go` files only.** A run cannot edit the workflows that schedule it, this skill file, `go.mod`, or CODEOWNERS, because none of them are Go source. Self-modification is blocked by construction rather than by a deny-list somebody has to keep complete.

`.experiments/tech-debt-burndown/memory.md` is the steering channel. It has a human-owned `Current focus` section that runs read and must never edit, plus agent-appendable sections for rejected targets and failed attempts, under a 150-line budget covering the entries only, so the fixed instructions at the top cannot crowd out learning.

The first run of the skill is included so reviewers can judge the output rather than only the instructions: it takes `pkg/cmd/alias/imports` from 5 `staticcheck` findings to zero.

### How did you test this change?

<!--
Demonstrate the code is solid, and how you know it solves the problem in the description.
Give the exact commands you ran and their output.
If this changes command output, show it before and after. Screenshot images are preferred over pasted text.

If you leave this empty, your pull request will very likely be closed.
-->

The sensor command, before the change:

```
$ golangci-lint run --no-config --default=none --enable=staticcheck \
    --max-issues-per-linter=0 --max-same-issues=0 ./pkg/cmd/alias/imports/...
pkg/cmd/alias/imports/import.go:132:5: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...))
pkg/cmd/alias/imports/import.go:142:5: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...))
pkg/cmd/alias/imports/import.go:155:4: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...))
pkg/cmd/alias/imports/import.go:167:4: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...))
pkg/cmd/alias/imports/import.go:174:4: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...))
5 issues:
* staticcheck: 5
```

And after:

```
$ golangci-lint run --no-config --default=none --enable=staticcheck \
    --max-issues-per-linter=0 --max-same-issues=0 ./pkg/cmd/alias/imports/...
0 issues.
```

`gh alias import` output is unchanged, and the existing tests are what prove it. `import_test.go` asserts exact `wantStderr` strings covering all five rewritten messages - the two "Could not import alias" refusals, the expansion refusal, "Changed alias", and "Added alias". They pass untouched:

```
$ go test ./pkg/cmd/alias/...
ok  	github.com/cli/cli/v2/pkg/cmd/alias/delete	0.326s
ok  	github.com/cli/cli/v2/pkg/cmd/alias/imports	0.625s
ok  	github.com/cli/cli/v2/pkg/cmd/alias/list	0.699s
ok  	github.com/cli/cli/v2/pkg/cmd/alias/set	0.939s
ok  	github.com/cli/cli/v2/pkg/cmd/alias/shared	(cached)
```

`go test ./...` and `make lint` were also run. Both report failures, and stashing the change and re-running confirms both are **pre-existing on a clean tree**, unrelated to this PR: 3 `govet` issues in toolchain source, and the `git` package tests failing due to a local `safe.bareRepository` git config.

That experience is why the skill now computes a validation baseline on clean `trunk` at the start of each run and compares failure *sets* afterwards, instead of demanding a green build. An earlier revision of this branch recorded those two specific failures in the memory file, which was a mistake: they are properties of one machine's git config and toolchain, so a run in Actions would have been misled by them. Computing the baseline per run makes the skill portable across environments.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- **No new test for the code change, deliberately.** The skill requires a test for new behavior. This change has none - it is a mechanical `WriteString(fmt.Sprintf(x))` to `Fprintf(&msg, x)` rewrite, and the existing exact-output assertions fail if a single byte moves. The skill now spells out this exception and requires the PR to name the covering test so the claim can be checked rather than trusted.
- **The skill does not respond to review comments.** An earlier design had a second skill that would read Copilot's review, apply what was right, argue with what was wrong, and mark the PR ready. It was dropped: the whole premise is that these diffs are small enough that review comments should be rare, and an agent that pushes follow-up commits in response to a reviewer is a much larger capability than the problem needs. If a comment does arrive, a human handles it, and the one-PR-at-a-time cap means the loop pauses until they do.
- **A run that lands nothing is silent.** No issue, no comment. With an hourly loop, any per-tick notification becomes noise fast, and the absence of PRs is a sufficient signal. The tradeoff is that "working through a hard area" and "broken since Tuesday" look identical from outside.
- **The sensor commands carry `--max-issues-per-linter=0 --max-same-issues=0`**, and that is load-bearing rather than tidiness. `golangci-lint` truncates to 50 per linter and 3 of the same text by default, which inverts the oracle: you fix the three findings you were shown, re-run, and the tool displays three that were previously hidden, so a correct fix reads as a failed one and gets reverted. `pkg/cmd/auth/status` reports 3 findings without the flags and 16 with them. Caught in review by @babakks.
- **`--no-config` on the sensor command** is deliberate but sharp: it bypasses this repo's `gosec` exclusions and test-file rules, so a `gosec` run under it reports findings `.golangci.yml` already excludes on purpose. The skill says to cross-check.
- **Repo-wide, `staticcheck` reports no `SA` findings at all** - it is entirely style and quickfix categories. Useful for calibrating how much of this backlog is correctness risk versus cosmetics, and recorded in the memory file.
- **`.experiments/` is a new top-level directory**, chosen to mark the whole thing as provisional and to give each experimental skill its own space.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `pkg/cmd/alias/imports/import.go`. It is 15 lines added, 25 removed, and it shows what a run actually produces. If that diff is not obviously correct at a glance, the skill has failed at its one job and the rest is not worth reading.

Then read `SKILL.md`, particularly "Assume nobody is watching", "Check the preconditions", "What you may change", and "Three attempts". Those four sections carry the unattended design; the rest is the target menu and mechanics.

What I would most like scrutiny on:

- **Is the backpressure right?** One open PR at a time means merging one a day gives you one a day regardless of tick frequency. That is intentional, but it also means a single contested PR halts the loop completely.
- **Is the `.go`-only allow-list the right boundary?** It blocks self-modification cleanly, but it also means the skill can never fix debt in workflows, Makefiles, or docs.
- **Is the memory file a good idea at all?** It is committed, human-editable state that an agent also appends to. It could rot, or grow into a diary nobody reads. The 150-line entry budget and the human-owned `Current focus` section are attempts to bound that, but they are conventions rather than mechanisms.
- **The authorship answers are now standing choices baked into the skill**, since an unattended run cannot pause to ask as the template instructs. Worth confirming that is an acceptable way to satisfy that requirement.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.


