### PR TITLE
Fail when the token cannot be written to stdout

### DIFF
--- a/.experiments/tech-debt-burndown/memory.md
+++ b/.experiments/tech-debt-burndown/memory.md
@@ -62,12 +62,36 @@ cleared 2026-08-06.
 
 ## Rejected targets
 
-None yet.
+2026-08-07: the `//nolint:gosimple` directives in `pkg/option/option_test.go`.
+`gosimple` folded into `staticcheck` in golangci-lint v2, so the name is dead,
+but the underlying S1025 finding is real. Removing them is wrong and renaming
+them to `staticcheck` is a judgement call about a linter nobody has enabled.
+
+2026-08-07: the errcheck ratchet described in Tier 1 of the skill does not work
+for `errcheck`, `staticcheck`, or `gosec`. Those three are not in the `enable`
+list at all, so `exclusions.rules` has nothing to narrow: a clean package cannot
+be held clean without enabling the linter repo-wide. Clear packages anyway, but
+do not expect to land an exclusion with them.
 
 ## False positives
 
-None yet.
+2026-08-07: `//nolint:bodyclose` at `pkg/httpmock/stub.go:252` is **not** stale.
+Removing it makes `golangci-lint run ./pkg/httpmock/...` report the finding.
 
 ## Failed attempts
 
 None yet.
+
+## Environment notes
+
+2026-08-07: on a macOS dev machine the baseline suite fails in `git`,
+`internal/config`, `pkg/cmdutil`, and every `pkg/cmd/auth/*` package, because the
+local keychain returns `******` in place of stored tokens and `safe.bareRepository
+= explicit` blocks the `git` fixtures. Worse, the set is **not stable between
+runs**: a first `go test ./...` reported 5 failing packages and an immediate
+re-run reported 11. Compare the failing *test names* against a re-run of the
+baseline on a stashed tree, not a set captured once at the start of the run.
+
+2026-08-07: `make lint` there also reports findings with paths pointing into
+*sibling worktrees* (`../<other-worktree>/...`). Those are not yours and cannot
+be fixed from this checkout.

--- a/pkg/cmd/auth/token/token.go
+++ b/pkg/cmd/auth/token/token.go
@@ -92,8 +92,10 @@ func tokenRun(opts *TokenOptions) error {
 		return errors.New(errMsg)
 	}
 
-	if val != "" {
-		fmt.Fprintf(opts.IO.Out, "%s\n", val)
+	// Callers commonly consume this as `TOKEN=$(gh auth token)` or pipe it into
+	// another process, so a failed write must not exit 0 with no token emitted.
+	if _, err := fmt.Fprintf(opts.IO.Out, "%s\n", val); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/cmd/auth/token/token_test.go
+++ b/pkg/cmd/auth/token/token_test.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/cli/cli/v2/internal/config"
@@ -188,6 +189,30 @@ func TestTokenRun(t *testing.T) {
 			require.Equal(t, tt.wantStdout, stdout.String())
 		})
 	}
+}
+
+// failingWriter fails every write, standing in for a closed pipe or a full disk
+// on stdout.
+type failingWriter struct{}
+
+func (failingWriter) Write(p []byte) (int, error) { return 0, errors.New("write failed") }
+
+func (failingWriter) Fd() uintptr { return 0 }
+
+func TestTokenRunReturnsWriteError(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	ios.Out = failingWriter{}
+
+	cfg, _ := config.NewIsolatedTestConfig(t)
+	login(t, cfg, "github.com", "test-user", "gho_ABCDEFG", "https", false)
+
+	opts := TokenOptions{
+		IO:     ios,
+		Config: func() (gh.Config, error) { return cfg, nil },
+	}
+
+	err := tokenRun(&opts)
+	require.EqualError(t, err, "write failed")
 }
 
 func TestTokenRunSecureStorage(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

N/A - no related issue.

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

`gh auth token` prints the stored authentication token to stdout. It threw away the error from that write, so if the write failed - a closed pipe, a full disk, stdout redirected somewhere unwritable - the command still exited 0 having printed nothing. People almost always consume this command as `TOKEN=$(gh auth token)` or pipe it into another process, so an empty string and a success exit code is the worst possible combination: the failure surfaces later, somewhere else, as a confusing auth error.

This was picked as a `tech-debt/*` run target because it is one of the `errcheck` findings from the linter backlog that `.golangci.yml` disables ("To enable later due to too many issues"), and it is one of the few where the ignored error is a real bug rather than a cosmetic one. `pkg/cmd/auth/token` had exactly one finding, so the package now reports zero.

The write is now checked and the error returned. While changing that line I also dropped the `if val != ""` guard wrapping it, which was unreachable: the function returns an error a few lines above whenever `val` is empty.

### How did you test this change?

<!--
Demonstrate the code is solid, and how you know it solves the problem in the description.
Give the exact commands you ran and their output.
If this changes command output, show it before and after. Screenshot images are preferred over pasted text.

If you leave this empty, your pull request will very likely be closed.
-->

**Sensor, before:**

```
$ golangci-lint run --no-config --default=none --enable=errcheck \
    --max-issues-per-linter=0 --max-same-issues=0 ./pkg/cmd/auth/token/...
pkg/cmd/auth/token/token.go:96:14: Error return value of `fmt.Fprintf` is not checked (errcheck)
		fmt.Fprintf(opts.IO.Out, "%s\n", val)
		           ^
1 issues:
* errcheck: 1
```

**Sensor, after:**

```
$ golangci-lint run --no-config --default=none --enable=errcheck \
    --max-issues-per-linter=0 --max-same-issues=0 ./pkg/cmd/auth/token/...
0 issues.
```

**New test is red before the fix and green after.** `TestTokenRunReturnsWriteError` swaps `ios.Out` for a writer that always fails. With `token.go` reverted to `trunk`:

```
--- FAIL: TestTokenRunReturnsWriteError (0.00s)
    	Error: An error is expected but got nil.
```

With the fix applied:

```
--- PASS: TestTokenRunReturnsWriteError (0.00s)
ok  	github.com/cli/cli/v2/pkg/cmd/auth/token	0.203s
```

**Baseline comparison.** `go test ./...` and `make lint` were captured on clean `trunk` before any edit and re-run afterwards. The set of failing test names is byte-identical before and after (`diff` of the sorted `--- FAIL:` lines is empty), so this change introduces nothing.

For the record, so nobody mistakes them for mine, these fail on clean `trunk` on the machine this ran on and are environmental:

- `git`, `internal/config`, `pkg/cmdutil` and every `pkg/cmd/auth/*` package, because the local keychain returns `******` in place of stored tokens and `safe.bareRepository = explicit` blocks the `git` test fixtures. Notably `TestTokenRun/token` and `TestTokenRun/no_token` in the package I touched are in this set, and were already failing before the change.
- `make lint` reports 3 pre-existing `govet` findings, and their paths point into a sibling git worktree rather than this checkout.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

Two other targets were examined first and abandoned, which is why the diff is this small rather than this lazy:

1. **`//nolint:bodyclose` in `pkg/httpmock/stub.go`** - looked like a stale suppression. Removing it makes the linter report the finding immediately, so it is load-bearing. Left alone.
2. **`//nolint:gosimple` in `pkg/option/option_test.go`** - the `gosimple` linter folded into `staticcheck` in golangci-lint v2, so the directive names a linter that no longer exists. But the underlying finding is real, and deciding whether to delete the directives or rename them to `staticcheck` is a judgement call about a linter this repo has not enabled. Not an unattended decision.

The skill this run follows suggests adding a scoped `.golangci.yml` exclusion to hold a cleaned package clean. That does not work for `errcheck`: it is not in the `enable` list at all, so there is nothing for an exclusion rule to narrow. No config change is included here, and the package will silently regress. Both findings are recorded in the memory file.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `pkg/cmd/auth/token/token.go`; it is a six-line diff and the whole behavioural change is there. Then `TestTokenRunReturnsWriteError` in the test file.

The one thing worth a second opinion: this makes a write failure a hard error, so `gh auth token | head -c 4` on a short-reading consumer can now exit non-zero where it previously exited 0. That is the intended behaviour and matches how the rest of the codebase treats failed writes to `Out`, but it is technically a change to the non-interactive contract on an error path, and it is your call whether that needs a note anywhere.

The remainder of the diff is the agent memory file at `.experiments/tech-debt-burndown/memory.md`, recording the abandoned targets above and the environmental test-failure noise so a future run does not rediscover either. It does not touch the human-owned Current focus section.

I have no proposal for Current focus.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
