### PR TITLE
Use reflect.Pointer instead of deprecated reflect.Ptr

### DIFF
--- a/pkg/cmdutil/json_flags.go
+++ b/pkg/cmdutil/json_flags.go
@@ -258,7 +258,7 @@ func (e *jsonExporter) Write(ios *iostreams.IOStreams, data interface{}) error {
 
 func (e *jsonExporter) exportData(v reflect.Value) interface{} {
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		if !v.IsNil() {
 			return e.exportData(v.Elem())
 		}
@@ -306,7 +306,7 @@ var emptyInterfaceType = reflect.TypeOf(sliceOfEmptyInterface).Elem()
 // need to be explicitly used.
 func StructExportData(s interface{}, fields []string) map[string]interface{} {
 	v := reflect.ValueOf(s)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -251,7 +251,7 @@ func (q Qualifiers) Map() map[string][]string {
 		}
 		value := v.Field(i)
 		switch value.Kind() {
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if value.IsNil() {
 				continue
 			}


### PR DESCRIPTION
### Description

`reflect.Ptr` has been a deprecated alias for `reflect.Pointer` since Go 1.18. This replaces the three remaining uses.

These are flagged by golangci-lint's govet `inline` analyzer, which is enabled in golangci-lint v2.12.x but **not** in v2.11.0, the version CI currently pins in `.github/workflows/lint.yml`. So this is not a live CI failure — CI is green on `trunk`. It shows up for maintainers running a newer golangci-lint locally, where `make lint` fails on a clean `trunk` while CI reports no issues.

Note that plain `go vet ./...` passes either way; bare `go vet` does not enable this analyzer.

Related: #14102 bumps the CI pin to v2.12.2. Once that lands, these three findings become real CI failures, so this PR should merge **before** it. #14102 deliberately does not duplicate this fix.

### How did you test this change?

The two golangci-lint versions run against the same unfixed tree, showing this is version skew rather than a regression:

```
$ /tmp/glci-bin/golangci-lint run ./...     # v2.11.0, the version CI pins
0 issues.
```

```
$ golangci-lint run ./...                    # v2.12.2, local install
pkg/cmdutil/json_flags.go:261:7: inline: Constant reflect.Ptr should be inlined (govet)
	case reflect.Ptr, reflect.Interface:
	     ^
pkg/cmdutil/json_flags.go:309:17: inline: Constant reflect.Ptr should be inlined (govet)
	if v.Kind() == reflect.Ptr {
	               ^
pkg/search/query.go:254:8: inline: Constant reflect.Ptr should be inlined (govet)
		case reflect.Ptr:
		     ^
3 issues:
* govet: 3
```

With this change applied, v2.12.2 reports:

```
$ make lint
golangci-lint run ./...
0 issues.
```

Tests for the affected packages:

```
$ go test ./pkg/cmdutil/... ./pkg/search/...
ok  	github.com/cli/cli/v2/pkg/search
FAIL	github.com/cli/cli/v2/pkg/cmdutil
```

The single `pkg/cmdutil` failure is `Test_CheckAuth/no_known_hosts,_no_env_auth_token`, and it is pre-existing: it fails identically on clean `trunk` with this change stashed. It is caused by local auth config in my environment and is unrelated to this diff.

### Key points

`reflect.Ptr` and `reflect.Pointer` are the same constant, so this is a pure rename with no behavior change and no new test. Existing tests in both packages already cover these code paths.

I originally wrote this up as a CI failure. It isn't — CI pins v2.11.0 and is green. The value here is removing a deprecated alias and unblocking the version bump in #14102, not fixing a broken build.

### Notes for reviewers

Three-line diff, nothing to unpack.

If you want to reproduce the finding, you need golangci-lint v2.12+; v2.11.0 will show nothing:

```
GOBIN=/tmp/glci go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
```

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
