### PR TITLE
Bump golangci-lint in CI to v2.12.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
       - go.mod
       - go.sum
       - ".github/licenses.tmpl"
+      - ".github/workflows/lint.yml"
       - "script/licenses"
   pull_request:
     paths:
@@ -15,6 +16,7 @@ on:
       - go.mod
       - go.sum
       - ".github/licenses.tmpl"
+      - ".github/workflows/lint.yml"
       - "script/licenses"
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11.0
+          version: v2.12.2
 
       # Verify that license generation succeeds for all release platforms (GOOS/GOARCH).
       # This catches issues like new dependencies with unrecognized licenses before release time.


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Depends on #14098 - please merge that first. **The failing lint check on this PR is intentional; see "Notes for reviewers".**

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

`.github/workflows/lint.yml` pins golangci-lint to `v2.11.0`. Maintainers installing it locally (for example via Homebrew) get the current release, `v2.12.2`.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @williammartin will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.