### PR TITLE
Clarify what belongs in the PR template's testing section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,9 +18,21 @@ background they need before the problem makes sense, and avoid jargon.
 ### How did you test this change?
 
 <!--
-Demonstrate the code is solid, and how you know it solves the problem in the description.
-Give the exact commands you ran and their output.
-If this changes command output, show it before and after. Screenshot images are preferred over pasted text.
+Show how you exercised the change yourself, as a user of `gh` would.
+
+Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
+coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.
+
+Use one or more of these, whichever communicates best:
+
+1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
+   in terminal output. If output changed, show it before and after.
+2. Given/When/Then scenarios. For example:
+   Given I am in a repo with no open pull requests
+   When I run `gh pr list`
+   Then I see "no open pull requests in cli/cli"
+3. A natural language walkthrough of what you did by hand, the states you covered, and what
+   you saw, including error and edge cases.
 
 If you leave this empty, your pull request will very likely be closed.
 -->


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

N/A - no related issue.

### Description

The pull request template asks "How did you test this change?" but doesn't say what a good answer looks like. In practice, agents opening PRs against this repo keep filling it in with unit test results - pasted `go test ./...` output, lists of test names, coverage numbers. That's not useful to a reviewer: CI already reports it, and it says nothing about whether the change actually behaves correctly for someone using `gh`.

This rewrites the section's guidance to state plainly that automated test output does not belong there, and to enumerate the three things that do: screenshots/GIFs of the real command, Given/When/Then scenarios, or a natural language walkthrough of what you did by hand - or a combination.

### How did you test this change?

This is a comment-only change to a Markdown template, so there is nothing to execute.

Given a contributor opens a new pull request in this repo
When GitHub prefills the body from `.github/PULL_REQUEST_TEMPLATE.md`
Then the "How did you test this change?" section shows the new guidance, with the rest of the template unchanged

I rendered the file to confirm the HTML comment block is still well-formed (opens with `<!--` and closes with `-->`), so none of the guidance leaks into the visible PR body. The body of this pull request is itself written against the new instructions, as a sanity check that the guidance is followable.

### Key points

The old wording said "Give the exact commands you ran and their output," which is arguably what invited the pasted test output in the first place. I kept the spirit of it - show your work - but moved it under the natural language and Given/When/Then options rather than leaving it as the headline instruction.

I also kept the existing "If you leave this empty, your pull request will very likely be closed" line, since that consequence hasn't changed.

The section is longer than it was. That's a deliberate tradeoff: this template is read by agents as much as by humans now, and terse guidance is exactly what got ignored.

### Notes for reviewers

Only one file changed; read the diff of `.github/PULL_REQUEST_TEMPLATE.md` top to bottom.

The main thing worth pushing back on is the example Given/When/Then - I used `gh pr list` in a repo with no open pull requests. If there's a scenario that better represents the kind of change this repo typically sees, I'm happy to swap it.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.