### PR TITLE
fix(release): reject duplicate asset filenames

### DIFF
--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -3,6 +3,7 @@ package create
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -426,6 +427,31 @@ func Test_NewCmdCreate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_NewCmdCreate_rejectsDuplicateAssetFilenamesBeforeHTTP(t *testing.T) {
+	firstDir := t.TempDir()
+	secondDir := t.TempDir()
+	first := filepath.Join(firstDir, "duplicate.zip")
+	second := filepath.Join(secondDir, "duplicate.zip")
+	require.NoError(t, os.WriteFile(first, nil, 0o644))
+	require.NoError(t, os.WriteFile(second, nil, 0o644))
+
+	ios, _, _, _ := iostreams.Test()
+	httpClientCalls := 0
+	f := &cmdutil.Factory{
+		IOStreams: ios,
+		HttpClient: func() (*http.Client, error) {
+			httpClientCalls++
+			return nil, errors.New("unexpected HTTP client call")
+		},
+	}
+	cmd := NewCmdCreate(f, nil)
+	cmd.SetArgs([]string{"v1.2.3", first + "#Linux", second + "#macOS"})
+
+	_, err := cmd.ExecuteC()
+	require.EqualError(t, err, "duplicate release asset filenames are not supported: duplicate.zip")
+	assert.Equal(t, 0, httpClientCalls)
 }
 
 func Test_createRun(t *testing.T) {

--- a/pkg/cmd/release/shared/upload.go
+++ b/pkg/cmd/release/shared/upload.go
@@ -107,7 +107,7 @@ func validateUniqueAssetNames(assets []*AssetForUpload) error {
 	return fmt.Errorf("duplicate release asset filenames are not supported: %s", strings.Join(names, ", "))
 }
 
-// SanitizeFileName returns the filename used by GitHub for a release asset.
+// SanitizeFileName approximates the filename normalization GitHub applies to release assets.
 func SanitizeFileName(name string) string {
 	value := text.RemoveDiacritics(name)
 	// Stripped all non-ascii characters, provide default name.

--- a/pkg/cmd/release/shared/upload.go
+++ b/pkg/cmd/release/shared/upload.go
@@ -4,18 +4,22 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/safeurl"
+	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"golang.org/x/sync/errgroup"
 )
@@ -73,7 +77,59 @@ func AssetsFromArgs(args []string) (assets []*AssetForUpload, err error) {
 			MIMEType: typeForFilename(fi.Name()),
 		})
 	}
+	if err := validateUniqueAssetNames(assets); err != nil {
+		return nil, err
+	}
 	return
+}
+
+func validateUniqueAssetNames(assets []*AssetForUpload) error {
+	seen := make(map[string]struct{}, len(assets))
+	duplicates := make(map[string]struct{})
+	for _, asset := range assets {
+		name := SanitizeFileName(asset.Name)
+		if _, ok := seen[name]; ok {
+			duplicates[name] = struct{}{}
+		}
+		seen[name] = struct{}{}
+	}
+
+	if len(duplicates) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(duplicates))
+	for name := range duplicates {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return fmt.Errorf("duplicate release asset filenames are not supported: %s", strings.Join(names, ", "))
+}
+
+// SanitizeFileName returns the filename used by GitHub for a release asset.
+func SanitizeFileName(name string) string {
+	value := text.RemoveDiacritics(name)
+	// Stripped all non-ascii characters, provide default name.
+	if strings.HasPrefix(value, ".") {
+		value = "default" + value
+	}
+
+	// Replace special characters with the separator.
+	value = regexp.MustCompile(`(?i)[^a-z0-9\-_\+@]+`).ReplaceAllLiteralString(value, ".")
+
+	// No more than one of the separator in a row.
+	value = regexp.MustCompile(`\.{2,}`).ReplaceAllLiteralString(value, ".")
+
+	// Remove leading/trailing separator.
+	value = strings.Trim(value, ".")
+
+	// Just file extension left, add default name.
+	if name != value && !strings.Contains(value, ".") {
+		value = "default." + value
+	}
+
+	return value
 }
 
 func typeForFilename(fn string) string {

--- a/pkg/cmd/release/shared/upload_test.go
+++ b/pkg/cmd/release/shared/upload_test.go
@@ -77,6 +77,60 @@ func Test_typeForFilename(t *testing.T) {
 	}
 }
 
+func Test_validateUniqueAssetNames(t *testing.T) {
+	tests := []struct {
+		name   string
+		assets []*AssetForUpload
+		want   string
+	}{
+		{
+			name: "unique",
+			assets: []*AssetForUpload{
+				{Name: "foo.zip"},
+				{Name: "bar.zip"},
+			},
+		},
+		{
+			name: "duplicate",
+			assets: []*AssetForUpload{
+				{Name: "foo.zip"},
+				{Name: "foo.zip"},
+			},
+			want: "duplicate release asset filenames are not supported: foo.zip",
+		},
+		{
+			name: "sanitized collision",
+			assets: []*AssetForUpload{
+				{Name: "foo bar.zip"},
+				{Name: "foo.bar.zip"},
+			},
+			want: "duplicate release asset filenames are not supported: foo.bar.zip",
+		},
+		{
+			name: "multiple duplicate groups are sorted",
+			assets: []*AssetForUpload{
+				{Name: "zeta.tar.gz"},
+				{Name: "alpha.zip"},
+				{Name: "alpha.zip"},
+				{Name: "zeta.tar.gz"},
+			},
+			want: "duplicate release asset filenames are not supported: alpha.zip, zeta.tar.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validateUniqueAssetNames(tt.assets); got != nil {
+				if got.Error() != tt.want {
+					t.Errorf("validateUniqueAssetNames() error = %q, want %q", got, tt.want)
+				}
+			} else if tt.want != "" {
+				t.Errorf("validateUniqueAssetNames() error = nil, want %q", tt.want)
+			}
+		})
+	}
+}
+
 func Test_uploadWithDelete_retry(t *testing.T) {
 	retryInterval = 0
 	ctx := context.Background()

--- a/pkg/cmd/release/shared/upload_test.go
+++ b/pkg/cmd/release/shared/upload_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/internal/safeurl"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_typeForFilename(t *testing.T) {
@@ -73,6 +74,51 @@ func Test_typeForFilename(t *testing.T) {
 			if got := typeForFilename(tt.file); got != tt.want {
 				t.Errorf("typeForFilename() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_SanitizeFileName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "foo",
+			expected: "foo",
+		},
+		{
+			name:     "foo bar",
+			expected: "foo.bar",
+		},
+		{
+			name:     ".foo",
+			expected: "default.foo",
+		},
+		{
+			name:     "Foo bar",
+			expected: "Foo.bar",
+		},
+		{
+			name:     "Hello, दुनिया",
+			expected: "default.Hello",
+		},
+		{
+			name:     "this+has+plusses.jpg",
+			expected: "this+has+plusses.jpg",
+		},
+		{
+			name:     "this@has@at@signs.jpg",
+			expected: "this@has@at@signs.jpg",
+		},
+		{
+			name:     "façade.exposé",
+			expected: "facade.expose",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, SanitizeFileName(tt.name))
 		})
 	}
 }

--- a/pkg/cmd/release/upload/upload.go
+++ b/pkg/cmd/release/upload/upload.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -93,7 +92,7 @@ func uploadRun(opts *UploadOptions) error {
 
 	var existingNames []string
 	for _, a := range opts.Assets {
-		sanitizedFileName := sanitizeFileName(a.Name)
+		sanitizedFileName := shared.SanitizeFileName(a.Name)
 		for _, ea := range release.Assets {
 			if ea.Name == sanitizedFileName {
 				a.ExistingURL = safeurl.NewImmutableSafeURL(ea.APIURL)
@@ -127,31 +126,4 @@ func uploadRun(opts *UploadOptions) error {
 	}
 
 	return nil
-}
-
-// this method attempts to mimic the same functionality on the client that the platform does on
-// uploaded assets in order to allow the --clobber logic work correctly, since that feature is
-// one that only exists in the client
-func sanitizeFileName(name string) string {
-	value := text.RemoveDiacritics(name)
-	// Stripped all non-ascii characters, provide default name.
-	if strings.HasPrefix(value, ".") {
-		value = "default" + value
-	}
-
-	// Replace special characters with the separator
-	value = regexp.MustCompile(`(?i)[^a-z0-9\-_\+@]+`).ReplaceAllLiteralString(value, ".")
-
-	// No more than one of the separator in a row.
-	value = regexp.MustCompile(`\.{2,}`).ReplaceAllLiteralString(value, ".")
-
-	// Remove leading/trailing separator.
-	value = strings.Trim(value, ".")
-
-	// Just file extension left, add default name.
-	if name != value && !strings.Contains(value, ".") {
-		value = "default." + value
-	}
-
-	return value
 }

--- a/pkg/cmd/release/upload/upload_test.go
+++ b/pkg/cmd/release/upload/upload_test.go
@@ -7,57 +7,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/cli/cli/v2/pkg/cmd/release/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func Test_SanitizeFileName(t *testing.T) {
-	tests := []struct {
-		name     string
-		expected string
-	}{
-		{
-			name:     "foo",
-			expected: "foo",
-		},
-		{
-			name:     "foo bar",
-			expected: "foo.bar",
-		},
-		{
-			name:     ".foo",
-			expected: "default.foo",
-		},
-		{
-			name:     "Foo bar",
-			expected: "Foo.bar",
-		},
-		{
-			name:     "Hello, दुनिया",
-			expected: "default.Hello",
-		},
-		{
-			name:     "this+has+plusses.jpg",
-			expected: "this+has+plusses.jpg",
-		},
-		{
-			name:     "this@has@at@signs.jpg",
-			expected: "this@has@at@signs.jpg",
-		},
-		{
-			name:     "façade.exposé",
-			expected: "facade.expose",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, shared.SanitizeFileName(tt.name))
-		})
-	}
-}
 
 func Test_NewCmdUpload_rejectsDuplicateAssetFilenames(t *testing.T) {
 	firstDir := t.TempDir()

--- a/pkg/cmd/release/upload/upload_test.go
+++ b/pkg/cmd/release/upload/upload_test.go
@@ -1,9 +1,17 @@
 package upload
 
 import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/cli/cli/v2/pkg/cmd/release/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_SanitizeFileName(t *testing.T) {
@@ -46,7 +54,32 @@ func Test_SanitizeFileName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, sanitizeFileName(tt.name))
+			assert.Equal(t, tt.expected, shared.SanitizeFileName(tt.name))
 		})
 	}
+}
+
+func Test_NewCmdUpload_rejectsDuplicateAssetFilenames(t *testing.T) {
+	firstDir := t.TempDir()
+	secondDir := t.TempDir()
+	first := filepath.Join(firstDir, "duplicate.zip")
+	second := filepath.Join(secondDir, "duplicate.zip")
+	require.NoError(t, os.WriteFile(first, nil, 0o644))
+	require.NoError(t, os.WriteFile(second, nil, 0o644))
+
+	ios, _, _, _ := iostreams.Test()
+	httpClientCalls := 0
+	f := &cmdutil.Factory{
+		IOStreams: ios,
+		HttpClient: func() (*http.Client, error) {
+			httpClientCalls++
+			return nil, errors.New("unexpected HTTP client call")
+		},
+	}
+	cmd := NewCmdUpload(f, nil)
+	cmd.SetArgs([]string{"v1.2.3", first + "#Linux", second + "#macOS"})
+
+	_, err := cmd.ExecuteC()
+	require.EqualError(t, err, "duplicate release asset filenames are not supported: duplicate.zip")
+	assert.Equal(t, 0, httpClientCalls)
 }


### PR DESCRIPTION
## Summary

- reject duplicate release asset filenames before creating a release or uploading assets
- report all duplicate filenames in deterministic order
- use the existing client-side approximation of GitHub's release asset filename normalization when validating names

The validation is shared by `gh release create` and `gh release upload`, and labels do not change the filename used for duplicate detection.

Fixes #10792

## Tests

- `go test ./pkg/cmd/release/shared ./pkg/cmd/release/create ./pkg/cmd/release/upload`
- `go test ./pkg/cmd/release/...`
- `make lint`
- `go run ./script/build.go bin/gh`
- `git diff --check`

`go test ./...` was also attempted. It encountered an unrelated existing pager expectation failure in `internal/ghcmd`, then did not complete because an `internal/prompter` test hung in this environment.
