### PR TITLE
Allow public extension installs past SAML enforcement

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -176,12 +177,24 @@ func ExtractHeader(name string, dest *string) func(http.RoundTripper) http.Round
 	return func(tr http.RoundTripper) http.RoundTripper {
 		return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
 			res, err := tr.RoundTrip(req)
-			if err == nil {
+			if err == nil && req.Context().Value(skipHeaderExtractionKey(name)) == nil {
 				if value := res.Header.Get(name); value != "" {
 					*dest = value
 				}
 			}
 			return res, err
+		}}
+	}
+}
+
+type skipHeaderExtractionKey string
+
+// SkipHeaderExtraction marks requests so ExtractHeader ignores the named response header.
+func SkipHeaderExtraction(name string) func(http.RoundTripper) http.RoundTripper {
+	return func(tr http.RoundTripper) http.RoundTripper {
+		return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			ctx := context.WithValue(req.Context(), skipHeaderExtractionKey(name), true)
+			return tr.RoundTrip(req.Clone(ctx))
 		}}
 	}
 }

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -209,6 +209,33 @@ func TestNewHTTPClient(t *testing.T) {
 	}
 }
 
+func TestSkipHeaderExtraction(t *testing.T) {
+	var extracted string
+	headers := http.Header{}
+	headers.Set("X-GitHub-SSO", "required; url=https://github.com/orgs/OWNER/sso")
+	base := funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     headers,
+			Body:       http.NoBody,
+			Request:    req,
+		}, nil
+	}}
+	transport := SkipHeaderExtraction("X-GitHub-SSO")(
+		ExtractHeader("X-GitHub-SSO", &extracted)(base),
+	)
+	client := &http.Client{Transport: transport}
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/OWNER/REPO", nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Empty(t, extracted)
+	assert.NotEmpty(t, resp.Header.Get("X-GitHub-SSO"))
+}
+
 func TestHTTPClientRedirectAuthenticationHeaderHandling(t *testing.T) {
 	var request *http.Request
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -231,13 +231,14 @@ func Main() exitCode {
 		}
 
 		var httpErr api.HTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 401 {
+		hasHTTPError := errors.As(err, &httpErr)
+		if hasHTTPError && httpErr.StatusCode == 401 {
 			authCommand := "gh auth login"
 			if cfg, cfgErr := cmdFactory.Config(); cfgErr == nil {
 				authCommand = authRecoveryCommand(cfg, httpErr)
 			}
 			fmt.Fprintf(stderr, "Try authenticating with:  %s\n", authCommand)
-		} else if u := factory.SSOURL(); u != "" {
+		} else if u := ssoRecoveryURL(httpErr, hasHTTPError); u != "" {
 			// handles organization SAML enforcement error
 			fmt.Fprintf(stderr, "Authorize in your web browser:  %s\n", u)
 		} else if msg := httpErr.ScopesSuggestion(); msg != "" {
@@ -312,6 +313,16 @@ func authRecoveryCommand(cfg gh.Config, httpErr api.HTTPError) string {
 	}
 
 	return fmt.Sprintf("gh auth login -h %s", hostname)
+}
+
+func ssoRecoveryURL(httpErr api.HTTPError, hasHTTPError bool) string {
+	if hasHTTPError && httpErr.HTTPError != nil {
+		return factory.SSOURLFromHeader(httpErr.Headers.Get("X-GitHub-SSO"))
+	}
+	if hasHTTPError {
+		return ""
+	}
+	return factory.SSOURL()
 }
 
 func checkForUpdate(ctx context.Context, f *cmdutil.Factory, currentVersion string) (*update.ReleaseInfo, error) {

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -482,6 +483,23 @@ func Test_mightBeGHESUser(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_ssoRecoveryURL(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-GitHub-SSO", "required; url=https://github.com/orgs/OWNER/sso?authorization_request=TOKEN")
+	httpErr := api.HTTPError{
+		HTTPError: &ghAPI.HTTPError{
+			Headers: headers,
+		},
+	}
+
+	assert.Equal(
+		t,
+		"https://github.com/orgs/OWNER/sso?authorization_request=TOKEN",
+		ssoRecoveryURL(httpErr, true),
+	)
+	assert.Empty(t, ssoRecoveryURL(api.HTTPError{}, true))
 }
 
 func pagerConfig() gh.Config {

--- a/pkg/cmd/extension/extension.go
+++ b/pkg/cmd/extension/extension.go
@@ -25,19 +25,22 @@ const (
 )
 
 type Extension struct {
-	path       string
-	kind       ExtensionKind
-	gitClient  gitClient
-	httpClient *http.Client
+	path            string
+	kind            ExtensionKind
+	gitClient       gitClient
+	httpClient      *http.Client
+	plainHTTPClient *http.Client
 
 	mu sync.RWMutex
 
 	// These fields get resolved dynamically:
-	url            string
-	isPinned       *bool
-	currentVersion string
-	latestVersion  string
-	owner          string
+	url                   string
+	isPinned              *bool
+	currentVersion        string
+	latestVersion         string
+	latestVersionErr      error
+	latestVersionResolved bool
+	owner                 string
 }
 
 func (e *Extension) Name() string {
@@ -114,37 +117,46 @@ func (e *Extension) CurrentVersion() string {
 }
 
 func (e *Extension) LatestVersion() string {
+	latestVersion, _ := e.latestVersionWithError()
+	return latestVersion
+}
+
+func (e *Extension) latestVersionWithError() (string, error) {
 	e.mu.RLock()
-	if e.latestVersion != "" {
+	if e.latestVersion != "" || e.latestVersionResolved {
 		defer e.mu.RUnlock()
-		return e.latestVersion
+		return e.latestVersion, e.latestVersionErr
 	}
 	e.mu.RUnlock()
 
 	var latestVersion string
+	var resolveErr error
 	switch e.kind {
 	case LocalKind:
 	case BinaryKind:
-		repo, err := ghrepo.FromFullName(e.URL())
-		if err != nil {
-			return ""
+		var repo ghrepo.Interface
+		repo, resolveErr = ghrepo.FromFullName(e.URL())
+		if resolveErr == nil {
+			var release *release
+			release, _, resolveErr = fetchLatestReleaseWithFallback(e.httpClient, e.plainHTTPClient, repo)
+			if resolveErr == nil {
+				latestVersion = release.Tag
+			}
 		}
-		release, err := fetchLatestRelease(e.httpClient, repo)
-		if err != nil {
-			return ""
-		}
-		latestVersion = release.Tag
 	case GitKind:
-		if lsRemote, err := e.gitClient.CommandOutput([]string{"ls-remote", "origin", "HEAD"}); err == nil {
+		var lsRemote []byte
+		if lsRemote, resolveErr = e.gitClient.CommandOutput([]string{"ls-remote", "origin", "HEAD"}); resolveErr == nil {
 			latestVersion = string(bytes.SplitN(lsRemote, []byte("\t"), 2)[0])
 		}
 	}
 
 	e.mu.Lock()
 	e.latestVersion = latestVersion
+	e.latestVersionErr = resolveErr
+	e.latestVersionResolved = true
 	e.mu.Unlock()
 
-	return e.latestVersion
+	return latestVersion, resolveErr
 }
 
 func (e *Extension) IsPinned() bool {

--- a/pkg/cmd/extension/extension.go
+++ b/pkg/cmd/extension/extension.go
@@ -40,6 +40,8 @@ type Extension struct {
 	latestVersion         string
 	latestVersionErr      error
 	latestVersionResolved bool
+	latestRelease         *release
+	latestReleaseClient   *http.Client
 	owner                 string
 }
 
@@ -131,16 +133,17 @@ func (e *Extension) latestVersionWithError() (string, error) {
 
 	var latestVersion string
 	var resolveErr error
+	var latestRelease *release
+	var latestReleaseClient *http.Client
 	switch e.kind {
 	case LocalKind:
 	case BinaryKind:
 		var repo ghrepo.Interface
 		repo, resolveErr = ghrepo.FromFullName(e.URL())
 		if resolveErr == nil {
-			var release *release
-			release, _, resolveErr = fetchLatestReleaseWithFallback(e.httpClient, e.plainHTTPClient, repo)
+			latestRelease, latestReleaseClient, resolveErr = fetchLatestReleaseWithFallback(e.httpClient, e.plainHTTPClient, repo)
 			if resolveErr == nil {
-				latestVersion = release.Tag
+				latestVersion = latestRelease.Tag
 			}
 		}
 	case GitKind:
@@ -153,10 +156,20 @@ func (e *Extension) latestVersionWithError() (string, error) {
 	e.mu.Lock()
 	e.latestVersion = latestVersion
 	e.latestVersionErr = resolveErr
-	e.latestVersionResolved = true
+	e.latestVersionResolved = e.kind != GitKind || resolveErr == nil
+	e.latestRelease = latestRelease
+	e.latestReleaseClient = latestReleaseClient
 	e.mu.Unlock()
 
 	return latestVersion, resolveErr
+}
+
+func (e *Extension) latestReleaseWithError() (*release, *http.Client, error) {
+	_, err := e.latestVersionWithError()
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.latestRelease, e.latestReleaseClient, err
 }
 
 func (e *Extension) IsPinned() bool {

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -143,6 +143,12 @@ func fetchLatestRelease(httpClient *http.Client, baseRepo ghrepo.Interface) (*re
 	return &r, nil
 }
 
+func fetchLatestReleaseWithFallback(httpClient, plainHTTPClient *http.Client, baseRepo ghrepo.Interface) (*release, *http.Client, error) {
+	return fetchReleaseWithFallback(httpClient, plainHTTPClient, baseRepo, func(client *http.Client) (*release, error) {
+		return fetchLatestRelease(client, baseRepo)
+	})
+}
+
 // fetchReleaseFromTag finds release by tag name for a repository
 func fetchReleaseFromTag(httpClient *http.Client, baseRepo ghrepo.Interface, tagName string) (*release, error) {
 	path, err := safeurl.JoinPath("repos", baseRepo.RepoOwner(), baseRepo.RepoName(), "releases", "tags", tagName)
@@ -169,6 +175,38 @@ func fetchReleaseFromTag(httpClient *http.Client, baseRepo ghrepo.Interface, tag
 	}
 
 	return &r, nil
+}
+
+func fetchReleaseFromTagWithFallback(httpClient, plainHTTPClient *http.Client, baseRepo ghrepo.Interface, tagName string) (*release, *http.Client, error) {
+	return fetchReleaseWithFallback(httpClient, plainHTTPClient, baseRepo, func(client *http.Client) (*release, error) {
+		return fetchReleaseFromTag(client, baseRepo, tagName)
+	})
+}
+
+func fetchReleaseWithFallback(
+	httpClient, plainHTTPClient *http.Client,
+	repo ghrepo.Interface,
+	fetch func(*http.Client) (*release, error),
+) (*release, *http.Client, error) {
+	r, err := fetch(httpClient)
+	if err == nil || plainHTTPClient == nil || !isSAMLProtectedError(err) {
+		return r, httpClient, err
+	}
+
+	isPublic, publicCheckErr := repoExists(plainHTTPClient, repo)
+	if publicCheckErr != nil || !isPublic {
+		return nil, httpClient, err
+	}
+
+	r, err = fetch(plainHTTPClient)
+	return r, plainHTTPClient, err
+}
+
+func isSAMLProtectedError(err error) bool {
+	var httpErr api.HTTPError
+	return errors.As(err, &httpErr) &&
+		httpErr.StatusCode == http.StatusForbidden &&
+		httpErr.Headers.Get("X-GitHub-SSO") != ""
 }
 
 // fetchCommitSHA finds full commit SHA from a target ref in a repo

--- a/pkg/cmd/extension/http_test.go
+++ b/pkg/cmd/extension/http_test.go
@@ -35,6 +35,16 @@ func requireExtensionHTTPError(t *testing.T, err error, status int) {
 	assert.Contains(t, err.Error(), fmt.Sprintf("HTTP %d", status))
 }
 
+func samlProtectedResponse() httpmock.Responder {
+	return httpmock.WithHeader(
+		httpmock.StatusJSONResponse(http.StatusForbidden, map[string]string{
+			"message": "Resource protected by organization SAML enforcement.",
+		}),
+		"X-GitHub-SSO",
+		"required; url=https://github.com/orgs/OWNER/sso?authorization_request=TOKEN",
+	)
+}
+
 func TestRepoExists(t *testing.T) {
 	repo := ghrepo.New("OWNER", "REPO")
 
@@ -181,6 +191,107 @@ func TestFetchLatestRelease(t *testing.T) {
 			require.EqualError(t, err, "unexpected end of JSON input")
 		})
 	}
+}
+
+func TestFetchLatestReleaseWithFallback(t *testing.T) {
+	repo := ghrepo.New("OWNER", "REPO")
+
+	t.Run("public repository", func(t *testing.T) {
+		authReg := &httpmock.Registry{}
+		defer authReg.Verify(t)
+		authReg.Register(
+			httpmock.REST(http.MethodGet, "repos/OWNER/REPO/releases/latest"),
+			samlProtectedResponse(),
+		)
+		authClient := &http.Client{Transport: authReg}
+
+		plainReg := &httpmock.Registry{}
+		defer plainReg.Verify(t)
+		plainReg.Register(
+			httpmock.REST(http.MethodGet, "repos/OWNER/REPO"),
+			httpmock.JSONResponse(map[string]string{"visibility": "public"}),
+		)
+		plainReg.Register(
+			httpmock.REST(http.MethodGet, "repos/OWNER/REPO/releases/latest"),
+			httpmock.JSONResponse(release{Tag: "v1.2.3"}),
+		)
+		plainClient := &http.Client{Transport: plainReg}
+
+		got, selectedClient, err := fetchLatestReleaseWithFallback(authClient, plainClient, repo)
+
+		require.NoError(t, err)
+		assert.Equal(t, "v1.2.3", got.Tag)
+		assert.Same(t, plainClient, selectedClient)
+	})
+
+	t.Run("public repository without a release", func(t *testing.T) {
+		authReg := &httpmock.Registry{}
+		defer authReg.Verify(t)
+		authReg.Register(
+			httpmock.REST(http.MethodGet, "repos/OWNER/REPO/releases/latest"),
+			samlProtectedResponse(),
+		)
+		authClient := &http.Client{Transport: authReg}
+
+		plainReg := &httpmock.Registry{}
+		defer plainReg.Verify(t)
+		plainReg.Register(
+			httpmock.REST(http.MethodGet, "repos/OWNER/REPO"),
+			httpmock.JSONResponse(map[string]string{"visibility": "public"}),
+		)
+		plainReg.Register(
+			httpmock.REST(http.MethodGet, "repos/OWNER/REPO/releases/latest"),
+			httpmock.StatusJSONResponse(http.StatusNotFound, map[string]string{"message": "Not Found"}),
+		)
+		plainClient := &http.Client{Transport: plainReg}
+
+		got, selectedClient, err := fetchLatestReleaseWithFallback(authClient, plainClient, repo)
+
+		assert.Nil(t, got)
+		require.ErrorIs(t, err, releaseNotFoundErr)
+		assert.Same(t, plainClient, selectedClient)
+	})
+
+	t.Run("private repository", func(t *testing.T) {
+		authReg := &httpmock.Registry{}
+		defer authReg.Verify(t)
+		authReg.Register(
+			httpmock.REST(http.MethodGet, "repos/OWNER/REPO/releases/latest"),
+			samlProtectedResponse(),
+		)
+		authClient := &http.Client{Transport: authReg}
+
+		plainReg := &httpmock.Registry{}
+		defer plainReg.Verify(t)
+		plainReg.Register(
+			httpmock.REST(http.MethodGet, "repos/OWNER/REPO"),
+			httpmock.StatusJSONResponse(http.StatusNotFound, map[string]string{"message": "Not Found"}),
+		)
+		plainClient := &http.Client{Transport: plainReg}
+
+		got, selectedClient, err := fetchLatestReleaseWithFallback(authClient, plainClient, repo)
+
+		assert.Nil(t, got)
+		requireExtensionHTTPError(t, err, http.StatusForbidden)
+		assert.Same(t, authClient, selectedClient)
+	})
+
+	t.Run("non-SAML forbidden response", func(t *testing.T) {
+		authReg := &httpmock.Registry{}
+		defer authReg.Verify(t)
+		authReg.Register(
+			httpmock.REST(http.MethodGet, "repos/OWNER/REPO/releases/latest"),
+			httpmock.StatusJSONResponse(http.StatusForbidden, map[string]string{"message": "Forbidden"}),
+		)
+		authClient := &http.Client{Transport: authReg}
+		plainClient := &http.Client{Transport: &httpmock.Registry{}}
+
+		got, selectedClient, err := fetchLatestReleaseWithFallback(authClient, plainClient, repo)
+
+		assert.Nil(t, got)
+		requireExtensionHTTPError(t, err, http.StatusForbidden)
+		assert.Same(t, authClient, selectedClient)
+	})
 }
 
 func TestFetchReleaseFromTag(t *testing.T) {

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -259,19 +259,24 @@ type binManifest struct {
 
 // Install installs an extension from repo, and pins to commitish if provided
 func (m *Manager) Install(repo ghrepo.Interface, target string) error {
-	isBin, client, err := isBinExtension(m.client, m.plainClient, repo)
+	isBin, latestRelease, client, err := isBinExtension(m.client, m.plainClient, repo)
 	if err != nil {
 		if errors.Is(err, releaseNotFoundErr) {
-			if ok, err := repoExists(client, repo); err != nil {
-				return err
-			} else if !ok {
-				return repositoryNotFoundErr
+			if client != m.plainClient || m.plainClient == nil {
+				if ok, err := repoExists(client, repo); err != nil {
+					return err
+				} else if !ok {
+					return repositoryNotFoundErr
+				}
 			}
 		} else {
 			return fmt.Errorf("could not check for binary extension: %w", err)
 		}
 	}
 	if isBin {
+		if target == "" {
+			return m.installBinFromRelease(repo, target, latestRelease, client)
+		}
 		return m.installBinWithClient(repo, target, client)
 	}
 
@@ -309,6 +314,10 @@ func (m *Manager) installBinWithClient(repo ghrepo.Interface, target string, cli
 		return err
 	}
 
+	return m.installBinFromRelease(repo, target, r, client)
+}
+
+func (m *Manager) installBinFromRelease(repo ghrepo.Interface, target string, r *release, client *http.Client) error {
 	platform, ext := m.platform()
 	isMacARM := platform == "darwin-arm64"
 	trueARMBinary := false
@@ -361,15 +370,14 @@ func (m *Manager) installBinWithClient(repo ghrepo.Interface, target string, cli
 	}
 
 	targetDir := filepath.Join(m.installDir(), name)
-	if err = os.MkdirAll(targetDir, 0755); err != nil {
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		return fmt.Errorf("failed to create installation directory: %w", err)
 	}
 
 	binPath := filepath.Join(targetDir, name)
 	binPath += ext
 
-	err = downloadAsset(client, safeurl.NewImmutableSafeURL(asset.APIURL), binPath)
-	if err != nil {
+	if err := downloadAsset(client, safeurl.NewImmutableSafeURL(asset.APIURL), binPath); err != nil {
 		return fmt.Errorf("failed to download asset %s: %w", asset.Name, err)
 	}
 	if trueARMBinary {
@@ -384,7 +392,7 @@ func (m *Manager) installBinWithClient(repo ghrepo.Interface, target string, cli
 		Host:     repo.RepoHost(),
 		Path:     binPath,
 		Tag:      r.Tag,
-		IsPinned: isPinned,
+		IsPinned: target != "",
 	}
 
 	bs, err := yaml.Marshal(manifest)
@@ -493,9 +501,13 @@ func (m *Manager) Upgrade(name string, force bool) error {
 			return localExtensionUpgradeError
 		}
 		// For single extensions manually retrieve latest version since we forgo doing it during list.
-		latestVersion, err := f.latestVersionWithError()
-		if err != nil {
-			return fmt.Errorf("unable to retrieve latest version for extension %q: %w", name, err)
+		latestVersion := f.LatestVersion()
+		if f.IsBinary() {
+			var err error
+			latestVersion, err = f.latestVersionWithError()
+			if err != nil {
+				return fmt.Errorf("unable to retrieve latest version for extension %q: %w", name, err)
+			}
 		}
 		if latestVersion == "" {
 			return fmt.Errorf("unable to retrieve latest version for extension %q", name)
@@ -514,11 +526,15 @@ func (m *Manager) upgradeExtensions(exts []*Extension, force bool) error {
 	var failed bool
 	for _, f := range exts {
 		fmt.Fprintf(m.io.Out, "[%*s]: ", longestExtName, f.Name())
-		latestVersion, latestVersionErr := f.latestVersionWithError()
-		if latestVersionErr != nil {
-			failed = true
-			fmt.Fprintf(m.io.Out, "%s\n", latestVersionErr)
-			continue
+		latestVersion := f.LatestVersion()
+		if f.IsBinary() {
+			var latestVersionErr error
+			latestVersion, latestVersionErr = f.latestVersionWithError()
+			if latestVersionErr != nil {
+				failed = true
+				fmt.Fprintf(m.io.Out, "%s\n", latestVersionErr)
+				continue
+			}
 		}
 		currentVersion := displayExtensionVersion(f, f.CurrentVersion())
 		err := m.upgradeExtension(f, force)
@@ -560,16 +576,17 @@ func (m *Manager) upgradeExtension(ext *Extension, force bool) error {
 	} else {
 		// Check if git extension has changed to a binary extension
 		var isBin bool
+		var latestRelease *release
 		var client *http.Client
 		repo, repoErr := repoFromPath(m.gitClient, filepath.Join(ext.Path(), ".."))
 		if repoErr == nil {
-			isBin, client, _ = isBinExtension(m.client, m.plainClient, repo)
+			isBin, latestRelease, client, _ = isBinExtension(m.client, m.plainClient, repo)
 		}
 		if isBin {
 			if err := m.Remove(ext.Name()); err != nil {
 				return fmt.Errorf("failed to migrate to new precompiled extension format: %w", err)
 			}
-			return m.installBinWithClient(repo, "", client)
+			return m.installBinFromRelease(repo, "", latestRelease, client)
 		}
 		err = m.upgradeGitExtension(ext, force)
 	}
@@ -600,6 +617,15 @@ func (m *Manager) upgradeBinExtension(ext *Extension) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse URL %s: %w", ext.URL(), err)
 	}
+
+	latestRelease, client, err := ext.latestReleaseWithError()
+	if err != nil {
+		return err
+	}
+	if latestRelease != nil && client != nil {
+		return m.installBinFromRelease(repo, "", latestRelease, client)
+	}
+
 	return m.installBin(repo, "")
 }
 
@@ -773,8 +799,7 @@ func readPathFromFile(path string) (string, error) {
 	return strings.TrimSpace(string(b[:n])), err
 }
 
-func isBinExtension(client, plainClient *http.Client, repo ghrepo.Interface) (isBin bool, selectedClient *http.Client, err error) {
-	var r *release
+func isBinExtension(client, plainClient *http.Client, repo ghrepo.Interface) (isBin bool, r *release, selectedClient *http.Client, err error) {
 	r, selectedClient, err = fetchLatestReleaseWithFallback(client, plainClient, repo)
 	if err != nil {
 		return

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -43,17 +43,18 @@ func (e *ErrExtensionExecutableNotFound) Error() string {
 const darwinAmd64 = "darwin-amd64"
 
 type Manager struct {
-	dataDir    func() string
-	updateDir  func() string
-	lookPath   func(string) (string, error)
-	findSh     func() (string, error)
-	newCommand func(string, ...string) *exec.Cmd
-	platform   func() (string, string)
-	client     *http.Client
-	gitClient  gitClient
-	config     gh.Config
-	io         *iostreams.IOStreams
-	dryRunMode bool
+	dataDir     func() string
+	updateDir   func() string
+	lookPath    func(string) (string, error)
+	findSh      func() (string, error)
+	newCommand  func(string, ...string) *exec.Cmd
+	platform    func() (string, string)
+	client      *http.Client
+	plainClient *http.Client
+	gitClient   gitClient
+	config      gh.Config
+	io          *iostreams.IOStreams
+	dryRunMode  bool
 }
 
 func NewManager(ios *iostreams.IOStreams, gc *git.Client) *Manager {
@@ -83,6 +84,11 @@ func (m *Manager) SetConfig(cfg gh.Config) {
 
 func (m *Manager) SetClient(client *http.Client) {
 	m.client = client
+}
+
+// SetPlainClient sets the client used to access public extension repositories without authentication.
+func (m *Manager) SetPlainClient(client *http.Client) {
+	m.plainClient = client
 }
 
 func (m *Manager) EnableDryRunMode() {
@@ -162,9 +168,10 @@ func (m *Manager) list(includeMetadata bool) ([]*Extension, error) {
 		if f.IsDir() {
 			if _, err := os.Stat(filepath.Join(dir, f.Name(), manifestName)); err == nil {
 				results = append(results, &Extension{
-					path:       filepath.Join(dir, f.Name(), f.Name()),
-					kind:       BinaryKind,
-					httpClient: m.client,
+					path:            filepath.Join(dir, f.Name(), f.Name()),
+					kind:            BinaryKind,
+					httpClient:      m.client,
+					plainHTTPClient: m.plainClient,
 				})
 			} else {
 				results = append(results, &Extension{
@@ -252,10 +259,10 @@ type binManifest struct {
 
 // Install installs an extension from repo, and pins to commitish if provided
 func (m *Manager) Install(repo ghrepo.Interface, target string) error {
-	isBin, err := isBinExtension(m.client, repo)
+	isBin, client, err := isBinExtension(m.client, m.plainClient, repo)
 	if err != nil {
 		if errors.Is(err, releaseNotFoundErr) {
-			if ok, err := repoExists(m.client, repo); err != nil {
+			if ok, err := repoExists(client, repo); err != nil {
 				return err
 			} else if !ok {
 				return repositoryNotFoundErr
@@ -265,10 +272,10 @@ func (m *Manager) Install(repo ghrepo.Interface, target string) error {
 		}
 	}
 	if isBin {
-		return m.installBin(repo, target)
+		return m.installBinWithClient(repo, target, client)
 	}
 
-	hs, err := hasScript(m.client, repo)
+	hs, err := hasScript(client, repo)
 	if err != nil {
 		return err
 	}
@@ -280,13 +287,23 @@ func (m *Manager) Install(repo ghrepo.Interface, target string) error {
 }
 
 func (m *Manager) installBin(repo ghrepo.Interface, target string) error {
+	return m.installBinWithClient(repo, target, nil)
+}
+
+func (m *Manager) installBinWithClient(repo ghrepo.Interface, target string, client *http.Client) error {
 	var r *release
 	var err error
 	isPinned := target != ""
-	if isPinned {
-		r, err = fetchReleaseFromTag(m.client, repo, target)
+	if client == nil {
+		if isPinned {
+			r, client, err = fetchReleaseFromTagWithFallback(m.client, m.plainClient, repo, target)
+		} else {
+			r, client, err = fetchLatestReleaseWithFallback(m.client, m.plainClient, repo)
+		}
+	} else if isPinned {
+		r, err = fetchReleaseFromTag(client, repo, target)
 	} else {
-		r, err = fetchLatestRelease(m.client, repo)
+		r, err = fetchLatestRelease(client, repo)
 	}
 	if err != nil {
 		return err
@@ -351,7 +368,7 @@ func (m *Manager) installBin(repo ghrepo.Interface, target string) error {
 	binPath := filepath.Join(targetDir, name)
 	binPath += ext
 
-	err = downloadAsset(m.client, safeurl.NewImmutableSafeURL(asset.APIURL), binPath)
+	err = downloadAsset(client, safeurl.NewImmutableSafeURL(asset.APIURL), binPath)
 	if err != nil {
 		return fmt.Errorf("failed to download asset %s: %w", asset.Name, err)
 	}
@@ -476,7 +493,11 @@ func (m *Manager) Upgrade(name string, force bool) error {
 			return localExtensionUpgradeError
 		}
 		// For single extensions manually retrieve latest version since we forgo doing it during list.
-		if latestVersion := f.LatestVersion(); latestVersion == "" {
+		latestVersion, err := f.latestVersionWithError()
+		if err != nil {
+			return fmt.Errorf("unable to retrieve latest version for extension %q: %w", name, err)
+		}
+		if latestVersion == "" {
 			return fmt.Errorf("unable to retrieve latest version for extension %q", name)
 		}
 		return m.upgradeExtensions([]*Extension{f}, force)
@@ -493,6 +514,12 @@ func (m *Manager) upgradeExtensions(exts []*Extension, force bool) error {
 	var failed bool
 	for _, f := range exts {
 		fmt.Fprintf(m.io.Out, "[%*s]: ", longestExtName, f.Name())
+		latestVersion, latestVersionErr := f.latestVersionWithError()
+		if latestVersionErr != nil {
+			failed = true
+			fmt.Fprintf(m.io.Out, "%s\n", latestVersionErr)
+			continue
+		}
 		currentVersion := displayExtensionVersion(f, f.CurrentVersion())
 		err := m.upgradeExtension(f, force)
 		if err != nil {
@@ -504,7 +531,7 @@ func (m *Manager) upgradeExtensions(exts []*Extension, force bool) error {
 			fmt.Fprintf(m.io.Out, "%s\n", err)
 			continue
 		}
-		latestVersion := displayExtensionVersion(f, f.LatestVersion())
+		latestVersion = displayExtensionVersion(f, latestVersion)
 		if m.dryRunMode {
 			fmt.Fprintf(m.io.Out, "would have upgraded from %s to %s\n", currentVersion, latestVersion)
 		} else {
@@ -533,15 +560,16 @@ func (m *Manager) upgradeExtension(ext *Extension, force bool) error {
 	} else {
 		// Check if git extension has changed to a binary extension
 		var isBin bool
+		var client *http.Client
 		repo, repoErr := repoFromPath(m.gitClient, filepath.Join(ext.Path(), ".."))
 		if repoErr == nil {
-			isBin, _ = isBinExtension(m.client, repo)
+			isBin, client, _ = isBinExtension(m.client, m.plainClient, repo)
 		}
 		if isBin {
 			if err := m.Remove(ext.Name()); err != nil {
 				return fmt.Errorf("failed to migrate to new precompiled extension format: %w", err)
 			}
-			return m.installBin(repo, "")
+			return m.installBinWithClient(repo, "", client)
 		}
 		err = m.upgradeGitExtension(ext, force)
 	}
@@ -745,9 +773,9 @@ func readPathFromFile(path string) (string, error) {
 	return strings.TrimSpace(string(b[:n])), err
 }
 
-func isBinExtension(client *http.Client, repo ghrepo.Interface) (isBin bool, err error) {
+func isBinExtension(client, plainClient *http.Client, repo ghrepo.Interface) (isBin bool, selectedClient *http.Client, err error) {
 	var r *release
-	r, err = fetchLatestRelease(client, repo)
+	r, selectedClient, err = fetchLatestReleaseWithFallback(client, plainClient, repo)
 	if err != nil {
 		return
 	}

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -395,6 +395,49 @@ func TestManager_UpgradeExtensions_DryRun(t *testing.T) {
 	gcTwo.AssertExpectations(t)
 }
 
+func TestManager_UpgradeExtensions_RetriesGitVersionError(t *testing.T) {
+	dataDir := t.TempDir()
+	extensionDir := filepath.Join(dataDir, "extensions", "gh-remote")
+	require.NoError(t, stubExtension(filepath.Join(extensionDir, "gh-remote")))
+
+	ios, _, stdout, _ := iostreams.Test()
+	gc, scopedClient := &mockGitClient{}, &mockGitClient{}
+	gc.On("ForRepo", extensionDir).Return(scopedClient).Times(3)
+	scopedClient.On("CommandOutput", []string{"ls-remote", "origin", "HEAD"}).Return("", fmt.Errorf("network unavailable")).Once()
+	scopedClient.On("CommandOutput", []string{"ls-remote", "origin", "HEAD"}).Return("new version\tHEAD", nil).Once()
+	scopedClient.On("CommandOutput", []string{"rev-parse", "HEAD"}).Return("old version", nil).Once()
+	scopedClient.On("Remotes").Return(nil, nil).Once()
+	scopedClient.On("Pull", "", "").Return(nil).Once()
+
+	m := newTestManager(dataDir, t.TempDir(), nil, gc, ios)
+
+	err := m.Upgrade("", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, "[remote]: upgraded from old vers to new vers\n", stdout.String())
+	gc.AssertExpectations(t)
+	scopedClient.AssertExpectations(t)
+}
+
+func TestManager_UpgradeSingleGitVersionErrorRemainsGeneric(t *testing.T) {
+	dataDir := t.TempDir()
+	extensionDir := filepath.Join(dataDir, "extensions", "gh-remote")
+	require.NoError(t, stubExtension(filepath.Join(extensionDir, "gh-remote")))
+
+	ios, _, _, _ := iostreams.Test()
+	gc, scopedClient := &mockGitClient{}, &mockGitClient{}
+	gc.On("ForRepo", extensionDir).Return(scopedClient).Once()
+	scopedClient.On("CommandOutput", []string{"ls-remote", "origin", "HEAD"}).Return("", fmt.Errorf("network unavailable")).Once()
+
+	m := newTestManager(dataDir, t.TempDir(), nil, gc, ios)
+
+	err := m.Upgrade("remote", false)
+
+	require.EqualError(t, err, `unable to retrieve latest version for extension "remote"`)
+	gc.AssertExpectations(t)
+	scopedClient.AssertExpectations(t)
+}
+
 func TestManager_UpgradeExtension_LocalExtension(t *testing.T) {
 	dataDir := t.TempDir()
 	updateDir := t.TempDir()
@@ -545,18 +588,6 @@ func TestManager_MigrateToBinaryExtension(t *testing.T) {
 				},
 			}))
 	reg.Register(
-		httpmock.REST("GET", "repos/owner/gh-remote/releases/latest"),
-		httpmock.JSONResponse(
-			release{
-				Tag: "v1.0.2",
-				Assets: []releaseAsset{
-					{
-						Name:   "gh-remote-windows-amd64.exe",
-						APIURL: "/release/cool",
-					},
-				},
-			}))
-	reg.Register(
 		httpmock.REST("GET", "release/cool"),
 		httpmock.StringResponse("FAKE UPGRADED BINARY"))
 
@@ -670,27 +701,9 @@ func TestManager_UpgradeExtension_public_binary_with_SAML_protected_token(t *tes
 		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
 		samlProtectedResponse(),
 	)
-	authReg.Register(
-		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
-		samlProtectedResponse(),
-	)
 
 	plainReg := &httpmock.Registry{}
 	defer plainReg.Verify(t)
-	plainReg.Register(
-		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext"),
-		httpmock.JSONResponse(map[string]string{"visibility": "public"}),
-	)
-	plainReg.Register(
-		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
-		httpmock.JSONResponse(release{
-			Tag: "v1.0.2",
-			Assets: []releaseAsset{{
-				Name:   "gh-bin-ext-windows-amd64.exe",
-				APIURL: "https://api.github.com/assets/2",
-			}},
-		}),
-	)
 	plainReg.Register(
 		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext"),
 		httpmock.JSONResponse(map[string]string{"visibility": "public"}),
@@ -1206,17 +1219,6 @@ func TestManager_Install_binary_unsupported(t *testing.T) {
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
 		httpmock.JSONResponse(
 			release{
-				Assets: []releaseAsset{
-					{
-						Name:   "gh-bin-ext-linux-amd64",
-						APIURL: "https://example.com/release/cool",
-					},
-				},
-			}))
-	reg.Register(
-		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
-		httpmock.JSONResponse(
-			release{
 				Tag: "v1.0.1",
 				Assets: []releaseAsset{
 					{
@@ -1246,17 +1248,6 @@ func TestManager_Install_rosetta_fallback_not_found(t *testing.T) {
 	defer reg.Verify(t)
 	client := http.Client{Transport: &reg}
 
-	reg.Register(
-		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
-		httpmock.JSONResponse(
-			release{
-				Assets: []releaseAsset{
-					{
-						Name:   "gh-bin-ext-darwin-amd64",
-						APIURL: "https://example.com/release/cool",
-					},
-				},
-			}))
 	reg.Register(
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
 		httpmock.JSONResponse(
@@ -1299,17 +1290,6 @@ func TestManager_Install_binary(t *testing.T) {
 	reg := httpmock.Registry{}
 	defer reg.Verify(t)
 
-	reg.Register(
-		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
-		httpmock.JSONResponse(
-			release{
-				Assets: []releaseAsset{
-					{
-						Name:   "gh-bin-ext-windows-amd64.exe",
-						APIURL: "https://example.com/release/cool",
-					},
-				},
-			}))
 	reg.Register(
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
 		httpmock.JSONResponse(
@@ -1390,16 +1370,6 @@ func TestManager_Install_public_binary_with_SAML_protected_token(t *testing.T) {
 		}),
 	)
 	plainReg.Register(
-		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
-		httpmock.JSONResponse(release{
-			Tag: "v1.0.1",
-			Assets: []releaseAsset{{
-				Name:   "gh-bin-ext-windows-amd64.exe",
-				APIURL: "https://api.github.com/assets/1",
-			}},
-		}),
-	)
-	plainReg.Register(
 		httpmock.REST(http.MethodGet, "assets/1"),
 		httpmock.StringResponse("FAKE BINARY"),
 	)
@@ -1438,10 +1408,6 @@ func TestManager_Install_public_script_with_SAML_protected_token(t *testing.T) {
 		httpmock.StatusJSONResponse(http.StatusNotFound, map[string]string{"message": "Not Found"}),
 	)
 	plainReg.Register(
-		httpmock.REST(http.MethodGet, "repos/github/gh-script-ext"),
-		httpmock.JSONResponse(map[string]string{"visibility": "public"}),
-	)
-	plainReg.Register(
 		httpmock.REST(http.MethodGet, "repos/github/gh-script-ext/contents/gh-script-ext"),
 		httpmock.JSONResponse(map[string]string{"type": "file"}),
 	)
@@ -1468,17 +1434,6 @@ func TestManager_Install_amd64_when_supported(t *testing.T) {
 	defer reg.Verify(t)
 	client := http.Client{Transport: &reg}
 
-	reg.Register(
-		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
-		httpmock.JSONResponse(
-			release{
-				Assets: []releaseAsset{
-					{
-						Name:   "gh-bin-ext-darwin-amd64",
-						APIURL: "https://example.com/release/cool",
-					},
-				},
-			}))
 	reg.Register(
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
 		httpmock.JSONResponse(

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -1387,6 +1387,67 @@ func TestManager_Install_public_binary_with_SAML_protected_token(t *testing.T) {
 	assert.Equal(t, "FAKE BINARY", string(bin))
 }
 
+func TestManager_Install_public_binary_pinned_with_SAML_protected_token(t *testing.T) {
+	repo := ghrepo.New("github", "gh-bin-ext")
+
+	authReg := &httpmock.Registry{}
+	defer authReg.Verify(t)
+	authReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
+		samlProtectedResponse(),
+	)
+
+	plainReg := &httpmock.Registry{}
+	defer plainReg.Verify(t)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext"),
+		httpmock.JSONResponse(map[string]string{"visibility": "public"}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
+		httpmock.JSONResponse(release{
+			Tag: "v1.0.1",
+			Assets: []releaseAsset{{
+				Name:   "gh-bin-ext-windows-amd64.exe",
+				APIURL: "https://api.github.com/assets/latest",
+			}},
+		}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/tags/v1.0.0"),
+		httpmock.JSONResponse(release{
+			Tag: "v1.0.0",
+			Assets: []releaseAsset{{
+				Name:   "gh-bin-ext-windows-amd64.exe",
+				APIURL: "https://api.github.com/assets/pinned",
+			}},
+		}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "assets/pinned"),
+		httpmock.StringResponse("FAKE PINNED BINARY"),
+	)
+
+	dataDir := t.TempDir()
+	ios, _, _, _ := iostreams.Test()
+	m := newTestManager(dataDir, t.TempDir(), &http.Client{Transport: authReg}, nil, ios)
+	m.SetPlainClient(&http.Client{Transport: plainReg})
+
+	err := m.Install(repo, "v1.0.0")
+
+	require.NoError(t, err)
+	bin, err := os.ReadFile(filepath.Join(dataDir, "extensions/gh-bin-ext/gh-bin-ext.exe"))
+	require.NoError(t, err)
+	assert.Equal(t, "FAKE PINNED BINARY", string(bin))
+
+	manifest, err := os.ReadFile(filepath.Join(dataDir, "extensions/gh-bin-ext", manifestName))
+	require.NoError(t, err)
+	var bm binManifest
+	require.NoError(t, yaml.Unmarshal(manifest, &bm))
+	assert.Equal(t, "v1.0.0", bm.Tag)
+	assert.True(t, bm.IsPinned)
+}
+
 func TestManager_Install_public_script_with_SAML_protected_token(t *testing.T) {
 	repo := ghrepo.New("github", "gh-script-ext")
 

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -652,6 +652,112 @@ func TestManager_UpgradeExtension_BinaryExtension(t *testing.T) {
 	assert.Equal(t, "", stderr.String())
 }
 
+func TestManager_UpgradeExtension_public_binary_with_SAML_protected_token(t *testing.T) {
+	dataDir := t.TempDir()
+	assert.NoError(t, stubBinaryExtension(
+		filepath.Join(dataDir, "extensions", "gh-bin-ext"),
+		binManifest{
+			Owner: "github",
+			Name:  "gh-bin-ext",
+			Host:  "github.com",
+			Tag:   "v1.0.1",
+		},
+	))
+
+	authReg := &httpmock.Registry{}
+	defer authReg.Verify(t)
+	authReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
+		samlProtectedResponse(),
+	)
+	authReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
+		samlProtectedResponse(),
+	)
+
+	plainReg := &httpmock.Registry{}
+	defer plainReg.Verify(t)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext"),
+		httpmock.JSONResponse(map[string]string{"visibility": "public"}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
+		httpmock.JSONResponse(release{
+			Tag: "v1.0.2",
+			Assets: []releaseAsset{{
+				Name:   "gh-bin-ext-windows-amd64.exe",
+				APIURL: "https://api.github.com/assets/2",
+			}},
+		}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext"),
+		httpmock.JSONResponse(map[string]string{"visibility": "public"}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
+		httpmock.JSONResponse(release{
+			Tag: "v1.0.2",
+			Assets: []releaseAsset{{
+				Name:   "gh-bin-ext-windows-amd64.exe",
+				APIURL: "https://api.github.com/assets/2",
+			}},
+		}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "assets/2"),
+		httpmock.StringResponse("FAKE UPGRADED BINARY"),
+	)
+
+	ios, _, _, _ := iostreams.Test()
+	m := newTestManager(dataDir, t.TempDir(), &http.Client{Transport: authReg}, nil, ios)
+	m.SetPlainClient(&http.Client{Transport: plainReg})
+
+	err := m.Upgrade("bin-ext", false)
+
+	require.NoError(t, err)
+	bin, err := os.ReadFile(filepath.Join(dataDir, "extensions/gh-bin-ext/gh-bin-ext.exe"))
+	require.NoError(t, err)
+	assert.Equal(t, "FAKE UPGRADED BINARY", string(bin))
+}
+
+func TestManager_UpgradeExtension_private_binary_preserves_SAML_error(t *testing.T) {
+	dataDir := t.TempDir()
+	assert.NoError(t, stubBinaryExtension(
+		filepath.Join(dataDir, "extensions", "gh-bin-ext"),
+		binManifest{
+			Owner: "github",
+			Name:  "gh-bin-ext",
+			Host:  "github.com",
+			Tag:   "v1.0.1",
+		},
+	))
+
+	authReg := &httpmock.Registry{}
+	defer authReg.Verify(t)
+	authReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
+		samlProtectedResponse(),
+	)
+
+	plainReg := &httpmock.Registry{}
+	defer plainReg.Verify(t)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext"),
+		httpmock.StatusJSONResponse(http.StatusNotFound, map[string]string{"message": "Not Found"}),
+	)
+
+	ios, _, _, _ := iostreams.Test()
+	m := newTestManager(dataDir, t.TempDir(), &http.Client{Transport: authReg}, nil, ios)
+	m.SetPlainClient(&http.Client{Transport: plainReg})
+
+	err := m.Upgrade("bin-ext", false)
+
+	require.ErrorContains(t, err, "unable to retrieve latest version for extension \"bin-ext\"")
+	require.ErrorContains(t, err, "HTTP 403: Resource protected by organization SAML enforcement.")
+}
+
 func TestManager_UpgradeExtension_BinaryExtension_Pinned_Force(t *testing.T) {
 	dataDir := t.TempDir()
 	updateDir := t.TempDir()
@@ -1255,6 +1361,104 @@ func TestManager_Install_binary(t *testing.T) {
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
 	require.NoDirExistsf(t, extensionUpdatePath, "update directory should be removed")
+}
+
+func TestManager_Install_public_binary_with_SAML_protected_token(t *testing.T) {
+	repo := ghrepo.New("github", "gh-bin-ext")
+
+	authReg := &httpmock.Registry{}
+	defer authReg.Verify(t)
+	authReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
+		samlProtectedResponse(),
+	)
+
+	plainReg := &httpmock.Registry{}
+	defer plainReg.Verify(t)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext"),
+		httpmock.JSONResponse(map[string]string{"visibility": "public"}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
+		httpmock.JSONResponse(release{
+			Tag: "v1.0.1",
+			Assets: []releaseAsset{{
+				Name:   "gh-bin-ext-windows-amd64.exe",
+				APIURL: "https://api.github.com/assets/1",
+			}},
+		}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-bin-ext/releases/latest"),
+		httpmock.JSONResponse(release{
+			Tag: "v1.0.1",
+			Assets: []releaseAsset{{
+				Name:   "gh-bin-ext-windows-amd64.exe",
+				APIURL: "https://api.github.com/assets/1",
+			}},
+		}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "assets/1"),
+		httpmock.StringResponse("FAKE BINARY"),
+	)
+
+	dataDir := t.TempDir()
+	ios, _, _, _ := iostreams.Test()
+	m := newTestManager(dataDir, t.TempDir(), &http.Client{Transport: authReg}, nil, ios)
+	m.SetPlainClient(&http.Client{Transport: plainReg})
+
+	err := m.Install(repo, "")
+
+	require.NoError(t, err)
+	bin, err := os.ReadFile(filepath.Join(dataDir, "extensions/gh-bin-ext/gh-bin-ext.exe"))
+	require.NoError(t, err)
+	assert.Equal(t, "FAKE BINARY", string(bin))
+}
+
+func TestManager_Install_public_script_with_SAML_protected_token(t *testing.T) {
+	repo := ghrepo.New("github", "gh-script-ext")
+
+	authReg := &httpmock.Registry{}
+	defer authReg.Verify(t)
+	authReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-script-ext/releases/latest"),
+		samlProtectedResponse(),
+	)
+
+	plainReg := &httpmock.Registry{}
+	defer plainReg.Verify(t)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-script-ext"),
+		httpmock.JSONResponse(map[string]string{"visibility": "public"}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-script-ext/releases/latest"),
+		httpmock.StatusJSONResponse(http.StatusNotFound, map[string]string{"message": "Not Found"}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-script-ext"),
+		httpmock.JSONResponse(map[string]string{"visibility": "public"}),
+	)
+	plainReg.Register(
+		httpmock.REST(http.MethodGet, "repos/github/gh-script-ext/contents/gh-script-ext"),
+		httpmock.JSONResponse(map[string]string{"type": "file"}),
+	)
+
+	dataDir := t.TempDir()
+	extensionDir := filepath.Join(dataDir, "extensions", "gh-script-ext")
+	gc := &mockGitClient{}
+	gc.On("Clone", "https://github.com/github/gh-script-ext.git", []string{extensionDir}).Return("", nil).Once()
+
+	ios, _, _, _ := iostreams.Test()
+	m := newTestManager(dataDir, t.TempDir(), &http.Client{Transport: authReg}, gc, ios)
+	m.SetPlainClient(&http.Client{Transport: plainReg})
+
+	err := m.Install(repo, "")
+
+	require.NoError(t, err)
+	gc.AssertExpectations(t)
 }
 
 func TestManager_Install_amd64_when_supported(t *testing.T) {

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -283,7 +283,14 @@ func extensionManager(f *cmdutil.Factory) *extension.Manager {
 		return em
 	}
 
-	em.SetClient(api.NewCachedHTTPClient(client, time.Second*30))
+	extensionClient := *client
+	extensionClient.Transport = api.SkipHeaderExtraction("X-GitHub-SSO")(client.Transport)
+	em.SetClient(api.NewCachedHTTPClient(&extensionClient, time.Second*30))
+
+	plainClient, err := f.PlainHttpClient()
+	if err == nil {
+		em.SetPlainClient(api.NewCachedHTTPClient(plainClient, time.Second*30))
+	}
 
 	return em
 }
@@ -291,10 +298,15 @@ func extensionManager(f *cmdutil.Factory) *extension.Manager {
 // SSOURL returns the URL of a SAML SSO challenge received by the server for clients that use ExtractHeader
 // to extract the value of the "X-GitHub-SSO" response header.
 func SSOURL() string {
-	if ssoHeader == "" {
+	return SSOURLFromHeader(ssoHeader)
+}
+
+// SSOURLFromHeader returns the authorization URL from an X-GitHub-SSO header.
+func SSOURLFromHeader(header string) string {
+	if header == "" {
 		return ""
 	}
-	m := ssoURLRE.FindStringSubmatch(ssoHeader)
+	m := ssoURLRE.FindStringSubmatch(header)
 	if m == nil {
 		return ""
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Fixes #6675

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

Organization SAML enforcement can make an otherwise valid token return a 403 when GitHub CLI reads release metadata for a public extension. This prevents commands such as `gh extension install github/gh-net`, even though the same release is publicly downloadable without authentication.

Extension release requests now remain authenticated by default, but retry without authentication when the response is specifically a SAML-enforced 403 and the repository is confirmed to be public. The selected client is then reused for release metadata and asset downloads. Private repositories and non-SAML failures continue to return the original authenticated error.

The change covers binary and script installs, pinned releases, upgrades, and Git-to-binary migration. It also keeps SSO response-header handling request-scoped so a recovered extension request cannot produce stale authorization guidance elsewhere.

### How did you test this change?

<!--
Demonstrate the code is solid, and how you know it solves the problem in the description.
Give the exact commands you ran and their output.
If this changes command output, show it before and after. Screenshot images are preferred over pasted text.

If you leave this empty, your pull request will very likely be closed.
-->

- `go test ./pkg/cmd/extension/...` - passed
- `go test -race ./pkg/cmd/extension/...` - passed
- `env -u GH_TOKEN -u GH_HOST -u GIT_CONFIG_COUNT -u GIT_CONFIG_KEY_0 -u GIT_CONFIG_VALUE_0 go test ./...` - passed
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0 run ./...` - `0 issues.`

I also reproduced the same failure mode with an active token: `GET /repos/github/gh-stack/releases/latest` returned 403 with `X-GitHub-SSO`. Using the built binary and that same token, an isolated `gh extension install github/gh-stack` installed v0.1.0 successfully, and `gh stack --help` ran successfully.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- Anonymous fallback is limited to 403 responses carrying `X-GitHub-SSO` and only proceeds after an unauthenticated repository check succeeds.
- The authenticated and anonymous clients remain separate; successful authenticated requests are unchanged.
- Binary release lookups cache both the selected client and release metadata to avoid duplicate SAML failures and anonymous API requests.
- Git extension version failures retain their existing retry and error behavior.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `pkg/cmd/extension/http.go` for fallback selection, then `pkg/cmd/extension/manager.go` for client and release reuse. `pkg/cmd/factory/default.go` and `internal/ghcmd/cmd.go` contain the request-scoped SSO handling.

Issue #6675 contains the original `github/gh-net` reproduction. `github/gh-stack` was used to validate the same failure mode and fix against the current implementation.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @loganrosen will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
