### PR TITLE
fix: preserve executable bits when installing skills

### DIFF
--- a/internal/skills/discovery/discovery.go
+++ b/internal/skills/discovery/discovery.go
@@ -158,6 +158,7 @@ type SkillFile struct {
 	Path string // relative path within the skill directory
 	SHA  string // blob SHA for fetching content
 	Size int    // file size in bytes
+	Mode string // git file mode, such as 100644 or 100755
 }
 
 type treeResponse struct {
@@ -833,6 +834,7 @@ func DiscoverSkillFiles(client *api.Client, host, owner, repo, treeSHA, skillPat
 				Path: skillPath + "/" + entry.Path,
 				SHA:  entry.SHA,
 				Size: entry.Size,
+				Mode: entry.Mode,
 			})
 		}
 	}
@@ -865,6 +867,7 @@ func ListSkillFiles(client *api.Client, host, owner, repo, treeSHA string) ([]Sk
 				Path: entry.Path,
 				SHA:  entry.SHA,
 				Size: entry.Size,
+				Mode: entry.Mode,
 			})
 		}
 	}
@@ -899,7 +902,7 @@ func walkTree(client *api.Client, host, owner, repo, sha, prefix string, depth i
 		}
 		switch entry.Type {
 		case "blob":
-			files = append(files, SkillFile{Path: entryPath, SHA: entry.SHA, Size: entry.Size})
+			files = append(files, SkillFile{Path: entryPath, SHA: entry.SHA, Size: entry.Size, Mode: entry.Mode})
 		case "tree":
 			sub, err := walkTree(client, host, owner, repo, entry.SHA, entryPath, depth+1)
 			if err != nil {

--- a/internal/skills/discovery/discovery_test.go
+++ b/internal/skills/discovery/discovery_test.go
@@ -1598,6 +1598,7 @@ func TestDiscoverSkillFiles(t *testing.T) {
 		name      string
 		stubs     func(*httpmock.Registry)
 		wantPaths []string
+		wantModes map[string]string
 		wantErr   string
 	}{
 		{
@@ -1608,13 +1609,17 @@ func TestDiscoverSkillFiles(t *testing.T) {
 					httpmock.JSONResponse(map[string]interface{}{
 						"sha": "tree123", "truncated": false,
 						"tree": []map[string]interface{}{
-							{"path": "SKILL.md", "type": "blob", "sha": "sha1", "size": 10},
-							{"path": "scripts/setup.sh", "type": "blob", "sha": "sha2", "size": 50},
+							{"path": "SKILL.md", "type": "blob", "sha": "sha1", "size": 10, "mode": "100644"},
+							{"path": "scripts/setup.sh", "type": "blob", "sha": "sha2", "size": 50, "mode": "100755"},
 							{"path": "scripts", "type": "tree", "sha": "treesub"},
 						},
 					}))
 			},
 			wantPaths: []string{"skills/code-review/SKILL.md", "skills/code-review/scripts/setup.sh"},
+			wantModes: map[string]string{
+				"skills/code-review/SKILL.md":         "100644",
+				"skills/code-review/scripts/setup.sh": "100755",
+			},
 		},
 		{
 			name: "truncated tree falls back to walkTree",
@@ -1662,6 +1667,9 @@ func TestDiscoverSkillFiles(t *testing.T) {
 			var paths []string
 			for _, f := range files {
 				paths = append(paths, f.Path)
+				if want, ok := tt.wantModes[f.Path]; ok {
+					assert.Equal(t, want, f.Mode)
+				}
 			}
 			assert.Equal(t, tt.wantPaths, paths)
 		})

--- a/internal/skills/installer/installer.go
+++ b/internal/skills/installer/installer.go
@@ -52,6 +52,27 @@ type skillResult struct {
 	err  error
 }
 
+func localFileMode(mode os.FileMode) os.FileMode {
+	if mode.Perm()&0o111 != 0 {
+		return 0o755
+	}
+	return 0o644
+}
+
+func remoteFileMode(mode string) os.FileMode {
+	if mode == "100755" {
+		return 0o755
+	}
+	return 0o644
+}
+
+func writeFileWithMode(path string, content []byte, mode os.FileMode) error {
+	if err := os.WriteFile(path, content, mode); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
+}
+
 // Install fetches and writes skills to the target directory.
 func Install(opts *Options) (*Result, error) {
 	targetDir := opts.Dir
@@ -235,6 +256,10 @@ func installLocalSkill(sourceRoot string, skill discovery.Skill, baseDir string)
 		if err != nil {
 			return fmt.Errorf("could not read %s: %w", p, err)
 		}
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("could not inspect %s: %w", p, err)
+		}
 
 		if filepath.Base(relPath) == "SKILL.md" {
 			injected, injectErr := frontmatter.InjectLocalMetadata(string(content), absSource)
@@ -244,7 +269,7 @@ func installLocalSkill(sourceRoot string, skill discovery.Skill, baseDir string)
 			content = []byte(injected)
 		}
 
-		return os.WriteFile(destPath, content, 0o644)
+		return writeFileWithMode(destPath, content, localFileMode(info.Mode()))
 	})
 }
 
@@ -300,7 +325,7 @@ func installSkill(opts *Options, skill discovery.Skill, baseDir string) error {
 			}
 		}
 
-		if err := os.WriteFile(destPath, []byte(content), 0o644); err != nil {
+		if err := writeFileWithMode(destPath, []byte(content), remoteFileMode(file.Mode)); err != nil {
 			return fmt.Errorf("could not write %s: %w", destPath, err)
 		}
 	}

--- a/internal/skills/installer/installer_test.go
+++ b/internal/skills/installer/installer_test.go
@@ -66,6 +66,24 @@ func TestInstallLocal(t *testing.T) {
 			},
 		},
 		{
+			name:   "preserves executable bit",
+			skills: []discovery.Skill{{Name: "shell-tools", Path: "skills/shell-tools"}},
+			setup: func(t *testing.T, srcDir string) {
+				t.Helper()
+				skillSrc := filepath.Join(srcDir, "skills", "shell-tools")
+				require.NoError(t, os.MkdirAll(filepath.Join(skillSrc, "scripts"), 0o755))
+				script := filepath.Join(skillSrc, "scripts", "run.sh")
+				require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\n"), 0o755))
+				require.NoError(t, os.Chmod(script, 0o755))
+			},
+			verify: func(t *testing.T, destDir string) {
+				t.Helper()
+				info, err := os.Stat(filepath.Join(destDir, "shell-tools", "scripts", "run.sh"))
+				require.NoError(t, err)
+				assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+			},
+		},
+		{
 			name:   "skips symlinks",
 			skills: []discovery.Skill{{Name: "pr-summary", Path: "skills/pr-summary"}},
 			setup: func(t *testing.T, srcDir string) {
@@ -200,6 +218,7 @@ func TestInstallSkill(t *testing.T) {
 						"tree": []map[string]interface{}{
 							{"path": "SKILL.md", "type": "blob", "sha": "skill-sha", "size": 10},
 							{"path": "prompt.txt", "type": "blob", "sha": "prompt-sha", "size": 5},
+							{"path": "scripts/run.sh", "type": "blob", "sha": "run-sha", "size": 10, "mode": "100755"},
 						},
 					}))
 				reg.Register(
@@ -214,6 +233,12 @@ func TestInstallSkill(t *testing.T) {
 						"sha": "prompt-sha", "encoding": "base64",
 						"content": base64.StdEncoding.EncodeToString([]byte("review this PR")),
 					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/run-sha"),
+					httpmock.JSONResponse(map[string]interface{}{
+						"sha": "run-sha", "encoding": "base64",
+						"content": base64.StdEncoding.EncodeToString([]byte("#!/bin/sh\n")),
+					}))
 			},
 			verify: func(t *testing.T, destDir string) {
 				t.Helper()
@@ -223,6 +248,9 @@ func TestInstallSkill(t *testing.T) {
 
 				_, err = os.Stat(filepath.Join(destDir, "code-review", "SKILL.md"))
 				assert.NoError(t, err)
+				info, err := os.Stat(filepath.Join(destDir, "code-review", "scripts", "run.sh"))
+				require.NoError(t, err)
+				assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- preserve executable bits when installing local skills
- carry GitHub tree file modes through discovery and apply them to remote files
- add regression coverage for local and remote executable scripts

Fixes #14086

## Testing

- `go test ./internal/skills/discovery ./internal/skills/installer`
- `git diff --check`

This change was prepared with AI assistance; the patch and tests were reviewed before submission.