### PR TITLE
skills: preserve executable file permissions when installing skills (Fixes #14086)

### DIFF
--- a/internal/skills/discovery/discovery.go
+++ b/internal/skills/discovery/discovery.go
@@ -158,6 +158,7 @@ type SkillFile struct {
 	Path string // relative path within the skill directory
 	SHA  string // blob SHA for fetching content
 	Size int    // file size in bytes
+	Mode string // git file mode (e.g. "100755")
 }
 
 type treeResponse struct {
@@ -833,6 +834,7 @@ func DiscoverSkillFiles(client *api.Client, host, owner, repo, treeSHA, skillPat
 				Path: skillPath + "/" + entry.Path,
 				SHA:  entry.SHA,
 				Size: entry.Size,
+				Mode: entry.Mode,
 			})
 		}
 	}

--- a/internal/skills/installer/installer.go
+++ b/internal/skills/installer/installer.go
@@ -244,7 +244,12 @@ func installLocalSkill(sourceRoot string, skill discovery.Skill, baseDir string)
 			content = []byte(injected)
 		}
 
-		return os.WriteFile(destPath, content, 0o644)
+		perm := os.FileMode(0o644)
+		if info, err := os.Stat(p); err == nil && info.Mode()&0111 != 0 {
+			perm = 0o755
+		}
+
+		return os.WriteFile(destPath, content, perm)
 	})
 }
 
@@ -300,7 +305,12 @@ func installSkill(opts *Options, skill discovery.Skill, baseDir string) error {
 			}
 		}
 
-		if err := os.WriteFile(destPath, []byte(content), 0o644); err != nil {
+		perm := os.FileMode(0o644)
+		if file.Mode == "100755" || strings.HasPrefix(relPath, "scripts/") || strings.Contains(relPath, "/scripts/") {
+			perm = 0o755
+		}
+
+		if err := os.WriteFile(destPath, []byte(content), perm); err != nil {
 			return fmt.Errorf("could not write %s: %w", destPath, err)
 		}
 	}

--- a/internal/skills/installer/installer_test.go
+++ b/internal/skills/installer/installer_test.go
@@ -66,6 +66,23 @@ func TestInstallLocal(t *testing.T) {
 			},
 		},
 		{
+			name:   "preserves executable file permissions",
+			skills: []discovery.Skill{{Name: "script-runner", Path: "skills/script-runner"}},
+			setup: func(t *testing.T, srcDir string) {
+				t.Helper()
+				scriptDir := filepath.Join(srcDir, "skills", "script-runner", "scripts")
+				require.NoError(t, os.MkdirAll(scriptDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(scriptDir, "hello.sh"), []byte("#!/bin/bash\necho hello"), 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(srcDir, "skills", "script-runner", "SKILL.md"), []byte("# Script Runner"), 0o644))
+			},
+			verify: func(t *testing.T, destDir string) {
+				t.Helper()
+				info, err := os.Stat(filepath.Join(destDir, "script-runner", "scripts", "hello.sh"))
+				require.NoError(t, err)
+				assert.NotZero(t, info.Mode()&0111, "expected executable permission bit to be preserved")
+			},
+		},
+		{
 			name:   "skips symlinks",
 			skills: []discovery.Skill{{Name: "pr-summary", Path: "skills/pr-summary"}},
 			setup: func(t *testing.T, srcDir string) {


### PR DESCRIPTION
### Summary
Fixes #14086 where `gh skill install` hardcoded file permissions to `0o644`, stripping executable permissions (`+x`) from bundled script files and causing `permission denied` (exit code 126) when executing installed scripts.

### Solution
1. **Local Skill Installation** (`installLocalSkill`): Stat the source file using `os.Stat(p)`. If the execute bit is set (`info.Mode() & 0111 != 0`), set destination file permissions to `0o755`.
2. **Remote Skill Installation** (`installSkill`): Added `Mode` string to `SkillFile` struct. If Git blob mode is `"100755"` or the file path resides under `scripts/`, write with `0o755` permissions.
3. **Tests**: Added `TestInstallLocal/preserves_executable_file_permissions` in `internal/skills/installer/installer_test.go`.
