### PR TITLE
fix(ssh-key): allow deleting signing keys

### DIFF
--- a/pkg/cmd/ssh-key/delete/delete.go
+++ b/pkg/cmd/ssh-key/delete/delete.go
@@ -67,7 +67,7 @@ func deleteRun(opts *DeleteOptions) error {
 	}
 
 	host, _ := cfg.Authentication().DefaultHost()
-	key, err := getSSHKey(httpClient, host, opts.KeyID)
+	key, keyType, err := getSSHKey(httpClient, host, opts.KeyID)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func deleteRun(opts *DeleteOptions) error {
 		}
 	}
 
-	err = deleteSSHKey(httpClient, host, opts.KeyID)
+	err = deleteSSHKey(httpClient, host, opts.KeyID, keyType)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/ssh-key/delete/delete_test.go
+++ b/pkg/cmd/ssh-key/delete/delete_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/ssh-key/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -110,6 +111,7 @@ func TestNewCmdDelete(t *testing.T) {
 
 func Test_deleteRun(t *testing.T) {
 	keyResp := "{\"title\":\"My Key\"}"
+	signingKeyResp := "{\"title\":\"My Signing Key\"}"
 	tests := []struct {
 		name          string
 		tty           bool
@@ -146,14 +148,41 @@ func Test_deleteRun(t *testing.T) {
 			wantStdout: "✓ SSH key \"My Key\" (123) deleted from your account\n",
 		},
 		{
+			name: "delete signing key tty",
+			tty:  true,
+			opts: DeleteOptions{KeyID: "123"},
+			prompterStubs: func(pm *prompter.PrompterMock) {
+				pm.ConfirmDeletionFunc = func(_ string) error {
+					return nil
+				}
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(200, signingKeyResp))
+				reg.Register(httpmock.REST("DELETE", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "✓ SSH key \"My Signing Key\" (123) deleted from your account\n",
+		},
+		{
+			name: "delete signing key no tty",
+			opts: DeleteOptions{KeyID: "123", Confirmed: true},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(200, signingKeyResp))
+				reg.Register(httpmock.REST("DELETE", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "",
+		},
+		{
 			name: "not found tty",
 			tty:  true,
 			opts: DeleteOptions{KeyID: "123"},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, `{"message":"Not Found"}`))
 			},
 			wantErr:    true,
-			wantErrMsg: "HTTP 404 (https://api.github.com/user/keys/123)",
+			wantErrMsg: "HTTP 404 (https://api.github.com/user/ssh_signing_keys/123)",
 		},
 		{
 			name: "delete no tty",
@@ -169,9 +198,10 @@ func Test_deleteRun(t *testing.T) {
 			opts: DeleteOptions{KeyID: "123", Confirmed: true},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, `{"message":"Not Found"}`))
 			},
 			wantErr:    true,
-			wantErrMsg: "HTTP 404 (https://api.github.com/user/keys/123)",
+			wantErrMsg: "HTTP 404 (https://api.github.com/user/ssh_signing_keys/123)",
 		},
 	}
 
@@ -220,7 +250,7 @@ func TestDeleteSSHKeyHTTPError(t *testing.T) {
 		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
 	)
 
-	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
+	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "1234", shared.AuthenticationKey)
 
 	var httpErr api.HTTPError
 	require.ErrorAs(t, err, &httpErr)
@@ -228,15 +258,88 @@ func TestDeleteSSHKeyHTTPError(t *testing.T) {
 	assert.Contains(t, err.Error(), "HTTP 404")
 }
 
-func TestGetSSHKeyHTTPError(t *testing.T) {
+func TestDeleteSSHKeySigningKey(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("DELETE", "user/ssh_signing_keys/5678"),
+		httpmock.StatusStringResponse(http.StatusNoContent, ""),
+	)
+
+	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "5678", shared.SigningKey)
+
+	require.NoError(t, err)
+}
+
+func TestGetSSHKeyAuthenticationKey(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys/5678"),
+		httpmock.StatusStringResponse(200, `{"title":"My Key"}`),
+	)
+	// A signing-key lookup must not happen when the authentication key is found.
+	reg.Exclude(t, httpmock.REST("GET", "user/ssh_signing_keys/5678"))
+
+	key, keyType, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
+
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	assert.Equal(t, "My Key", key.Title)
+	assert.Equal(t, shared.AuthenticationKey, keyType)
+}
+
+func TestGetSSHKeySigningKeyFallback(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys/5678"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+	reg.Register(
+		httpmock.REST("GET", "user/ssh_signing_keys/5678"),
+		httpmock.StatusStringResponse(200, `{"title":"My Signing Key"}`),
+	)
+
+	key, keyType, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
+
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	assert.Equal(t, "My Signing Key", key.Title)
+	assert.Equal(t, shared.SigningKey, keyType)
+}
+
+func TestGetSSHKeyAuthenticationEndpointErrorNotRetried(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys/5678"),
+		httpmock.StatusStringResponse(http.StatusForbidden, `{"message":"Forbidden"}`),
+	)
+	// A non-404 error from the authentication endpoint must not trigger a
+	// signing-key lookup.
+	reg.Exclude(t, httpmock.REST("GET", "user/ssh_signing_keys/5678"))
+
+	_, _, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusForbidden, httpErr.StatusCode)
+}
+
+func TestGetSSHKeyBothEndpointsNotFound(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 	reg.Register(
 		httpmock.REST("GET", "user/keys/1234"),
 		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
 	)
+	reg.Register(
+		httpmock.REST("GET", "user/ssh_signing_keys/1234"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
 
-	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
+	key, _, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
 
 	assert.Nil(t, key)
 	var httpErr api.HTTPError

--- a/pkg/cmd/ssh-key/delete/http.go
+++ b/pkg/cmd/ssh-key/delete/http.go
@@ -1,30 +1,54 @@
 package delete
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/safeurl"
+	"github.com/cli/cli/v2/pkg/cmd/ssh-key/shared"
 )
 
 type sshKey struct {
 	Title string
 }
 
-func deleteSSHKey(httpClient *http.Client, host string, keyID string) error {
-	path, err := safeurl.JoinPath("user", "keys", keyID)
-	if err != nil {
-		return err
+// keyPath returns the REST API path for an SSH key of the given type. GitHub
+// stores authentication keys and signing keys at separate endpoints
+// (/user/keys and /user/ssh_signing_keys) with independent ID namespaces, so the key type
+// determines which endpoint addresses the key.
+func keyPath(keyID, keyType string) (safeurl.SafeURL, error) {
+	if keyType == shared.SigningKey {
+		return safeurl.JoinPath("user", "ssh_signing_keys", keyID)
 	}
-	// TODO(api-client-rollout)
-	// This line of code is part of a mechanical roll out of the api client.
-	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
+	return safeurl.JoinPath("user", "keys", keyID)
 }
 
-func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, error) {
+// getSSHKey resolves an SSH key by ID across both the authentication-keys and
+// signing-keys endpoints. It tries the authentication-keys endpoint first and
+// falls back to the signing-keys endpoint only when the first returns 404, so
+// that other errors (e.g. 403 or 500) are surfaced without a misleading second
+// request. The returned key type reports which endpoint the key was found at
+// and must be passed to deleteSSHKey so the key is removed from the same
+// endpoint it was resolved at.
+func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, string, error) {
+	key, err := fetchSSHKey(httpClient, host, keyID, shared.AuthenticationKey)
+	if err == nil {
+		return key, shared.AuthenticationKey, nil
+	}
+	if !isNotFound(err) {
+		return nil, "", err
+	}
+	key, err = fetchSSHKey(httpClient, host, keyID, shared.SigningKey)
+	if err != nil {
+		return nil, "", err
+	}
+	return key, shared.SigningKey, nil
+}
+
+func fetchSSHKey(httpClient *http.Client, host string, keyID, keyType string) (*sshKey, error) {
 	var key sshKey
-	path, err := safeurl.JoinPath("user", "keys", keyID)
+	path, err := keyPath(keyID, keyType)
 	if err != nil {
 		return nil, err
 	}
@@ -37,4 +61,20 @@ func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, err
 	}
 
 	return &key, nil
+}
+
+func deleteSSHKey(httpClient *http.Client, host string, keyID, keyType string) error {
+	path, err := keyPath(keyID, keyType)
+	if err != nil {
+		return err
+	}
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
+}
+
+func isNotFound(err error) bool {
+	var httpErr api.HTTPError
+	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound
 }


### PR DESCRIPTION
## Summary

`gh ssh-key delete` only looked up and deleted keys through `/user/keys/{id}`, so IDs for SSH signing keys always returned 404 even though `gh ssh-key add --type signing` and `gh ssh-key list` support them.

This change resolves a key against the authentication-key endpoint first, falls back to `/user/ssh_signing_keys/{id}` only on 404, and remembers the resolved key type so deletion uses the matching endpoint. Non-404 errors from the authentication endpoint are preserved.

## Tests

- Added coverage for resolving and deleting signing keys
- Added coverage for authentication-key behavior and non-404 errors
- `go test ./pkg/cmd/ssh-key/delete`
- `git diff --check`

Fixes #14064