### PR TITLE
Add support for reading issue field values

### DIFF
--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -111,6 +111,12 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 				"nodes":      items,
 				"totalCount": issue.Blocking.TotalCount,
 			}
+		case "issueFields":
+			items := make([]map[string]interface{}, 0, len(issue.IssueFields.Nodes))
+			for _, field := range issue.IssueFields.Nodes {
+				items = append(items, field.ExportData())
+			}
+			data[f] = items
 		default:
 			sf := fieldByName(v, f)
 			data[f] = sf.Interface()

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -32,6 +32,27 @@ func TestIssue_ExportData(t *testing.T) {
 			`),
 		},
 		{
+			name:   "issue fields",
+			fields: []string{"issueFields"},
+			inputJSON: heredoc.Doc(`
+				{ "issueFields": { "nodes": [
+					{ "field": { "name": "Priority", "dataType": "SINGLE_SELECT" }, "name": "High" },
+					{ "field": { "name": "Estimate", "dataType": "NUMBER" }, "value": 3.5 },
+					{ "field": { "name": "Teams", "dataType": "MULTI_SELECT" }, "options": [
+						{ "id": "OPT_1", "name": "CLI" },
+						{ "id": "OPT_2", "name": "Desktop" }
+					] }
+				] } }
+			`),
+			outputJSON: heredoc.Doc(`
+				{ "issueFields": [
+					{ "name": "Priority", "dataType": "single_select", "value": "High" },
+					{ "name": "Estimate", "dataType": "number", "value": "3.5" },
+					{ "name": "Teams", "dataType": "multi_select", "value": ["CLI", "Desktop"] }
+				] }
+			`),
+		},
+		{
 			name:   "milestone",
 			fields: []string{"number", "milestone"},
 			inputJSON: heredoc.Doc(`

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -47,7 +47,7 @@ func TestIssue_ExportData(t *testing.T) {
 			outputJSON: heredoc.Doc(`
 				{ "issueFields": [
 					{ "name": "Priority", "dataType": "single_select", "value": "High" },
-					{ "name": "Estimate", "dataType": "number", "value": "3.5" },
+					{ "name": "Estimate", "dataType": "number", "value": 3.5 },
 					{ "name": "Teams", "dataType": "multi_select", "value": ["CLI", "Desktop"] }
 				] }
 			`),

--- a/api/issue_fields.go
+++ b/api/issue_fields.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+)
+
+const issueFieldDefinitions = `
+	...on IssueFieldText{id,name,dataType}
+	...on IssueFieldNumber{id,name,dataType}
+	...on IssueFieldDate{id,name,dataType}
+	...on IssueFieldSingleSelect{id,name,dataType,options{id,name}}
+	...on IssueFieldMultiSelect{id,name,dataType,options{id,name}}
+`
+
+// RepoIssueFields fetches all issue fields available to a repository.
+func RepoIssueFields(client *Client, repo ghrepo.Interface) ([]IssueFieldDefinition, error) {
+	query := fmt.Sprintf(`
+	query RepositoryIssueFields($owner: String!, $name: String!, $endCursor: String) {
+		repository(owner: $owner, name: $name) {
+			issueFields(first: 100, after: $endCursor) {
+				nodes{%s}
+				pageInfo{hasNextPage,endCursor}
+			}
+		}
+	}`, issueFieldDefinitions)
+	variables := map[string]interface{}{
+		"owner": repo.RepoOwner(),
+		"name":  repo.RepoName(),
+	}
+
+	var fields []IssueFieldDefinition
+	for {
+		var result struct {
+			Repository struct {
+				IssueFields issueFieldDefinitionConnection
+			}
+		}
+		if err := client.GraphQL(repo.RepoHost(), query, variables, &result); err != nil {
+			return nil, err
+		}
+		fields = append(fields, result.Repository.IssueFields.Nodes...)
+		if !result.Repository.IssueFields.PageInfo.HasNextPage {
+			return fields, nil
+		}
+		variables["endCursor"] = result.Repository.IssueFields.PageInfo.EndCursor
+	}
+}
+
+type issueFieldDefinitionConnection struct {
+	Nodes    []IssueFieldDefinition
+	PageInfo struct {
+		HasNextPage bool
+		EndCursor   string
+	}
+}

--- a/api/issue_fields.go
+++ b/api/issue_fields.go
@@ -6,16 +6,21 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
 
-const issueFieldDefinitions = `
+const issueFieldDefinitionsWithoutMultiSelect = `
 	...on IssueFieldText{id,name,dataType}
 	...on IssueFieldNumber{id,name,dataType}
 	...on IssueFieldDate{id,name,dataType}
 	...on IssueFieldSingleSelect{id,name,dataType,options{id,name}}
-	...on IssueFieldMultiSelect{id,name,dataType,options{id,name}}
 `
 
+const issueFieldMultiSelectDefinition = `...on IssueFieldMultiSelect{id,name,dataType,options{id,name}}`
+
 // RepoIssueFields fetches all issue fields available to a repository.
-func RepoIssueFields(client *Client, repo ghrepo.Interface) ([]IssueFieldDefinition, error) {
+func RepoIssueFields(client *Client, repo ghrepo.Interface, includeMultiSelect bool) ([]IssueFieldDefinition, error) {
+	definitions := issueFieldDefinitionsWithoutMultiSelect
+	if includeMultiSelect {
+		definitions += issueFieldMultiSelectDefinition
+	}
 	query := fmt.Sprintf(`
 	query RepositoryIssueFields($owner: String!, $name: String!, $endCursor: String) {
 		repository(owner: $owner, name: $name) {
@@ -24,7 +29,7 @@ func RepoIssueFields(client *Client, repo ghrepo.Interface) ([]IssueFieldDefinit
 				pageInfo{hasNextPage,endCursor}
 			}
 		}
-	}`, issueFieldDefinitions)
+	}`, definitions)
 	variables := map[string]interface{}{
 		"owner": repo.RepoOwner(),
 		"name":  repo.RepoName(),

--- a/api/issue_fields_test.go
+++ b/api/issue_fields_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepoIssueFields(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryIssueFields\b`),
+		httpmock.GraphQLQuery(`{
+			"data": {"repository": {"issueFields": {
+				"nodes": [{"id":"IF_1","name":"Priority","dataType":"SINGLE_SELECT","options":[{"id":"OPT_1","name":"High"}]}],
+				"pageInfo": {"hasNextPage": true, "endCursor": "CURSOR_1"}
+			}}}
+		}`, func(_ string, variables map[string]interface{}) {
+			assert.Equal(t, map[string]interface{}{
+				"owner": "OWNER", "name": "REPO",
+			}, variables)
+		}),
+	)
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryIssueFields\b`),
+		httpmock.GraphQLQuery(`{
+			"data": {"repository": {"issueFields": {
+				"nodes": [{"id":"IF_2","name":"Due date","dataType":"DATE"}],
+				"pageInfo": {"hasNextPage": false, "endCursor": "CURSOR_2"}
+			}}}
+		}`, func(_ string, variables map[string]interface{}) {
+			assert.Equal(t, map[string]interface{}{
+				"owner": "OWNER", "name": "REPO", "endCursor": "CURSOR_1",
+			}, variables)
+		}),
+	)
+
+	client := NewClientFromHTTP(&http.Client{Transport: reg})
+	fields, err := RepoIssueFields(client, ghrepo.New("OWNER", "REPO"))
+	require.NoError(t, err)
+	require.Len(t, fields, 2)
+	assert.Equal(t, "Priority", fields[0].Name)
+	assert.Equal(t, []IssueFieldOption{{ID: "OPT_1", Name: "High"}}, fields[0].Options)
+	assert.Equal(t, "Due date", fields[1].Name)
+}

--- a/api/issue_fields_test.go
+++ b/api/issue_fields_test.go
@@ -42,10 +42,26 @@ func TestRepoIssueFields(t *testing.T) {
 	)
 
 	client := NewClientFromHTTP(&http.Client{Transport: reg})
-	fields, err := RepoIssueFields(client, ghrepo.New("OWNER", "REPO"))
+	fields, err := RepoIssueFields(client, ghrepo.New("OWNER", "REPO"), true)
 	require.NoError(t, err)
 	require.Len(t, fields, 2)
 	assert.Equal(t, "Priority", fields[0].Name)
 	assert.Equal(t, []IssueFieldOption{{ID: "OPT_1", Name: "High"}}, fields[0].Options)
 	assert.Equal(t, "Due date", fields[1].Name)
+}
+
+func TestRepoIssueFieldsWithoutMultiSelect(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryIssueFields\b`),
+		httpmock.GraphQLQuery(`{"data":{"repository":{"issueFields":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}`, func(query string, _ map[string]interface{}) {
+			assert.NotContains(t, query, "IssueFieldMultiSelect")
+		}),
+	)
+
+	client := NewClientFromHTTP(&http.Client{Transport: reg})
+	fields, err := RepoIssueFields(client, ghrepo.New("OWNER", "REPO"), false)
+	require.NoError(t, err)
+	assert.Empty(t, fields)
 }

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -55,8 +56,86 @@ type Issue struct {
 	SubIssuesSummary SubIssuesSummary
 	BlockedBy        LinkedIssueConnection
 	Blocking         LinkedIssueConnection
+	IssueFields      IssueFieldValues `json:"issueFields"`
 
 	ClosedByPullRequestsReferences ClosedByPullRequestsReferences
+}
+
+// IssueFieldValues is a connection of issue field values.
+type IssueFieldValues struct {
+	Nodes []IssueFieldValue `json:"nodes"`
+}
+
+// IssueFieldValue represents the union of issue field value types.
+type IssueFieldValue struct {
+	ID    string `json:"id"`
+	Field struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		DataType string `json:"dataType"`
+	} `json:"field"`
+	Value   interface{}        `json:"value"`
+	Name    string             `json:"name"`
+	Options []IssueFieldOption `json:"options"`
+}
+
+// IssueFieldDefinition represents an issue field configured for an organization or repository.
+type IssueFieldDefinition struct {
+	ID       string             `json:"id"`
+	Name     string             `json:"name"`
+	DataType string             `json:"dataType"`
+	Options  []IssueFieldOption `json:"options"`
+}
+
+// ExportData returns selected public JSON fields for an issue field definition.
+func (f IssueFieldDefinition) ExportData(fields []string) map[string]interface{} {
+	data := make(map[string]interface{}, len(fields))
+	for _, field := range fields {
+		switch field {
+		case "id":
+			data[field] = f.ID
+		case "name":
+			data[field] = f.Name
+		case "dataType":
+			data[field] = strings.ToLower(f.DataType)
+		case "options":
+			data[field] = f.Options
+		}
+	}
+	return data
+}
+
+// IssueFieldOption represents an option configured for a select issue field.
+type IssueFieldOption struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// ExportData returns the public JSON representation of an issue field value.
+func (v IssueFieldValue) ExportData() map[string]interface{} {
+	return map[string]interface{}{
+		"name":     v.Field.Name,
+		"dataType": strings.ToLower(v.Field.DataType),
+		"value":    v.DisplayValue(),
+	}
+}
+
+// DisplayValue returns the human-readable value for an issue field.
+func (v IssueFieldValue) DisplayValue() interface{} {
+	switch v.Field.DataType {
+	case "NUMBER":
+		return fmt.Sprint(v.Value)
+	case "SINGLE_SELECT":
+		return v.Name
+	case "MULTI_SELECT":
+		values := make([]string, len(v.Options))
+		for i, option := range v.Options {
+			values[i] = option.Name
+		}
+		return values
+	default:
+		return v.Value
+	}
 }
 
 // IssueType represents an issue type configured for a repository.

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -123,8 +123,6 @@ func (v IssueFieldValue) ExportData() map[string]interface{} {
 // DisplayValue returns the human-readable value for an issue field.
 func (v IssueFieldValue) DisplayValue() interface{} {
 	switch v.Field.DataType {
-	case "NUMBER":
-		return fmt.Sprint(v.Value)
 	case "SINGLE_SELECT":
 		return v.Name
 	case "MULTI_SELECT":

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -346,6 +346,7 @@ var issueOnlyFields = []string{
 	"subIssuesSummary",
 	"blockedBy",
 	"blocking",
+	"issueFields",
 }
 
 var IssueFields = append(sharedIssuePRFields, issueOnlyFields...)
@@ -454,12 +455,30 @@ func IssueGraphQL(fields []string) string {
 			q = append(q, `blockedBy(first:50){nodes{id,number,title,url,state,repository{nameWithOwner}},totalCount}`)
 		case "blocking":
 			q = append(q, `blocking(first:50){nodes{id,number,title,url,state,repository{nameWithOwner}},totalCount}`)
+		case "issueFields":
+			q = append(q, issueFields)
 		default:
 			q = append(q, field)
 		}
 	}
 	return strings.Join(q, ",")
 }
+
+const issueFieldMetadata = `field{
+	...on IssueFieldText{id,name,dataType}
+	...on IssueFieldNumber{id,name,dataType}
+	...on IssueFieldDate{id,name,dataType}
+	...on IssueFieldSingleSelect{id,name,dataType}
+	...on IssueFieldMultiSelect{id,name,dataType}
+}`
+
+var issueFields = fmt.Sprintf(`issueFields:issueFieldValues(first:100){nodes{
+	...on IssueFieldTextValue{id,%[1]s,value}
+	...on IssueFieldNumberValue{id,%[1]s,value}
+	...on IssueFieldDateValue{id,%[1]s,value}
+	...on IssueFieldSingleSelectValue{id,%[1]s,name}
+	...on IssueFieldMultiSelectValue{id,%[1]s,options{id,name}}
+}}`, issueFieldMetadata)
 
 // PullRequestGraphQL constructs a GraphQL query fragment for a set of pull request fields.
 // It will try to sanitize the fields to just those available on pull request.

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -457,12 +457,21 @@ func IssueGraphQL(fields []string) string {
 			q = append(q, `blocking(first:50){nodes{id,number,title,url,state,repository{nameWithOwner}},totalCount}`)
 		case "issueFields":
 			q = append(q, issueFields)
+		case "issueFieldsWithoutMultiSelect":
+			q = append(q, issueFieldsWithoutMultiSelect)
 		default:
 			q = append(q, field)
 		}
 	}
 	return strings.Join(q, ",")
 }
+
+const issueFieldMetadataWithoutMultiSelect = `field{
+	...on IssueFieldText{id,name,dataType}
+	...on IssueFieldNumber{id,name,dataType}
+	...on IssueFieldDate{id,name,dataType}
+	...on IssueFieldSingleSelect{id,name,dataType}
+}`
 
 const issueFieldMetadata = `field{
 	...on IssueFieldText{id,name,dataType}
@@ -471,6 +480,13 @@ const issueFieldMetadata = `field{
 	...on IssueFieldSingleSelect{id,name,dataType}
 	...on IssueFieldMultiSelect{id,name,dataType}
 }`
+
+var issueFieldsWithoutMultiSelect = fmt.Sprintf(`issueFields:issueFieldValues(first:100){nodes{
+	...on IssueFieldTextValue{id,%[1]s,value}
+	...on IssueFieldNumberValue{id,%[1]s,value}
+	...on IssueFieldDateValue{id,%[1]s,value}
+	...on IssueFieldSingleSelectValue{id,%[1]s,name}
+}}`, issueFieldMetadataWithoutMultiSelect)
 
 var issueFields = fmt.Sprintf(`issueFields:issueFieldValues(first:100){nodes{
 	...on IssueFieldTextValue{id,%[1]s,value}
@@ -486,6 +502,7 @@ func PullRequestGraphQL(fields []string) string {
 	s := set.NewStringSet()
 	s.AddValues(fields)
 	s.RemoveValues(issueOnlyFields)
+	s.Remove("issueFieldsWithoutMultiSelect")
 	return IssueGraphQL(s.ToSlice())
 }
 

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -38,6 +38,11 @@ func TestPullRequestGraphQL(t *testing.T) {
 			fields: []string{"projectItems"},
 			want:   `projectItems(first:100){nodes{id, project{id,title}, status:fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue{optionId,name}}},totalCount}`,
 		},
+		{
+			name:   "issue fields are filtered",
+			fields: []string{"issueFields"},
+			want:   "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -78,6 +83,11 @@ func TestIssueGraphQL(t *testing.T) {
 			name:   "projectItems",
 			fields: []string{"projectItems"},
 			want:   `projectItems(first:100){nodes{id, project{id,title}, status:fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue{optionId,name}}},totalCount}`,
+		},
+		{
+			name:   "issue fields",
+			fields: []string{"issueFields"},
+			want:   issueFields,
 		},
 	}
 	for _, tt := range tests {

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -40,7 +40,7 @@ func TestPullRequestGraphQL(t *testing.T) {
 		},
 		{
 			name:   "issue fields are filtered",
-			fields: []string{"issueFields"},
+			fields: []string{"issueFields", "issueFieldsWithoutMultiSelect"},
 			want:   "",
 		},
 	}
@@ -88,6 +88,11 @@ func TestIssueGraphQL(t *testing.T) {
 			name:   "issue fields",
 			fields: []string{"issueFields"},
 			want:   issueFields,
+		},
+		{
+			name:   "issue fields without multi-select",
+			fields: []string{"issueFieldsWithoutMultiSelect"},
+			want:   issueFieldsWithoutMultiSelect,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -59,12 +59,17 @@ type IssueFeatures struct {
 
 	// IssueFieldsSupported indicates the host supports custom issue fields.
 	IssueFieldsSupported bool
+
+	// IssueFieldMultiSelectSupported indicates the host supports multi-select
+	// issue field definitions and values.
+	IssueFieldMultiSelectSupported bool
 }
 
 var allIssueFeatures = IssueFeatures{
-	ApiActorsSupported:          true,
-	IssueRelationshipsSupported: true,
-	IssueFieldsSupported:        true,
+	ApiActorsSupported:             true,
+	IssueRelationshipsSupported:    true,
+	IssueFieldsSupported:           true,
+	IssueFieldMultiSelectSupported: true,
 }
 
 type PullRequestFeatures struct {
@@ -186,10 +191,24 @@ func (d *detector) IssueFeatures() (IssueFeatures, error) {
 			} `graphql:"fields(includeDeprecated: true)"`
 		} `graphql:"Issue: __type(name: \"Issue\")"`
 	}
+	var issueFieldFeatureDetection struct {
+		IssueFieldMultiSelect struct {
+			Name string
+		} `graphql:"IssueFieldMultiSelect: __type(name: \"IssueFieldMultiSelect\")"`
+		IssueFieldMultiSelectValue struct {
+			Name string
+		} `graphql:"IssueFieldMultiSelectValue: __type(name: \"IssueFieldMultiSelectValue\")"`
+	}
 
 	gql := api.NewClientFromHTTP(d.httpClient)
-	err := gql.Query(d.host, "Issue_fields", &featureDetection, nil)
-	if err != nil {
+	var wg errgroup.Group
+	wg.Go(func() error {
+		return gql.Query(d.host, "Issue_fields", &featureDetection, nil)
+	})
+	wg.Go(func() error {
+		return gql.Query(d.host, "Issue_field_types", &issueFieldFeatureDetection, nil)
+	})
+	if err := wg.Wait(); err != nil {
 		return IssueFeatures{}, err
 	}
 
@@ -201,6 +220,8 @@ func (d *detector) IssueFeatures() (IssueFeatures, error) {
 			features.IssueFieldsSupported = true
 		}
 	}
+	features.IssueFieldMultiSelectSupported = issueFieldFeatureDetection.IssueFieldMultiSelect.Name != "" &&
+		issueFieldFeatureDetection.IssueFieldMultiSelectValue.Name != ""
 
 	return features, nil
 }

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -56,11 +56,15 @@ type IssueFeatures struct {
 	// GHES 3.19+. Issue types and sub-issues are GA on all supported GHES
 	// versions (3.17+) and do not need feature detection.
 	IssueRelationshipsSupported bool
+
+	// IssueFieldsSupported indicates the host supports custom issue fields.
+	IssueFieldsSupported bool
 }
 
 var allIssueFeatures = IssueFeatures{
 	ApiActorsSupported:          true,
 	IssueRelationshipsSupported: true,
+	IssueFieldsSupported:        true,
 }
 
 type PullRequestFeatures struct {
@@ -190,9 +194,11 @@ func (d *detector) IssueFeatures() (IssueFeatures, error) {
 	}
 
 	for _, field := range featureDetection.Issue.Fields {
-		if field.Name == "blockedBy" {
+		switch field.Name {
+		case "blockedBy":
 			features.IssueRelationshipsSupported = true
-			break
+		case "issueFieldValues":
+			features.IssueFieldsSupported = true
 		}
 	}
 

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -14,6 +14,8 @@ import (
 func TestIssueFeatures(t *testing.T) {
 	issueFieldsWithRelationships := `{"data":{"Issue":{"fields":[{"name":"title"},{"name":"body"},{"name":"blockedBy"},{"name":"issueFieldValues"}]}}}`
 	issueFieldsWithoutRelationships := `{"data":{"Issue":{"fields":[{"name":"title"},{"name":"body"}]}}}`
+	issueFieldMultiSelectTypes := `{"data":{"IssueFieldMultiSelect":{"name":"IssueFieldMultiSelect"},"IssueFieldMultiSelectValue":{"name":"IssueFieldMultiSelectValue"}}}`
+	noIssueFieldMultiSelectTypes := `{"data":{"IssueFieldMultiSelect":null,"IssueFieldMultiSelectValue":null}}`
 
 	tests := []struct {
 		name          string
@@ -26,9 +28,10 @@ func TestIssueFeatures(t *testing.T) {
 			name:     "github.com",
 			hostname: "github.com",
 			wantFeatures: IssueFeatures{
-				ApiActorsSupported:          true,
-				IssueRelationshipsSupported: true,
-				IssueFieldsSupported:        true,
+				ApiActorsSupported:             true,
+				IssueRelationshipsSupported:    true,
+				IssueFieldsSupported:           true,
+				IssueFieldMultiSelectSupported: true,
 			},
 			wantErr: false,
 		},
@@ -36,9 +39,10 @@ func TestIssueFeatures(t *testing.T) {
 			name:     "ghec data residency (ghe.com)",
 			hostname: "stampname.ghe.com",
 			wantFeatures: IssueFeatures{
-				ApiActorsSupported:          true,
-				IssueRelationshipsSupported: true,
-				IssueFieldsSupported:        true,
+				ApiActorsSupported:             true,
+				IssueRelationshipsSupported:    true,
+				IssueFieldsSupported:           true,
+				IssueFieldMultiSelectSupported: true,
 			},
 			wantErr: false,
 		},
@@ -46,12 +50,14 @@ func TestIssueFeatures(t *testing.T) {
 			name:     "GHE with relationship support",
 			hostname: "git.my.org",
 			queryResponse: map[string]string{
-				`query Issue_fields`: issueFieldsWithRelationships,
+				`query Issue_fields`:      issueFieldsWithRelationships,
+				`query Issue_field_types`: issueFieldMultiSelectTypes,
 			},
 			wantFeatures: IssueFeatures{
-				ApiActorsSupported:          false,
-				IssueRelationshipsSupported: true,
-				IssueFieldsSupported:        true,
+				ApiActorsSupported:             false,
+				IssueRelationshipsSupported:    true,
+				IssueFieldsSupported:           true,
+				IssueFieldMultiSelectSupported: true,
 			},
 			wantErr: false,
 		},
@@ -59,11 +65,26 @@ func TestIssueFeatures(t *testing.T) {
 			name:     "GHE without relationship support",
 			hostname: "git.my.org",
 			queryResponse: map[string]string{
-				`query Issue_fields`: issueFieldsWithoutRelationships,
+				`query Issue_fields`:      issueFieldsWithoutRelationships,
+				`query Issue_field_types`: noIssueFieldMultiSelectTypes,
 			},
 			wantFeatures: IssueFeatures{
 				ApiActorsSupported:          false,
 				IssueRelationshipsSupported: false,
+			},
+			wantErr: false,
+		},
+		{
+			name:     "GHE with issue fields without multi-select support",
+			hostname: "git.my.org",
+			queryResponse: map[string]string{
+				`query Issue_fields`:      issueFieldsWithRelationships,
+				`query Issue_field_types`: noIssueFieldMultiSelectTypes,
+			},
+			wantFeatures: IssueFeatures{
+				ApiActorsSupported:          false,
+				IssueRelationshipsSupported: true,
+				IssueFieldsSupported:        true,
 			},
 			wantErr: false,
 		},

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIssueFeatures(t *testing.T) {
-	issueFieldsWithRelationships := `{"data":{"Issue":{"fields":[{"name":"title"},{"name":"body"},{"name":"blockedBy"}]}}}`
+	issueFieldsWithRelationships := `{"data":{"Issue":{"fields":[{"name":"title"},{"name":"body"},{"name":"blockedBy"},{"name":"issueFieldValues"}]}}}`
 	issueFieldsWithoutRelationships := `{"data":{"Issue":{"fields":[{"name":"title"},{"name":"body"}]}}}`
 
 	tests := []struct {
@@ -28,6 +28,7 @@ func TestIssueFeatures(t *testing.T) {
 			wantFeatures: IssueFeatures{
 				ApiActorsSupported:          true,
 				IssueRelationshipsSupported: true,
+				IssueFieldsSupported:        true,
 			},
 			wantErr: false,
 		},
@@ -37,6 +38,7 @@ func TestIssueFeatures(t *testing.T) {
 			wantFeatures: IssueFeatures{
 				ApiActorsSupported:          true,
 				IssueRelationshipsSupported: true,
+				IssueFieldsSupported:        true,
 			},
 			wantErr: false,
 		},
@@ -49,6 +51,7 @@ func TestIssueFeatures(t *testing.T) {
 			wantFeatures: IssueFeatures{
 				ApiActorsSupported:          false,
 				IssueRelationshipsSupported: true,
+				IssueFieldsSupported:        true,
 			},
 			wantErr: false,
 		},

--- a/pkg/cmd/issue/field/field.go
+++ b/pkg/cmd/issue/field/field.go
@@ -1,0 +1,18 @@
+package field
+
+import (
+	cmdList "github.com/cli/cli/v2/pkg/cmd/issue/field/list"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdField creates the issue field command.
+func NewCmdField(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "field <command>",
+		Short: "View issue fields",
+	}
+
+	cmdutil.AddGroup(cmd, "General commands", cmdList.NewCmdList(f, nil))
+	return cmd
+}

--- a/pkg/cmd/issue/field/list/list.go
+++ b/pkg/cmd/issue/field/list/list.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -21,6 +23,7 @@ type ListOptions struct {
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
 	Exporter   cmdutil.Exporter
+	Detector   fd.Detector
 }
 
 // NewCmdList creates the issue field list command.
@@ -61,14 +64,22 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return err
 	}
+	if opts.Detector == nil {
+		cachedClient := api.NewCachedHTTPClient(httpClient, 24*time.Hour)
+		opts.Detector = fd.NewDetector(cachedClient, repo.RepoHost())
+	}
+	issueFeatures, err := opts.Detector.IssueFeatures()
+	if err != nil {
+		return err
+	}
 
 	opts.IO.StartProgressIndicator()
-	fields, err := api.RepoIssueFields(api.NewClientFromHTTP(httpClient), repo)
+	fields, err := api.RepoIssueFields(api.NewClientFromHTTP(httpClient), repo, issueFeatures.IssueFieldMultiSelectSupported)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
 	}
-	if len(fields) == 0 {
+	if len(fields) == 0 && opts.Exporter == nil {
 		return cmdutil.NewNoResultsError(fmt.Sprintf("no issue fields found in %s", ghrepo.FullName(repo)))
 	}
 	if opts.Exporter != nil {

--- a/pkg/cmd/issue/field/list/list.go
+++ b/pkg/cmd/issue/field/list/list.go
@@ -1,0 +1,90 @@
+package list
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/tableprinter"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+var jsonFields = []string{"id", "name", "dataType", "options"}
+
+type ListOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+	Exporter   cmdutil.Exporter
+}
+
+// NewCmdList creates the issue field list command.
+func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
+	opts := &ListOptions{
+		HttpClient: f.HttpClient,
+		IO:         f.IOStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List issue fields in a repository",
+		Example: heredoc.Doc(`
+			$ gh issue field list
+			$ gh issue field list --repo OWNER/REPO
+			$ gh issue field list --json name,dataType,options
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.BaseRepo = f.BaseRepo
+			if runF != nil {
+				return runF(opts)
+			}
+			return listRun(opts)
+		},
+	}
+
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, jsonFields)
+	return cmd
+}
+
+func listRun(opts *ListOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicator()
+	fields, err := api.RepoIssueFields(api.NewClientFromHTTP(httpClient), repo)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+	if len(fields) == 0 {
+		return cmdutil.NewNoResultsError(fmt.Sprintf("no issue fields found in %s", ghrepo.FullName(repo)))
+	}
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, fields)
+	}
+
+	table := tableprinter.New(opts.IO, tableprinter.WithHeader("NAME", "DATA TYPE", "OPTIONS"))
+	for _, field := range fields {
+		optionNames := make([]string, len(field.Options))
+		for i, option := range field.Options {
+			optionNames[i] = option.Name
+		}
+		table.AddField(field.Name)
+		table.AddField(strings.ToLower(field.DataType))
+		table.AddField(strings.Join(optionNames, ", "))
+		table.EndRow()
+	}
+	return table.Render()
+}

--- a/pkg/cmd/issue/field/list/list_test.go
+++ b/pkg/cmd/issue/field/list/list_test.go
@@ -80,3 +80,49 @@ func TestListRunJSON(t *testing.T) {
 		"options":[{"id":"OPT_1","name":"High"}]
 	}]`, stdout.String())
 }
+
+func TestListRunEmpty(t *testing.T) {
+	tests := []struct {
+		name       string
+		exporter   cmdutil.Exporter
+		wantOutput string
+		wantError  string
+	}{
+		{
+			name:      "human output",
+			wantError: "no issue fields found in OWNER/REPO",
+		},
+		{
+			name:       "JSON output",
+			exporter:   cmdutil.NewJSONExporter(),
+			wantOutput: "[]\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			reg.Register(
+				httpmock.GraphQL(`query RepositoryIssueFields\b`),
+				httpmock.StringResponse(`{"data":{"repository":{"issueFields":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}`),
+			)
+
+			ios, _, stdout, _ := iostreams.Test()
+			opts := &ListOptions{
+				HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+				BaseRepo:   func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
+				IO:         ios,
+				Exporter:   tt.exporter,
+			}
+
+			err := listRun(opts)
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantOutput, stdout.String())
+		})
+	}
+}

--- a/pkg/cmd/issue/field/list/list_test.go
+++ b/pkg/cmd/issue/field/list/list_test.go
@@ -1,0 +1,82 @@
+package list
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/jsonfieldstest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONFields(t *testing.T) {
+	jsonfieldstest.ExpectCommandToSupportJSONFields(t, NewCmdList, []string{
+		"id",
+		"name",
+		"dataType",
+		"options",
+	})
+}
+
+func TestListRun(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryIssueFields\b`),
+		httpmock.StringResponse(`{
+			"data":{"repository":{"issueFields":{"nodes":[
+				{"id":"IF_1","name":"Priority","dataType":"SINGLE_SELECT","options":[{"id":"OPT_1","name":"High"},{"id":"OPT_2","name":"Low"}]},
+				{"id":"IF_2","name":"Due date","dataType":"DATE"}
+			],"pageInfo":{"hasNextPage":false}}}}
+		}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+	ios.SetStdoutTTY(true)
+	opts := &ListOptions{
+		HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+		BaseRepo:   func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
+		IO:         ios,
+	}
+
+	err := listRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "NAME      DATA TYPE      OPTIONS\n")
+	assert.Contains(t, stdout.String(), "Priority  single_select  High, Low\n")
+	assert.Contains(t, stdout.String(), "Due date  date")
+}
+
+func TestListRunJSON(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryIssueFields\b`),
+		httpmock.StringResponse(`{
+			"data":{"repository":{"issueFields":{"nodes":[
+				{"id":"IF_1","name":"Priority","dataType":"SINGLE_SELECT","options":[{"id":"OPT_1","name":"High"}]}
+			],"pageInfo":{"hasNextPage":false}}}}
+		}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+	exporter := cmdutil.NewJSONExporter()
+	exporter.SetFields([]string{"name", "dataType", "options"})
+	opts := &ListOptions{
+		HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+		BaseRepo:   func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
+		IO:         ios,
+		Exporter:   exporter,
+	}
+
+	err := listRun(opts)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{
+		"name":"Priority",
+		"dataType":"single_select",
+		"options":[{"id":"OPT_1","name":"High"}]
+	}]`, stdout.String())
+}

--- a/pkg/cmd/issue/issue.go
+++ b/pkg/cmd/issue/issue.go
@@ -8,6 +8,7 @@ import (
 	cmdDelete "github.com/cli/cli/v2/pkg/cmd/issue/delete"
 	cmdDevelop "github.com/cli/cli/v2/pkg/cmd/issue/develop"
 	cmdEdit "github.com/cli/cli/v2/pkg/cmd/issue/edit"
+	cmdField "github.com/cli/cli/v2/pkg/cmd/issue/field"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/issue/list"
 	cmdLock "github.com/cli/cli/v2/pkg/cmd/issue/lock"
 	cmdPin "github.com/cli/cli/v2/pkg/cmd/issue/pin"
@@ -46,6 +47,7 @@ func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 		cmdList.NewCmdList(f, nil),
 		cmdCreate.NewCmdCreate(f, nil),
 		cmdStatus.NewCmdStatus(f, nil),
+		cmdField.NewCmdField(f),
 	)
 
 	cmdutil.AddGroup(cmd, "Targeted commands",

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/api"
@@ -12,7 +13,60 @@ import (
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestIssueListIssueFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		queryName string
+		list      func(*api.Client, ghrepo.Interface, prShared.FilterOptions) (*api.IssuesAndTotalCount, error)
+		response  string
+	}{
+		{
+			name:      "repository list",
+			queryName: `query IssueList\b`,
+			list: func(client *api.Client, repo ghrepo.Interface, filters prShared.FilterOptions) (*api.IssuesAndTotalCount, error) {
+				return listIssues(client, repo, filters, 30)
+			},
+			response: `{"data":{"repository":{"hasIssuesEnabled":true,"issues":{"totalCount":1,"nodes":[{"issueFields":{"nodes":[{"field":{"name":"Priority","dataType":"SINGLE_SELECT"},"name":"High"}]}}],"pageInfo":{"hasNextPage":false}}}}}`,
+		},
+		{
+			name:      "search list",
+			queryName: `query IssueSearch\b`,
+			list: func(client *api.Client, repo ghrepo.Interface, filters prShared.FilterOptions) (*api.IssuesAndTotalCount, error) {
+				return searchIssues(client, fd.AdvancedIssueSearchSupportedAsOnlyBackend(), repo, filters, 30)
+			},
+			response: `{"data":{"repository":{"hasIssuesEnabled":true},"search":{"issueCount":1,"nodes":[{"issueFields":{"nodes":[{"field":{"name":"Priority","dataType":"SINGLE_SELECT"},"name":"High"}]} }],"pageInfo":{"hasNextPage":false}}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			reg.Register(
+				httpmock.GraphQL(tt.queryName),
+				httpmock.GraphQLQuery(tt.response, func(query string, _ map[string]interface{}) {
+					assert.True(t, strings.Contains(query, "issueFields:issueFieldValues"))
+				}),
+			)
+
+			client := api.NewClientFromHTTP(&http.Client{Transport: reg})
+			result, err := tt.list(client, ghrepo.New("OWNER", "REPO"), prShared.FilterOptions{
+				Entity: "issue",
+				State:  "open",
+				Fields: []string{"issueFields"},
+			})
+			require.NoError(t, err)
+			require.Len(t, result.Issues, 1)
+			require.Len(t, result.Issues[0].IssueFields.Nodes, 1)
+			assert.Equal(t, map[string]interface{}{
+				"name": "Priority", "dataType": "single_select", "value": "High",
+			}, result.Issues[0].IssueFields.Nodes[0].ExportData())
+		})
+	}
+}
 
 func TestIssueList(t *testing.T) {
 	reg := &httpmock.Registry{}

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -136,8 +136,13 @@ func viewRun(opts *ViewOptions) error {
 			if issueFeatures.IssueRelationshipsSupported {
 				lookupFields.AddValues([]string{"blockedBy", "blocking"})
 			}
+			// TODO IssueFieldsCleanup - remove when all supported GHES versions include issue fields.
 			if issueFeatures.IssueFieldsSupported {
-				lookupFields.Add("issueFields")
+				if issueFeatures.IssueFieldMultiSelectSupported {
+					lookupFields.Add("issueFields")
+				} else {
+					lookupFields.Add("issueFieldsWithoutMultiSelect")
+				}
 			}
 		}
 	}

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -132,8 +132,13 @@ func viewRun(opts *ViewOptions) error {
 
 		// TODO IssueRelationshipsCleanup
 		issueFeatures, issueErr := opts.Detector.IssueFeatures()
-		if issueErr == nil && issueFeatures.IssueRelationshipsSupported {
-			lookupFields.AddValues([]string{"blockedBy", "blocking"})
+		if issueErr == nil {
+			if issueFeatures.IssueRelationshipsSupported {
+				lookupFields.AddValues([]string{"blockedBy", "blocking"})
+			}
+			if issueFeatures.IssueFieldsSupported {
+				lookupFields.Add("issueFields")
+			}
 		}
 	}
 
@@ -276,6 +281,9 @@ func printHumanIssuePreview(opts *ViewOptions, baseRepo ghrepo.Interface, issue 
 		fmt.Fprint(out, cs.Bold("Type: "))
 		fmt.Fprintln(out, issue.IssueType.Name)
 	}
+	for _, field := range issue.IssueFields.Nodes {
+		fmt.Fprintf(out, "%s %s\n", cs.Bold(field.Field.Name+":"), formatIssueFieldValue(field.DisplayValue()))
+	}
 	if issue.Parent != nil {
 		fmt.Fprint(out, cs.Bold("Parent: "))
 		fmt.Fprintln(out, formatLinkedIssueRef(issue.Parent)+" "+issue.Parent.Title)
@@ -350,6 +358,13 @@ func printHumanIssuePreview(opts *ViewOptions, baseRepo ghrepo.Interface, issue 
 	fmt.Fprintf(out, cs.Muted("View this issue on GitHub: %s\n"), issue.URL)
 
 	return nil
+}
+
+func formatIssueFieldValue(value interface{}) string {
+	if values, ok := value.([]string); ok {
+		return strings.Join(values, ", ")
+	}
+	return fmt.Sprint(value)
 }
 
 // formatLinkedIssueRef formats an issue reference as owner/repo#N.

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -54,6 +54,7 @@ func TestJSONFields(t *testing.T) {
 		"subIssuesSummary",
 		"blockedBy",
 		"blocking",
+		"issueFields",
 	})
 }
 
@@ -664,6 +665,10 @@ func issueResponseAllIssues2Fields() string {
 		"projectItems": {"nodes": [], "totalCount": 0},
 		"url": "https://github.com/OWNER/REPO/issues/123",
 		"issueType": {"id":"IT_1","name":"Bug","description":"Something is not working","color":"d73a4a"},
+		"issueFields": {"nodes": [
+			{"field":{"id":"IF_1","name":"Priority","dataType":"SINGLE_SELECT"},"name":"High"},
+			{"field":{"id":"IF_2","name":"Teams","dataType":"MULTI_SELECT"},"options":[{"id":"OPT_1","name":"CLI"},{"id":"OPT_2","name":"Desktop"}]}
+		]},
 		"parent": {"number":100,"title":"Epic: Authentication overhaul","url":"https://github.com/OWNER/REPO/issues/100","state":"OPEN","repository":{"nameWithOwner":"OWNER/REPO"}},
 		"subIssues": {
 			"nodes": [
@@ -753,6 +758,10 @@ func TestIssueView_tty_Issues2AllFields(t *testing.T) {
 	// Type metadata row
 	assert.Contains(t, out, "Type:")
 	assert.Contains(t, out, "Bug")
+	assert.Contains(t, out, "Priority:")
+	assert.Contains(t, out, "High")
+	assert.Contains(t, out, "Teams:")
+	assert.Contains(t, out, "CLI, Desktop")
 
 	// Parent metadata row
 	assert.Contains(t, out, "Parent:")
@@ -940,6 +949,31 @@ func TestIssueView_json_IssueType(t *testing.T) {
 	assert.Equal(t, "Bug", issueType["name"])
 	assert.Equal(t, "Something is not working", issueType["description"])
 	assert.Equal(t, "d73a4a", issueType["color"])
+}
+
+func TestIssueView_json_IssueFields(t *testing.T) {
+	httpReg := &httpmock.Registry{}
+	defer httpReg.Verify(t)
+
+	httpReg.Register(
+		httpmock.GraphQL(`query IssueByNumber\b`),
+		httpmock.StringResponse(issueResponseAllIssues2Fields()),
+	)
+
+	output, err := runCommand(httpReg, false, `123 --json issueFields`)
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(output.OutBuf.Bytes(), &data))
+	fields, ok := data["issueFields"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, fields, 2)
+	assert.Equal(t, map[string]interface{}{
+		"name": "Priority", "dataType": "single_select", "value": "High",
+	}, fields[0])
+	assert.Equal(t, map[string]interface{}{
+		"name": "Teams", "dataType": "multi_select", "value": []interface{}{"CLI", "Desktop"},
+	}, fields[1])
 }
 
 func TestIssueView_json_ParentSubIssues(t *testing.T) {

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -63,6 +63,14 @@ func TestNewCmdView(t *testing.T) {
 	argparsetest.TestArgParsing(t, NewCmdView)
 }
 
+type issueFieldsWithoutMultiSelectDetector struct {
+	fd.DisabledDetectorMock
+}
+
+func (d *issueFieldsWithoutMultiSelectDetector) IssueFeatures() (fd.IssueFeatures, error) {
+	return fd.IssueFeatures{IssueFieldsSupported: true}, nil
+}
+
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
 	ios, _, stdout, stderr := iostreams.Test()
 	ios.SetStdoutTTY(isTTY)
@@ -141,6 +149,33 @@ func TestIssueView_web(t *testing.T) {
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "Opening https://github.com/OWNER/REPO/issues/123 in your browser.\n", stderr.String())
 	browser.Verify(t, "https://github.com/OWNER/REPO/issues/123")
+}
+
+func TestIssueViewIssueFieldsWithoutMultiSelect(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.GraphQL(`query IssueByNumber\b`),
+		httpmock.GraphQLQuery(`{"data":{"repository":{"hasIssuesEnabled":true,"issue":{"number":123}}}}`, func(query string, _ map[string]interface{}) {
+			assert.Contains(t, query, "IssueFieldSingleSelectValue")
+			assert.NotContains(t, query, "IssueFieldMultiSelectValue")
+		}),
+	)
+	mockEmptyV2ProjectItems(t, reg)
+
+	err := viewRun(&ViewOptions{
+		IO: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.New("OWNER", "REPO"), nil
+		},
+		Detector:    &issueFieldsWithoutMultiSelectDetector{},
+		IssueNumber: 123,
+	})
+	require.NoError(t, err)
 }
 
 func TestIssueView_nontty_Preview(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Related to https://github.com/github/issues/issues/21241
Design: https://github.com/github/gh-cli-and-desktop/issues/273

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

Issue fields are not currently available when reading issues through `gh`, and there is no command for discovering the issue fields defined for a repository.

This adds read-only issue-field support for text, number, date, single-select, and multi-select values. `gh issue view` renders field values in terminal output, while `gh issue view --json issueFields` and `gh issue list --json issueFields` return normalized JSON. It also adds `gh issue field list`, including table output and `--json id,name,dataType,options`, with pagination over repository field definitions.

Default issue views use feature detection before requesting issue fields so older GHES instances continue to work. Issue fields remain issue-only and are filtered from pull request field lists and GraphQL queries.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

<img width="781" height="439" alt="image" src="https://github.com/user-attachments/assets/e7d69315-2274-4873-a343-7c087c9f8543" />
<img width="517" height="413" alt="image" src="https://github.com/user-attachments/assets/0b3ca59e-f183-4ef6-b83f-9c63f550e50d" />
<img width="448" height="395" alt="image" src="https://github.com/user-attachments/assets/ff448db1-ffc8-433c-b253-c7509e67f8f8" />


### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

This PR is intentionally read-only. Setting and clearing field values will be handled separately. Repository field definitions are fully paginated; values attached to an individual issue currently use the API's first 100 values. Explicit field discovery and `--json issueFields` requests surface API errors on unsupported hosts, while the default terminal view is compatibility-gated because it is not opt-in.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `api/query_builder.go` and `api/queries_issue.go` for the GraphQL and normalized value model, then `pkg/cmd/issue/view/view.go` and `pkg/cmd/issue/field/list/list.go` for the user-facing behavior. The tracking issue and design proposal linked above describe the broader create/edit work that is deliberately outside this PR.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @iulia-b will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
