### PR TITLE
Allow public extension installs past SAML enforcement

### DIFF
--- a/pkg/cmd/extension/saml_fallback.go
+++ b/pkg/cmd/extension/saml_fallback.go
@@ -1,0 +1,78 @@
+package extension
+
+import (
+	"io"
+	"net/http"
+)
+
+const ssoHeader = "X-GitHub-SSO"
+
+// WithSAMLFallback returns a copy of authClient that retries GET requests through
+// plainClient when SAML enforcement rejects the token. Extension repositories are
+// often public but owned by an org the user has no reason to authorize, and a
+// successful anonymous retry proves the repository is public. See
+// https://github.com/cli/cli/issues/6675.
+//
+// This is only sound because anonymous access cannot observe private data, so
+// preferring the anonymous response can never widen what the user sees. Do not
+// reuse it for endpoints whose response body differs by authentication level.
+//
+// onRecover, if non-nil, is called each time a rejected request is recovered.
+func WithSAMLFallback(authClient, plainClient *http.Client, onRecover func()) *http.Client {
+	fallbackClient := *authClient
+	fallbackClient.Transport = samlFallbackTransport{
+		authed:    authClient.Transport,
+		plain:     plainClient.Transport,
+		onRecover: onRecover,
+	}
+	return &fallbackClient
+}
+
+type samlFallbackTransport struct {
+	authed    http.RoundTripper
+	plain     http.RoundTripper
+	onRecover func()
+}
+
+func (t samlFallbackTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// The authenticated chain sets Authorization on req in place, so a clone taken
+	// afterwards would resend the token.
+	var pristine *http.Request
+	if isRetryable(req) {
+		pristine = req.Clone(req.Context())
+	}
+
+	res, err := t.authed.RoundTrip(req)
+	if err != nil || pristine == nil || !isSAMLEnforced(res) {
+		return res, err
+	}
+
+	// Only 4xx and 5xx are failures, because a release asset download answers
+	// with a 302 to a storage host that the outer http.Client then follows.
+	plainRes, plainErr := t.plain.RoundTrip(pristine)
+	if plainErr != nil || plainRes.StatusCode >= http.StatusBadRequest {
+		if plainRes != nil {
+			_, _ = io.Copy(io.Discard, plainRes.Body)
+			plainRes.Body.Close()
+		}
+		// Returning the authenticated response keeps existing errors for private repos.
+		return res, err
+	}
+
+	_, _ = io.Copy(io.Discard, res.Body)
+	res.Body.Close()
+	if t.onRecover != nil {
+		t.onRecover()
+	}
+	return plainRes, nil
+}
+
+func isSAMLEnforced(res *http.Response) bool {
+	return res != nil && res.StatusCode == http.StatusForbidden && res.Header.Get(ssoHeader) != ""
+}
+
+// isRetryable restricts replays to bodyless GETs, which covers every extension
+// request while guaranteeing a mutating request is never resent.
+func isRetryable(req *http.Request) bool {
+	return req.Method == http.MethodGet && req.Body == nil
+}

--- a/pkg/cmd/extension/saml_fallback_test.go
+++ b/pkg/cmd/extension/saml_fallback_test.go
@@ -1,0 +1,348 @@
+package extension
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestWithSAMLFallback(t *testing.T) {
+	samlResponse := func(req *http.Request) (*http.Response, error) {
+		res := &http.Response{
+			Request:    req,
+			StatusCode: http.StatusForbidden,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(`{"message":"Resource protected by organization SAML enforcement"}`)),
+		}
+		res.Header.Set(ssoHeader, "required; url=https://github.com/orgs/o/sso")
+		return res, nil
+	}
+
+	tests := []struct {
+		name             string
+		method           string
+		body             io.Reader
+		authedResponder  httpmock.Responder
+		plainResponder   httpmock.Responder
+		wantPlainCalls   int
+		wantStatus       int
+		wantBody         string
+		wantAuthedHeader string
+	}{
+		{
+			name:            "successful authenticated request is not retried",
+			authedResponder: httpmock.StringResponse(`{"tag_name":"v1.0.0"}`),
+			wantPlainCalls:  0,
+			wantStatus:      http.StatusOK,
+			wantBody:        `{"tag_name":"v1.0.0"}`,
+		},
+		{
+			name:            "non-SAML failure is not retried",
+			authedResponder: httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+			wantPlainCalls:  0,
+			wantStatus:      http.StatusNotFound,
+			wantBody:        `{"message":"Not Found"}`,
+		},
+		{
+			name:            "403 without SSO header is not retried",
+			authedResponder: httpmock.StatusStringResponse(http.StatusForbidden, `{"message":"Forbidden"}`),
+			wantPlainCalls:  0,
+			wantStatus:      http.StatusForbidden,
+			wantBody:        `{"message":"Forbidden"}`,
+		},
+		{
+			name:            "SAML 403 falls back to an unauthenticated request",
+			authedResponder: samlResponse,
+			plainResponder:  httpmock.StringResponse(`{"tag_name":"v1.0.0"}`),
+			wantPlainCalls:  1,
+			wantStatus:      http.StatusOK,
+			wantBody:        `{"tag_name":"v1.0.0"}`,
+		},
+		{
+			name:            "failed fallback returns the original authenticated response",
+			authedResponder: samlResponse,
+			plainResponder:  httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+			wantPlainCalls:  1,
+			wantStatus:      http.StatusForbidden,
+			wantBody:        `{"message":"Resource protected by organization SAML enforcement"}`,
+		},
+		{
+			name:            "non-GET request is not retried",
+			method:          http.MethodPost,
+			authedResponder: samlResponse,
+			wantPlainCalls:  0,
+			wantStatus:      http.StatusForbidden,
+			wantBody:        `{"message":"Resource protected by organization SAML enforcement"}`,
+		},
+		{
+			name:            "GET with a body is not retried",
+			body:            strings.NewReader(`{"query":"..."}`),
+			authedResponder: samlResponse,
+			wantPlainCalls:  0,
+			wantStatus:      http.StatusForbidden,
+			wantBody:        `{"message":"Resource protected by organization SAML enforcement"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authedReg := &httpmock.Registry{}
+			defer authedReg.Verify(t)
+
+			method := tt.method
+			if method == "" {
+				method = http.MethodGet
+			}
+			authedReg.Register(httpmock.REST(method, "repos/OWNER/REPO/releases/latest"), tt.authedResponder)
+
+			plainReg := &httpmock.Registry{}
+			if tt.plainResponder != nil {
+				plainReg.Register(httpmock.REST(http.MethodGet, "repos/OWNER/REPO/releases/latest"), tt.plainResponder)
+			}
+
+			authedClient := &http.Client{Transport: setHeaderTransport{
+				name: "Authorization", value: "token abc123", base: authedReg,
+			}}
+			plainClient := &http.Client{Transport: plainReg}
+
+			req, err := http.NewRequest(method, "https://api.github.com/repos/OWNER/REPO/releases/latest", tt.body)
+			require.NoError(t, err)
+
+			res, err := WithSAMLFallback(authedClient, plainClient, nil).Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			body, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantStatus, res.StatusCode)
+			assert.Equal(t, tt.wantBody, string(body))
+			assert.Len(t, plainReg.Requests, tt.wantPlainCalls)
+			for _, plainReq := range plainReg.Requests {
+				assert.Empty(t, plainReq.Header.Get("Authorization"), "fallback request must not be authenticated")
+			}
+		})
+	}
+}
+
+type setHeaderTransport struct {
+	name  string
+	value string
+	base  http.RoundTripper
+}
+
+func (t setHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(t.name, t.value)
+	return t.base.RoundTrip(req)
+}
+
+func TestWithSAMLFallback_redirectIsSuccess(t *testing.T) {
+	authedReg := &httpmock.Registry{}
+	defer authedReg.Verify(t)
+	authedReg.Register(httpmock.REST("GET", "repos/OWNER/REPO/releases/assets/1"), func(req *http.Request) (*http.Response, error) {
+		res := &http.Response{
+			Request:    req,
+			StatusCode: http.StatusForbidden,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}
+		res.Header.Set(ssoHeader, "required; url=https://github.com/orgs/o/sso")
+		return res, nil
+	})
+
+	plainReg := &httpmock.Registry{}
+	defer plainReg.Verify(t)
+	plainReg.Register(httpmock.REST("GET", "repos/OWNER/REPO/releases/assets/1"), func(req *http.Request) (*http.Response, error) {
+		res := &http.Response{
+			Request:    req,
+			StatusCode: http.StatusFound,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}
+		res.Header.Set("Location", "https://release-assets.githubusercontent.com/asset")
+		return res, nil
+	})
+
+	client := WithSAMLFallback(&http.Client{Transport: authedReg}, &http.Client{Transport: plainReg}, nil)
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/OWNER/REPO/releases/assets/1", nil)
+	require.NoError(t, err)
+
+	// RoundTrip rather than Do, so the redirect is observed instead of followed.
+	res, err := client.Transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusFound, res.StatusCode)
+	assert.Equal(t, "https://release-assets.githubusercontent.com/asset", res.Header.Get("Location"))
+}
+
+// Exercises the whole install path with the fallback wired the way
+// pkg/cmd/factory does it, with every authenticated request SAML rejected.
+// The outer http.Client follows the fallback's 302 back through this transport,
+// so the second hop must not carry the token the authenticated chain set in place.
+func TestWithSAMLFallback_followsRedirectWithoutAuth(t *testing.T) {
+	var mu sync.Mutex
+	var storageReqs []http.Header
+	storage := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		storageReqs = append(storageReqs, r.Header.Clone())
+		mu.Unlock()
+		fmt.Fprint(w, "FAKE BINARY")
+	}))
+	defer storage.Close()
+
+	const apiHost = "api.github.com"
+
+	authed := funcRoundTripper(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host != apiHost {
+			return http.DefaultTransport.RoundTrip(req)
+		}
+		// Mimic the real chain, which attaches the token to req in place.
+		req.Header.Set("Authorization", "token secret")
+		res := &http.Response{
+			Request:    req,
+			StatusCode: http.StatusForbidden,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}
+		res.Header.Set(ssoHeader, "required; url=https://github.com/orgs/o/sso")
+		return res, nil
+	})
+
+	plain := funcRoundTripper(func(req *http.Request) (*http.Response, error) {
+		require.Empty(t, req.Header.Get("Authorization"), "fallback request must not be authenticated")
+		res := &http.Response{
+			Request:    req,
+			StatusCode: http.StatusFound,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("")),
+		}
+		res.Header.Set("Location", storage.URL+"/asset")
+		return res, nil
+	})
+
+	var recovered int
+	client := WithSAMLFallback(
+		&http.Client{Transport: authed},
+		&http.Client{Transport: plain},
+		func() { recovered++ },
+	)
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/OWNER/REPO/releases/assets/1", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "application/octet-stream")
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "FAKE BINARY", string(body))
+	assert.Equal(t, 1, recovered)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, storageReqs, 1)
+	// Accept proves headers really do carry across the redirect, so the absent
+	// Authorization below is meaningful rather than an artifact of nothing copying.
+	assert.Equal(t, "application/octet-stream", storageReqs[0].Get("Accept"))
+	assert.Empty(t, storageReqs[0].Get("Authorization"), "redirected request must not be authenticated")
+}
+
+func TestWithSAMLFallback_onRecoverNotCalledWithoutRecovery(t *testing.T) {
+	authedReg := &httpmock.Registry{}
+	defer authedReg.Verify(t)
+	authedReg.Register(httpmock.MatchAny, httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`))
+
+	var recovered int
+	client := WithSAMLFallback(
+		&http.Client{Transport: authedReg},
+		&http.Client{Transport: &httpmock.Registry{}},
+		func() { recovered++ },
+	)
+
+	res, err := client.Get("https://api.github.com/repos/OWNER/REPO/releases/latest")
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+	assert.Zero(t, recovered)
+}
+
+type funcRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f funcRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestManager_Install_binary_SAMLFallback(t *testing.T) {
+	fakeExtensionName := "gh-bin-ext"
+	repo := ghrepo.NewWithHost("owner", fakeExtensionName, "example.com")
+
+	authedReg := &httpmock.Registry{}
+	defer authedReg.Verify(t)
+	samlRejected := func(req *http.Request) (*http.Response, error) {
+		res := &http.Response{
+			Request:    req,
+			StatusCode: http.StatusForbidden,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(`{"message":"Resource protected by organization SAML enforcement"}`)),
+		}
+		res.Header.Set(ssoHeader, "required; url=https://example.com/orgs/owner/sso")
+		return res, nil
+	}
+	for i := 0; i < 3; i++ {
+		authedReg.Register(httpmock.MatchAny, samlRejected)
+	}
+
+	plainReg := &httpmock.Registry{}
+	defer plainReg.Verify(t)
+	latestRelease := release{
+		Tag: "v1.0.1",
+		Assets: []releaseAsset{
+			{Name: "gh-bin-ext-windows-amd64.exe", APIURL: "https://example.com/release/cool"},
+		},
+	}
+	plainReg.Register(httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"), httpmock.JSONResponse(latestRelease))
+	plainReg.Register(httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"), httpmock.JSONResponse(latestRelease))
+	plainReg.Register(httpmock.REST("GET", "release/cool"), httpmock.StringResponse("FAKE BINARY"))
+
+	ios, _, _, _ := iostreams.Test()
+	dataDir := t.TempDir()
+
+	client := WithSAMLFallback(&http.Client{Transport: authedReg}, &http.Client{Transport: plainReg}, nil)
+	m := newTestManager(dataDir, t.TempDir(), client, nil, ios)
+
+	require.NoError(t, m.Install(repo, ""))
+
+	manifest, err := os.ReadFile(filepath.Join(dataDir, "extensions/gh-bin-ext", manifestName))
+	require.NoError(t, err)
+
+	var bm binManifest
+	require.NoError(t, yaml.Unmarshal(manifest, &bm))
+	assert.Equal(t, binManifest{
+		Name:  fakeExtensionName,
+		Owner: "owner",
+		Host:  "example.com",
+		Tag:   "v1.0.1",
+		Path:  filepath.Join(dataDir, "extensions/gh-bin-ext/gh-bin-ext.exe"),
+	}, bm)
+
+	fakeBin, err := os.ReadFile(filepath.Join(dataDir, "extensions/gh-bin-ext/gh-bin-ext.exe"))
+	require.NoError(t, err)
+	assert.Equal(t, "FAKE BINARY", string(fakeBin))
+}

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -283,6 +283,13 @@ func extensionManager(f *cmdutil.Factory) *extension.Manager {
 		return em
 	}
 
+	// SAML enforcement rejects a valid token even for public extension repos.
+	// Clearing ssoHeader on recovery matters because Main reports SSOURL for any
+	// later failure, which would otherwise blame SSO for an unrelated error.
+	if plainClient, plainErr := f.PlainHttpClient(); plainErr == nil {
+		client = extension.WithSAMLFallback(client, plainClient, func() { ssoHeader = "" })
+	}
+
 	em.SetClient(api.NewCachedHTTPClient(client, time.Second*30))
 
 	return em


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Fixes #6675

Supersedes #14108, which was auto-closed for size. Per @BagToad's feedback, this rewrite drops from 646 changed lines across 10 files to 433 across 3, and no longer touches `internal/ghcmd/cmd.go` or `api/`.

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

Organizations can require SAML single sign-on, and until a user authorizes their token for that specific organization GitHub answers API requests for it with a 403 carrying an `X-GitHub-SSO` header. Extensions are often published by organizations a user has no other reason to work with, so `gh extension install github/gh-net` fails for people who have a perfectly valid token.

The frustrating part is that nothing about the request needs authentication. The repository is public and the release is downloadable by anyone, so sending no token at all succeeds where sending a valid one fails.

This adds a round tripper on the extension manager's HTTP client that notices a SAML-enforced 403 and replays the request with no authentication. A successful anonymous response is itself proof that the repository is public, so no extra visibility check is needed. If the anonymous retry does not succeed, the original authenticated response is returned unchanged, so private repositories and non-SAML failures keep exactly the errors they have today.

Because it sits at the transport layer, every extension request is covered - release lookup, pinned tags, script detection, asset download, and upgrades - without any change to `Manager`.

### How did you test this change?

<!--
Demonstrate the code is solid, and how you know it solves the problem in the description.
Give the exact commands you ran and their output.
If this changes command output, show it before and after. Screenshot images are preferred over pasted text.

If you leave this empty, your pull request will very likely be closed.
-->

- `go test ./pkg/cmd/extension/... ./pkg/cmd/factory/...` - passed
- `go test -race ./pkg/cmd/extension/... ./pkg/cmd/factory/...` - passed
- `go test ./...` - passed, apart from a `pkg/cmd/auth/shared/gitcredentials` failure that reproduces on unmodified `trunk` on my machine because of a local credential helper
- `golangci-lint run ./pkg/cmd/extension/... ./pkg/cmd/factory/...` - `0 issues.`

`TestManager_Install_binary_SAMLFallback` drives a real `Manager.Install` with the fallback wired the way `pkg/cmd/factory` wires it, with every authenticated request SAML rejected, and asserts the manifest and binary are written from the anonymous responses.

I also ran the fallback against live github.com, forcing every authenticated request to return a SAML 403:

```
authed request REJECTED with SAML 403: https://api.github.com/repos/github/gh-stack/releases/latest
anonymous retry:                       https://api.github.com/repos/github/gh-stack/releases/latest
authed request REJECTED with SAML 403: https://api.github.com/repos/github/gh-stack/releases/latest
anonymous retry:                       https://api.github.com/repos/github/gh-stack/releases/latest
authed request REJECTED with SAML 403: https://api.github.com/repos/github/gh-stack/releases/assets/494339447
anonymous retry:                       https://api.github.com/repos/github/gh-stack/releases/assets/494339447
authed request REJECTED with SAML 403: https://release-assets.githubusercontent.com/...
anonymous retry:                       https://release-assets.githubusercontent.com/...
installed .../extensions/gh-stack/gh-stack (23776960 bytes)
```

`gh-stack --help` then ran from the installed binary. As a control, `gh extension install github/gh-stack` with no token and isolated config, data, and cache directories also installs successfully, confirming the anonymous path is genuinely sufficient.

That live run caught two bugs the unit tests had not:

1. The authenticated transport chain sets `Authorization` on the request in place, so cloning after the first attempt leaked the token into the anonymous retry. The request is now snapshotted before the authenticated chain runs, and a test asserts the retry carries no `Authorization` header.
2. Release asset downloads answer with a 302, which an initial `>= 300` failure check rejected. Only 4xx and 5xx count as failures now, with a regression test.

A test also follows that redirect through a real `httptest` server and asserts the second hop reaches the storage host with no `Authorization` header, while a caller-set `Accept` header does carry across, so the assertion is not vacuous.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- Only bodyless GETs are replayed, so a mutating request can never be resent.
- The fallback is scoped to the extension manager's client, so no other command changes behavior.
- The previous version of this change also made `X-GitHub-SSO` extraction request-scoped, which required touching `internal/ghcmd/cmd.go` and every command's error path. That is replaced by a one-line hook: `WithSAMLFallback` takes an `onRecover` callback, and `pkg/cmd/factory` passes one that clears the recorded SSO header. This matters because `ghcmd.Main` prints "Authorize in your web browser" whenever that header is set and the command failed, for any error. Without clearing it, a SAML-org user installing an extension that publishes no binary for their platform would see the correct "unsupported for darwin-arm64" message followed by a bogus authorization prompt, because the 403s along the way were recovered rather than fatal.
- The fallback is deliberately narrow: it is only sound because an anonymous request cannot observe private data, so preferring the anonymous response can never widen what the user sees. That is stated in the doc comment so it is not reused for endpoints whose response body varies by authentication level.
- The previous version also threaded the resolved release and client through `Manager` to avoid duplicate lookups. That is unnecessary: `go-gh` does not cache 403s but does cache the successful anonymous response, so the SAML path costs one extra request rather than a doubled one.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

`pkg/cmd/extension/saml_fallback.go` is the whole change at 78 lines; `pkg/cmd/factory/default.go` is the 7-line wiring. Everything else is tests.

The judgement call I would most like a second opinion on is putting this at the transport layer at all. It keeps the diff small and covers every extension request without touching `Manager`, but it does mean an authentication downgrade happens somewhere a reader of the call site would not see it. I think the doc comment plus the anonymous-cannot-see-more argument carries it, but I would rather be told otherwise now than later.

Issue #6675 has the original `github/gh-net` report. #14108 is the prior, larger version of this change and its review discussion.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @loganrosen will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
