### PR TITLE
Don't ask for feature detection cleanup comments when not needed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,8 @@ if features.SomeCapability {
 
 Use feature detection only when an API is not GA on all supported GHES versions; skip it for long-established APIs.
 
+Note that a cleanup comment is only needed when a feature will eventually be available on all GitHub API server (i.e. `github.com`, GHEC, and GHES). Those that are not going to be supported on GHES should not have a cleanup comment.
+
 ## API Patterns
 
 ```go

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Use `cmdutil.MutuallyExclusive("message", cond1, cond2)` for mutually exclusive 
 
 ## Feature Detection
 
-Commands using feature detection must include a `// TODO <cleanupIdentifier>` comment directly above the if-statement for linter compliance:
+Commands using feature detection for a temporary gate (one that will eventually be available on all GitHub API servers, i.e. `github.com`, GHEC, and GHES) must include a `// TODO <cleanupIdentifier>` comment directly above the if-statement for linter compliance:
 
 ```go
 // TODO someFeatureCleanup
@@ -173,7 +173,7 @@ if features.SomeCapability {
 
 Use feature detection only when an API is not GA on all supported GHES versions; skip it for long-established APIs.
 
-Note that a cleanup comment is only needed when a feature will eventually be available on all GitHub API server (i.e. `github.com`, GHEC, and GHES). Those that are not going to be supported on GHES should not have a cleanup comment.
+A cleanup comment is not needed when the gate is permanent, i.e. the feature is not going to be supported on GHES.
 
 ## API Patterns
 


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

This change is due to the misleading comment on another PR review (https://github.com/cli/cli/pull/14006#discussion_r3766452399) where :copilot: was asking for a cleanup comment on a feature detection conditional, while it didn't make sense because the feature would never be shipped to GHES.

### How did you test this change?

N/A

### Key points

N/A

### Notes for reviewers

N/A

### Authorship and follow-up

Who wrote this:

- [x] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @babakks will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
