### PR TITLE
fix(skills): install Codex user skills to ~/.agents/skills

### DIFF
--- a/internal/skills/registry/registry.go
+++ b/internal/skills/registry/registry.go
@@ -69,7 +69,7 @@ var Agents = []AgentHost{
 		ID:         "codex",
 		Name:       "Codex",
 		ProjectDir: sharedProjectSkillsDir,
-		UserDir:    ".codex/skills",
+		UserDir:    sharedProjectSkillsDir,
 	},
 	{
 		ID:         "gemini-cli",

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -115,6 +115,14 @@ func TestInstallDir(t *testing.T) {
 			wantDir: filepath.Join("/tmp/monalisa-repo", ".agents", "skills"),
 		},
 		{
+			name:    "codex user scope",
+			hostID:  "codex",
+			scope:   ScopeUser,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/home/monalisa", ".agents", "skills"),
+		},
+		{
 			name:    "gemini project scope",
 			hostID:  "gemini-cli",
 			scope:   ScopeProject,


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

Fixes #14153

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

`gh skill install --agent codex --scope user` still installed skills to the deprecated `~/.codex/skills` directory. Codex now documents `~/.agents/skills` as its user-level skill directory, and project-scoped installs already follow the matching `.agents/skills` convention.

This changes the Codex registry entry to use the shared `.agents/skills` directory at user scope and adds regression coverage for that path.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

Given a temporary home directory and the repository's local `code-review` skill,
when I ran the built CLI with `skill install . code-review --from-local --allow-hidden-dirs --agent codex --scope user`,
then the command reported installation in `~/.agents\skills`, the installed `SKILL.md` existed under that directory, and no skill was created under `~/.codex/skills`.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

This updates the canonical registry path only. It does not move existing files from `~/.codex/skills`; users with an existing gh-managed installation there can reinstall the skill to place it in the current directory. `gh skill list` and `gh skill update` will use the new registry path as well.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

The functional change is the Codex `UserDir` entry in `internal/skills/registry/registry.go`, followed by the new user-scope case in `TestInstallDir`.

#13681 made the same directory correction for the Universal host and is the closest prior change.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @scarletkc will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
