### PR TITLE
test: stabilize Windows development checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 .github/actions/*/lib/* linguist-generated
 
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
+
+*.go text eol=lf

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/cli/cli/v2/api"
@@ -16,6 +17,7 @@ import (
 	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_printError(t *testing.T) {
@@ -85,6 +87,18 @@ check your internet connection or https://githubstatus.com
 }
 
 func Test_newIOStreams_pager(t *testing.T) {
+	for _, key := range []string{"GH_PAGER", "PAGER"} {
+		value, exists := os.LookupEnv(key)
+		require.NoError(t, os.Unsetenv(key))
+		t.Cleanup(func() {
+			if exists {
+				require.NoError(t, os.Setenv(key, value))
+			} else {
+				require.NoError(t, os.Unsetenv(key))
+			}
+		})
+	}
+
 	tests := []struct {
 		name      string
 		env       map[string]string

--- a/internal/prompter/huh_prompter_test.go
+++ b/internal/prompter/huh_prompter_test.go
@@ -2,6 +2,7 @@ package prompter
 
 import (
 	"io"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -32,7 +33,7 @@ func newInteraction(steps ...interactionStep) interaction {
 	return interaction{steps: steps}
 }
 
-func (ix interaction) run(t *testing.T, w *io.PipeWriter) {
+func (ix interaction) run(t *testing.T, w io.Writer) {
 	t.Helper()
 	for _, s := range ix.steps {
 		if s.waitFn != nil {
@@ -152,10 +153,15 @@ func newTestHuhPrompter() *huhPrompter {
 }
 
 // runForm runs a huh form with the given interaction, returning any error.
-// The form runs in a goroutine using bubbletea's real event loop via io.Pipe.
+// The form runs in a goroutine using bubbletea's real event loop via os.Pipe.
 func runForm(t *testing.T, f *huh.Form, ix interaction) {
 	t.Helper()
-	r, w := io.Pipe()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, r.Close())
+		require.NoError(t, w.Close())
+	})
 	f.WithInput(r).WithOutput(io.Discard).WithWidth(80)
 
 	errCh := make(chan error, 1)

--- a/pkg/cmd/auth/shared/gitcredentials/updater_test.go
+++ b/pkg/cmd/auth/shared/gitcredentials/updater_test.go
@@ -19,7 +19,7 @@ func configureStoreCredentialHelper(t *testing.T) {
 
 	gc := &git.Client{}
 	// Use `--file` to store credentials in a temporary file that gets cleaned up when the test has finished running
-	cmd, err := gc.Command(context.Background(), "config", "--global", "--add", "credential.helper", fmt.Sprintf("store --file %s", tmpCredentialsFile))
+	cmd, err := gc.Command(context.Background(), "config", "--global", "--add", "credential.helper", fmt.Sprintf("store --file %q", filepath.ToSlash(tmpCredentialsFile)))
 	require.NoError(t, err)
 	require.NoError(t, cmd.Run())
 }


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Fixes #14156

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

Windows development checks had four platform-specific failure modes:

- Git's default `core.autocrlf=true` checkout converted Go files to CRLF, so the `gofmt` formatter reported hundreds of unchanged files.
- The pager test inherited `GH_PAGER` and `PAGER` from the invoking shell when a test case did not set them.
- The Huh test harness used `io.Pipe`, which prevented Bubble Tea forms from completing on Windows.
- The credential updater test passed an unquoted Windows path with backslashes to Git's credential helper configuration, causing Git to write test credentials into the repository root.

This change pins Go files to LF in `.gitattributes`, isolates pager environment variables, uses an OS pipe for the Huh event loop, and quotes a slash-normalized temporary credential path.

The changes affect development and test behavior only. Production `gh` behavior is unchanged.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

On Windows with Git's global `core.autocrlf=true`, I checked out the committed branch into a fresh worktree and inspected representative Go files with `git ls-files --eol`. Their index and worktree forms were both LF, and the repository-wide linter no longer proposed formatter changes.

I kept `GH_PAGER=cat` and `PAGER=cat` in the outer shell while exercising the full test suite. The pager cases used their own declared environments, the Huh form interactions completed, and the credential updater left its file in the temporary directory instead of creating path-shaped files in the repository root.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- The LF rule is limited to `*.go`; this avoids changing line-ending policy for unrelated file types.
- The PR does not contain a bulk line-ending rewrite. Renormalizing the index changed only the four intended files.
- `os.Pipe` preserves the real Bubble Tea event-loop coverage while providing a native cross-platform pipe.
- Converting the temporary credential path to slash form before quoting supports Windows drive paths and paths containing spaces.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `.gitattributes` and `internal/prompter/huh_prompter_test.go`; those address the two failures that prevented repository-wide Windows checks from completing. The pager and credential changes isolate the remaining test-only leaks discovered by that run.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @scarletkc will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
