### PR TITLE
issue/list: fix searchIssues over-fetching subsequent pages

### DIFF
--- a/pkg/cmd/issue/list/http.go
+++ b/pkg/cmd/issue/list/http.go
@@ -212,7 +212,7 @@ loop:
 			break
 		}
 		variables["after"] = resp.Search.PageInfo.EndCursor
-		variables["perPage"] = min(perPage, limit-len(ic.Issues))
+		variables["limit"] = min(perPage, limit-len(ic.Issues))
 	}
 
 	return &ic, nil

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -2,8 +2,10 @@ package list
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/api"
@@ -213,6 +215,51 @@ func TestSearchIssuesAndAdvancedSearch(t *testing.T) {
 			searchIssues(client, tt.detector, ghrepo.New("OWNER", "REPO"), prShared.FilterOptions{State: "open"}, 30)
 		})
 	}
+}
+
+func TestSearchIssues_pagination(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	makeNodes := func(n int) string {
+		nodes := make([]string, n)
+		for i := range nodes {
+			nodes[i] = `{"title": "issue"}`
+		}
+		return "[" + strings.Join(nodes, ",") + "]"
+	}
+
+	var firstLimit, secondLimit float64
+	reg.Register(
+		httpmock.GraphQL(`query IssueSearch\b`),
+		httpmock.GraphQLQuery(
+			fmt.Sprintf(`{"data":{"repository":{"hasIssuesEnabled":true},"search":{"issueCount":150,"nodes":%s,"pageInfo":{"hasNextPage":true,"endCursor":"ENDCURSOR"}}}}`, makeNodes(100)),
+			func(_ string, vars map[string]interface{}) {
+				firstLimit = vars["limit"].(float64)
+			},
+		),
+	)
+	reg.Register(
+		httpmock.GraphQL(`query IssueSearch\b`),
+		httpmock.GraphQLQuery(
+			fmt.Sprintf(`{"data":{"repository":{"hasIssuesEnabled":true},"search":{"issueCount":150,"nodes":%s,"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`, makeNodes(50)),
+			func(_ string, vars map[string]interface{}) {
+				secondLimit = vars["limit"].(float64)
+			},
+		),
+	)
+
+	httpClient := &http.Client{Transport: reg}
+	client := api.NewClientFromHTTP(httpClient)
+
+	res, err := searchIssues(client, fd.AdvancedIssueSearchSupportedAsOnlyBackend(), ghrepo.New("OWNER", "REPO"), prShared.FilterOptions{State: "open"}, 150)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assert.Equal(t, 150, len(res.Issues))
+	assert.Equal(t, float64(100), firstLimit, "first page should request the full page size")
+	assert.Equal(t, float64(50), secondLimit, "second page should only request the remaining count, not another full page")
 }
 
 func TestSearchIssues_rejectsPullRequestQualifiers(t *testing.T) {


### PR DESCRIPTION
## What this PR does
Fixes #13906.

`searchIssues` (`gh issue list --search`) writes the shrinking per-page size for subsequent pages to `variables["perPage"]`. The `IssueSearch` GraphQL operation only declares `$limit` (consumed at `search(..., last: $limit, ...)`) and has no `$perPage` variable, so the write is silently discarded — `variables["limit"]` stays pinned at `min(limit, 100)`, and every page after the first requests a full page instead of only the remaining count.

`listIssues` in the same file already writes this reduction to the correct `variables["limit"]`; `searchIssues` was the lone outlier.

## Fix
One-line change: write the reduced count to `variables["limit"]` instead of `variables["perPage"]`.

## Verification
- Added `TestSearchIssues_pagination`, asserting the second page's `limit` reflects the remaining count (50) rather than another full page (100).
- Confirmed the new test fails against the pre-fix code (asserts 50, gets 100 — reproducing the exact over-fetch) and passes with the fix.
- `go build ./...`, `go vet ./pkg/cmd/issue/list/...`, and the full `pkg/cmd/issue/list` test suite pass; `gofmt` clean.