### PR TITLE
fix(issue): preserve comments on already closed issues

### DIFF
--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -115,6 +115,20 @@ func closeRun(opts *CloseOptions) error {
 	}
 
 	if issue.State == "CLOSED" {
+		if opts.Comment != "" {
+			commentOpts := &prShared.CommentableOptions{
+				Body:       opts.Comment,
+				HttpClient: opts.HttpClient,
+				InputType:  prShared.InputTypeInline,
+				Quiet:      true,
+				RetrieveCommentable: func() (prShared.Commentable, ghrepo.Interface, error) {
+					return issue, baseRepo, nil
+				},
+			}
+			if err := prShared.CommentableRun(commentOpts); err != nil {
+				return err
+			}
+		}
 		fmt.Fprintf(opts.IO.ErrOut, "%s Issue %s#%d (%s) is already closed\n", cs.Yellow("!"), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 		return nil
 	}

--- a/pkg/cmd/issue/close/close_test.go
+++ b/pkg/cmd/issue/close/close_test.go
@@ -338,6 +338,7 @@ func TestCloseRun(t *testing.T) {
 			name: "issue already closed",
 			opts: &CloseOptions{
 				IssueNumber: 13,
+				Comment:     "closing comment",
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
@@ -347,6 +348,16 @@ func TestCloseRun(t *testing.T) {
               "hasIssuesEnabled": true,
               "issue": { "number": 13, "title": "The title of the issue", "state": "CLOSED"}
             } } }`),
+				)
+				reg.Register(
+					httpmock.GraphQL(`mutation CommentCreate\b`),
+					httpmock.GraphQLMutation(`
+            { "data": { "addComment": { "commentEdge": { "node": {
+              "url": "https://github.com/OWNER/REPO/issues/13#issuecomment-456"
+            } } } } }`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, "closing comment", inputs["body"])
+						}),
 				)
 			},
 			wantStderr: "! Issue OWNER/REPO#13 (The title of the issue) is already closed\n",


### PR DESCRIPTION
Closes #14152

### Description

When `gh issue close --comment` was used for an issue that was already closed, the command returned before posting the requested comment. The command now posts the comment before reporting that the issue is already closed; the close operation remains a no-op.

### How did you test this change?

Given an already-closed issue and a closing comment, the command posts the comment and reports that the issue is already closed without attempting another close mutation. The regression test exercises the comment mutation on the already-closed path.

### Key points

The existing behavior for already-closed issues without `--comment`, and for open issues with `--comment`, is unchanged.

### Notes for reviewers

The implementation and regression test are in `pkg/cmd/issue/close/`. The issue's expected behavior is to preserve the comment, matching the web UI's close-with-comment behavior.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [x] Nobody has explicitly committed to replying.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
