### PR TITLE
fix: `gh ssh-key delete` cannot delete signing keys

### DIFF
--- a/pkg/cmd/ssh-key/delete/delete.go
+++ b/pkg/cmd/ssh-key/delete/delete.go
@@ -78,7 +78,7 @@ func deleteRun(opts *DeleteOptions) error {
 		}
 	}
 
-	err = deleteSSHKey(httpClient, host, opts.KeyID)
+	err = deleteSSHKey(httpClient, host, opts.KeyID, key.IsSigningKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/ssh-key/delete/http.go
+++ b/pkg/cmd/ssh-key/delete/http.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
@@ -8,11 +9,20 @@ import (
 )
 
 type sshKey struct {
-	Title string
+	Title        string
+	IsSigningKey bool
 }
 
-func deleteSSHKey(httpClient *http.Client, host string, keyID string) error {
-	path, err := safeurl.JoinPath("user", "keys", keyID)
+func deleteSSHKey(httpClient *http.Client, host string, keyID string, isSigningKey bool) error {
+	var (
+		path *safeurl.MutableSafeURL
+		err  error
+	)
+	if isSigningKey {
+		path, err = safeurl.JoinPath("user", "ssh_signing_keys", keyID)
+	} else {
+		path, err = safeurl.JoinPath("user", "keys", keyID)
+	}
 	if err != nil {
 		return err
 	}
@@ -23,6 +33,22 @@ func deleteSSHKey(httpClient *http.Client, host string, keyID string) error {
 }
 
 func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, error) {
+	key, err := getAuthenticationKey(httpClient, host, keyID)
+	if err == nil {
+		return key, nil
+	}
+
+	var httpErr api.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusNotFound {
+		return nil, err
+	}
+
+	// Not found among authentication keys; try signing keys, which live under
+	// a separate endpoint with their own ID namespace.
+	return getSigningKey(httpClient, host, keyID)
+}
+
+func getAuthenticationKey(httpClient *http.Client, host string, keyID string) (*sshKey, error) {
 	var key sshKey
 	path, err := safeurl.JoinPath("user", "keys", keyID)
 	if err != nil {
@@ -35,6 +61,24 @@ func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, err
 	if err != nil {
 		return nil, err
 	}
+
+	return &key, nil
+}
+
+func getSigningKey(httpClient *http.Client, host string, keyID string) (*sshKey, error) {
+	var key sshKey
+	path, err := safeurl.JoinPath("user", "ssh_signing_keys", keyID)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(api-client-rollout)
+	// This line of code is part of a mechanical roll out of the api client.
+	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
+	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodGet, path.String(), nil, &key)
+	if err != nil {
+		return nil, err
+	}
+	key.IsSigningKey = true
 
 	return &key, nil
 }


### PR DESCRIPTION
When `gh ssh-key delete <id>` is called with a signing key ID (copied from `gh ssh-key list`), the command always routes to `DELETE /user/keys/{id}` (the authentication keys endpoint). Signing keys live under a separate endpoint (`/user/ssh_signing_keys/{id}`) with an independent ID namespace, so the request returns HTTP 404 and the key is never deleted.

### Change

- `getSSHKey` now tries the authentication keys endpoint first; on HTTP 404 it falls back to the signing keys endpoint.
- `deleteSSHKey` accepts the resolved key type and uses the correct endpoint for deletion.
- Existing authentication key deletion is unaffected.

### Related

Fixes #14064
