### PR TITLE
fix(auth/status): report keyring error instead of misleading "invalid token" message

### DIFF
--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -93,7 +93,11 @@ func (e authEntry) String(cs *iostreams.ColorScheme) string {
 		}
 		activeStr := fmt.Sprintf("%v", e.Active)
 		sb.WriteString(fmt.Sprintf("  - Active account: %s\n", cs.Bold(activeStr)))
-		sb.WriteString(fmt.Sprintf("  - The token in %s is invalid.\n", e.TokenSource))
+		if e.Error != "" {
+			sb.WriteString(fmt.Sprintf("  - %s\n", e.Error))
+		} else {
+			sb.WriteString(fmt.Sprintf("  - The token in %s is invalid.\n", e.TokenSource))
+		}
 		if authTokenWriteable(e.TokenSource) {
 			loginInstructions := fmt.Sprintf("gh auth login -h %s", e.Host)
 			if shared.AuthTokenRefreshable(e.Token, e.TokenSource) {
@@ -382,6 +386,16 @@ func buildEntry(httpClient *http.Client, opts buildEntryOptions) authEntry {
 		TokenSource: tokenSource,
 		Token:       opts.token,
 		GitProtocol: opts.gitProtocol,
+	}
+
+	// If the token is empty, the keyring is inaccessible (e.g. macOS system daemon
+	// without a graphical session). Report the keyring error instead of making an
+	// API call that would produce a misleading "invalid token" message.
+	if opts.token == "" {
+		entry.State = authEntryStateError
+		entry.Error = "The auth token could not be read from the keyring; " +
+			"try setting the GH_TOKEN environment variable or re-authenticating with --insecure-storage"
+		return entry
 	}
 
 	// If token is not writeable, then it came from an environment variable and


### PR DESCRIPTION
Fixes #14171

## Problem

When `gh` runs in an environment without access to the user's graphical session (e.g., a macOS system daemon), reading the auth token from the keyring fails with a permission error. `gh auth status` then reports "The token in default is invalid" and suggests re-authenticating — but re-authenticating can never succeed because the token also cannot be stored in the keyring from that environment.

## Root Cause

`authCfg.ActiveToken(hostname)` returns an empty token when the keyring is inaccessible. `buildEntry` then calls `shared.GetScopes(httpClient, hostname, "")` with an empty token, which makes a GitHub API call that returns 401 Unauthorized. The error is reported as an "invalid token" rather than a keyring access problem.

## Fix

Two changes in `pkg/cmd/auth/status/status.go`:

1. **`buildEntry`**: Check if the token is empty before making the API call. If empty, return a clear error message directing the user to set `GH_TOKEN` or use `--insecure-storage`.

2. **`String()`**: Display the `entry.Error` field when it is set, instead of the hardcoded "The token is invalid" message. This also benefits other error cases that set `entry.Error`.
