### PR TITLE
fix(gitcredential): replace fuzzy gist prefix match with exact host validation

### DIFF
--- a/pkg/cmd/auth/gitcredential/helper.go
+++ b/pkg/cmd/auth/gitcredential/helper.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
@@ -113,9 +114,28 @@ func helperRun(opts *CredentialOptions) error {
 	lookupHost := wants["host"]
 	var gotUser string
 	gotToken, source := cfg.ActiveToken(lookupHost)
-	if gotToken == "" && strings.HasPrefix(lookupHost, "gist.") {
-		lookupHost = strings.TrimPrefix(lookupHost, "gist.")
-		gotToken, source = cfg.ActiveToken(lookupHost)
+	if gotToken == "" {
+		// Check if the lookup host is the gist subdomain for the default
+		// GitHub host (gist.github.com) or a tenancy host (gist.<tenant>.ghe.com).
+		// For GHES and other instances, gist uses path-based routing
+		// (e.g. ghes.example.com/gist/) so the credential host is the base host.
+		//
+		// Previously this used strings.HasPrefix(lookupHost, "gist.") without
+		// host validation, which incorrectly matched any host starting with
+		// "gist." (e.g. gist.evil.com), potentially returning credentials for
+		// a different host.
+		defaultHost := ghinstance.Default()
+		gistHost := strings.TrimSuffix(ghinstance.GistHost(defaultHost), "/")
+		if strings.EqualFold(lookupHost, gistHost) {
+			lookupHost = defaultHost
+			gotToken, source = cfg.ActiveToken(lookupHost)
+		} else if strings.HasPrefix(lookupHost, "gist.") {
+			baseHost := strings.TrimPrefix(lookupHost, "gist.")
+			if _, isTenancy := ghinstance.TenantName(baseHost); isTenancy {
+				lookupHost = baseHost
+				gotToken, source = cfg.ActiveToken(lookupHost)
+			}
+		}
 	}
 
 	if strings.HasSuffix(source, "_TOKEN") {

--- a/pkg/cmd/auth/gitcredential/helper_test.go
+++ b/pkg/cmd/auth/gitcredential/helper_test.go
@@ -105,6 +105,74 @@ func Test_helperRun(t *testing.T) {
 			wantStderr: "",
 		},
 		{
+			name: "gist prefix with tenancy host should match",
+			opts: CredentialOptions{
+				Operation: "get",
+				Config: func() (config, error) {
+					return tinyConfig{
+						"_source":                       "/Users/monalisa/.config/gh/hosts.yml",
+						"mytenant.ghe.com:user":        "monalisa",
+						"mytenant.ghe.com:oauth_token": "TENANT_TOKEN",
+					}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=gist.mytenant.ghe.com
+				username=monalisa
+			`),
+			wantErr: false,
+			wantStdout: heredoc.Doc(`
+				protocol=https
+				host=gist.mytenant.ghe.com
+				username=monalisa
+				password=TENANT_TOKEN
+			`),
+			wantStderr: "",
+		},
+		{
+			name: "gist prefix with non-GitHub host should not match",
+			opts: CredentialOptions{
+				Operation: "get",
+				Config: func() (config, error) {
+					return tinyConfig{
+						"_source":                  "/Users/monalisa/.config/gh/hosts.yml",
+						"evil.com:user":            "monalisa",
+						"evil.com:oauth_token":     "EVIL_TOKEN",
+						"github.com:user":          "monalisa",
+						"github.com:oauth_token":   "GITHUB_TOKEN",
+					}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=gist.evil.com
+			`),
+			wantErr:    true,
+			wantStdout: "",
+			wantStderr: "",
+		},
+		{
+			name: "gist prefix with custom corp host should not match",
+			opts: CredentialOptions{
+				Operation: "get",
+				Config: func() (config, error) {
+					return tinyConfig{
+						"_source":                    "/Users/monalisa/.config/gh/hosts.yml",
+						"mycorp.com:user":            "monalisa",
+						"mycorp.com:oauth_token":     "CORP_TOKEN",
+					}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=gist.mycorp.com
+			`),
+			wantErr:    true,
+			wantStdout: "",
+			wantStderr: "",
+		},
+		{
 			name: "url input",
 			opts: CredentialOptions{
 				Operation: "get",


### PR DESCRIPTION
Fixes #14176

### Description

In `pkg/cmd/auth/gitcredential/helper.go`, when `cfg.ActiveToken(lookupHost)` returns empty, the credential helper attempted to fall back to the base host token if `strings.HasPrefix(lookupHost, "gist.")` by stripping the `"gist."` prefix.

However, using a loose prefix-only match meant that any host starting with `gist.` (such as `gist.evil.com` or `gist.customdomain.com`) would trigger the fallback logic and attempt to retrieve stored credentials for the stripped domain (e.g. `evil.com`).

This change replaces the loose prefix matching with exact host validation:
1. Matches `gist.github.com` (the canonical gist host for default GitHub `github.com`).
2. Supports GitHub Tenancy instances (`gist.<tenant>.ghe.com`) via `ghinstance.TenantName`.
3. For GHES and other GitHub instances, gist uses path-based routing (`hostname/gist/`) where the credential helper host is already the base host.
4. Non-GitHub domains prefixed with `gist.` are safely ignored and will not trigger token lookup for other hosts.

### How did you test this change?

**Scenario 1: Fallback for gist.github.com (Default Host)**
- **Given** GitHub CLI is authenticated with `github.com` (user `monalisa`, token `OTOKEN`)
- **When** Git credential helper requests credentials for `protocol=https\nhost=gist.github.com`
- **Then** It successfully falls back and returns credentials for `github.com` (`username=monalisa`, `password=OTOKEN`).

**Scenario 2: Fallback for GHE.com Tenancy Host**
- **Given** GitHub CLI is authenticated with tenancy host `mytenant.ghe.com` (user `monalisa`, token `TENANT_TOKEN`)
- **When** Git credential helper requests credentials for `protocol=https\nhost=gist.mytenant.ghe.com`
- **Then** It successfully falls back and returns credentials for `mytenant.ghe.com` (`username=monalisa`, `password=TENANT_TOKEN`).

**Scenario 3: Non-GitHub gist.* domain (Negative Test)**
- **Given** GitHub CLI has stored credentials for `evil.com` or `mycorp.com`
- **When** Git credential helper receives a request for `host=gist.evil.com` or `host=gist.mycorp.com`
- **Then** No fallback is triggered, returning no credentials (`wantErr = true`).

### Key points

- `ghinstance.GistHost(defaultHost)` provides the canonical gist host `gist.github.com/` for `github.com`.
- Tenancy instances follow `gist.<tenant>.ghe.com` and are safely validated via `ghinstance.TenantName(baseHost)`.
- For GHES and GitHub Enterprise Server instances, `GistHost` produces path-based URLs (`<host>/gist/`), so the host requested by git is always `<host>`, not `gist.<host>`.

### Notes for reviewers

- The change is localized to `pkg/cmd/auth/gitcredential/helper.go` and accompanied by unit tests in `pkg/cmd/auth/gitcredential/helper_test.go`.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @Juwan-Hwang will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
