### PR TITLE
`--attach` stack 1/8: Report what kind of token is active

### DIFF
--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -464,6 +464,26 @@ func TestPullRequest_ExportData(t *testing.T) {
 			`),
 		},
 		{
+			// The upload path needs a numeric id and a viewer permission,
+			// which this selection cannot provide. Sharing one Go type with
+			// that path once put both keys here, always zero. This row fails
+			// if that happens again.
+			name:   "head repository",
+			fields: []string{"headRepository"},
+			inputJSON: heredoc.Doc(`
+				{ "headRepository": {"id": "R_kgDOAAA", "name": "REPO", "nameWithOwner": "OWNER/REPO"} }
+			`),
+			outputJSON: heredoc.Doc(`
+				{
+					"headRepository": {
+						"id": "R_kgDOAAA",
+						"name": "REPO",
+						"nameWithOwner": "OWNER/REPO"
+					}
+				}
+			`),
+		},
+		{
 			name:   "status checks",
 			fields: []string{"statusCheckRollup"},
 			inputJSON: heredoc.Doc(`

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -57,6 +57,9 @@ type Issue struct {
 	Blocking         LinkedIssueConnection
 
 	ClosedByPullRequestsReferences ClosedByPullRequestsReferences
+
+	// Repository is only populated when the "repository" field was requested.
+	Repository *PRRepository
 }
 
 // IssueType represents an issue type configured for a repository.
@@ -479,6 +482,24 @@ func (i Issue) Identifier() string {
 
 func (i Issue) CurrentUserComments() []Comment {
 	return i.Comments.CurrentUserComments()
+}
+
+// RepositoryDatabaseID returns the numeric REST id of the repository, or zero
+// when the "repository" field was not requested.
+func (i Issue) RepositoryDatabaseID() int64 {
+	if i.Repository == nil {
+		return 0
+	}
+	return i.Repository.DatabaseID
+}
+
+// RepositoryViewerPermission returns the requesting user's role on the
+// repository, or an empty string when the "repository" field was not requested.
+func (i Issue) RepositoryViewerPermission() string {
+	if i.Repository == nil {
+		return ""
+	}
+	return i.Repository.ViewerPermission
 }
 
 // UpdateIssueIssueType sets or clears the issue type on an issue. Pass an

--- a/api/queries_issue_test.go
+++ b/api/queries_issue_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssueRepositoryUnmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want *PRRepository
+	}{
+		{
+			name: "every field the repository selection asks for",
+			json: `{"repository":{"id":"R_kgDOAAA","name":"REPO","nameWithOwner":"OWNER/REPO","databaseId":1234,"viewerPermission":"WRITE"}}`,
+			want: &PRRepository{ID: "R_kgDOAAA", Name: "REPO", NameWithOwner: "OWNER/REPO", DatabaseID: 1234, ViewerPermission: "WRITE"},
+		},
+		{
+			name: "nil when the field was never requested",
+			json: `{"number":42}`,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got Issue
+			require.NoError(t, json.Unmarshal([]byte(tt.json), &got))
+
+			assert.Equal(t, tt.want, got.Repository)
+		})
+	}
+}
+
+func TestIssueRepositoryDatabaseID(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue Issue
+		want  int64
+	}{
+		{
+			name:  "the repository field was requested",
+			issue: Issue{Repository: &PRRepository{DatabaseID: 1234}},
+			want:  1234,
+		},
+		{
+			name:  "the repository field was not requested",
+			issue: Issue{},
+			want:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.issue.RepositoryDatabaseID())
+		})
+	}
+}
+
+func TestIssueRepositoryViewerPermission(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue Issue
+		want  string
+	}{
+		{
+			name:  "the repository field was requested",
+			issue: Issue{Repository: &PRRepository{ViewerPermission: "WRITE"}},
+			want:  "WRITE",
+		},
+		{
+			name:  "the repository field was not requested",
+			issue: Issue{},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.issue.RepositoryViewerPermission())
+		})
+	}
+}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -255,6 +255,12 @@ type PRRepository struct {
 	ID            string `json:"id"`
 	Name          string `json:"name"`
 	NameWithOwner string `json:"nameWithOwner"`
+
+	// Fields below are omitted when empty because this type is used by
+	// headRepository.
+	DatabaseID int64 `json:"databaseId,omitempty"`
+	// One of ADMIN, MAINTAIN, WRITE, TRIAGE, READ.
+	ViewerPermission string `json:"viewerPermission,omitempty"`
 }
 
 type AutoMergeRequest struct {
@@ -316,6 +322,24 @@ func (pr PullRequest) Identifier() string {
 
 func (pr PullRequest) CurrentUserComments() []Comment {
 	return pr.Comments.CurrentUserComments()
+}
+
+// RepositoryDatabaseID returns the numeric REST id of the repository, or zero
+// when the "repository" field was not requested.
+func (pr PullRequest) RepositoryDatabaseID() int64 {
+	if pr.Repository == nil {
+		return 0
+	}
+	return pr.Repository.DatabaseID
+}
+
+// RepositoryViewerPermission returns the requesting user's role on the
+// repository, or an empty string when the "repository" field was not requested.
+func (pr PullRequest) RepositoryViewerPermission() string {
+	if pr.Repository == nil {
+		return ""
+	}
+	return pr.Repository.ViewerPermission
 }
 
 func (pr PullRequest) IsOpen() bool {

--- a/api/queries_pr_test.go
+++ b/api/queries_pr_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -563,6 +564,108 @@ func TestSuggestedReviewerActorsForRepo(t *testing.T) {
 				logins[i] = c.Login()
 			}
 			assert.Equal(t, tt.expectedLogins, logins)
+		})
+	}
+}
+
+func TestPRRepositoryUnmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want PRRepository
+	}{
+		{
+			name: "every field the repository selection asks for",
+			json: `{"id":"R_kgDOAAA","name":"REPO","nameWithOwner":"OWNER/REPO","databaseId":1234,"viewerPermission":"WRITE"}`,
+			want: PRRepository{ID: "R_kgDOAAA", Name: "REPO", NameWithOwner: "OWNER/REPO", DatabaseID: 1234, ViewerPermission: "WRITE"},
+		},
+		{
+			name: "a database id larger than a 32 bit int",
+			json: `{"databaseId":5000000000}`,
+			want: PRRepository{DatabaseID: 5000000000},
+		},
+		{
+			name: "absent when the field was never requested",
+			json: `{"id":"R_kgDOAAA"}`,
+			want: PRRepository{ID: "R_kgDOAAA"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got PRRepository
+			err := json.Unmarshal([]byte(tt.json), &got)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestPRRepositorySelectionMatchesStruct guards the seam between the two:
+// a field added to the selection but not the struct is silently dropped, and
+// one added to the struct but not the selection is silently zero.
+func TestPRRepositorySelectionMatchesStruct(t *testing.T) {
+	selection := PullRequestGraphQL([]string{"repository"})
+	inner := strings.TrimSuffix(strings.TrimPrefix(selection, "repository{"), "}")
+	selected := strings.Split(inner, ",")
+
+	var declared []string
+	repositoryType := reflect.TypeOf(PRRepository{})
+	for i := range repositoryType.NumField() {
+		name, _, _ := strings.Cut(repositoryType.Field(i).Tag.Get("json"), ",")
+		declared = append(declared, name)
+	}
+
+	assert.ElementsMatch(t, declared, selected)
+}
+
+func TestPullRequestRepositoryDatabaseID(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   PullRequest
+		want int64
+	}{
+		{
+			name: "the repository field was requested",
+			pr:   PullRequest{Repository: &PRRepository{DatabaseID: 1234}},
+			want: 1234,
+		},
+		{
+			name: "the repository field was not requested",
+			pr:   PullRequest{},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.pr.RepositoryDatabaseID())
+		})
+	}
+}
+
+func TestPullRequestRepositoryViewerPermission(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   PullRequest
+		want string
+	}{
+		{
+			name: "the repository field was requested",
+			pr:   PullRequest{Repository: &PRRepository{ViewerPermission: "WRITE"}},
+			want: "WRITE",
+		},
+		{
+			name: "the repository field was not requested",
+			pr:   PullRequest{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.pr.RepositoryViewerPermission())
 		})
 	}
 }

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -29,6 +29,7 @@ const (
 // Repository contains information about a GitHub repo
 type Repository struct {
 	ID                       string
+	DatabaseID               int64
 	Name                     string
 	NameWithOwner            string
 	Owner                    RepositoryOwner
@@ -323,6 +324,7 @@ func IssueRepoInfo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 	query IssueRepositoryInfo($owner: String!, $name: String!) {
 		repository(owner: $owner, name: $name) {
 			id
+			databaseId
 			name
 			owner { login }
 			hasIssuesEnabled
@@ -360,6 +362,7 @@ func GitHubRepo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 	query := `
 	fragment repo on Repository {
 		id
+		databaseId
 		name
 		owner { login }
 		hasIssuesEnabled
@@ -498,6 +501,7 @@ func RepoNetwork(client *Client, repos []ghrepo.Interface) (RepoNetworkResult, e
 	err := client.GraphQL(hostname, fmt.Sprintf(`
 	fragment repo on Repository {
 		id
+		databaseId
 		name
 		owner { login }
 		viewerPermission

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -39,6 +39,7 @@ func TestGitHubRepo_success(t *testing.T) {
 		httpmock.StringResponse(`
 		{ "data": { "repository": {
 			"id": "REPOID",
+			"databaseId": 1234,
 			"name": "REPO",
 			"owner": {"login": "OWNER"},
 			"hasIssuesEnabled": true,
@@ -57,6 +58,7 @@ func TestGitHubRepo_success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, &Repository{
 		ID:                 "REPOID",
+		DatabaseID:         1234,
 		Name:               "REPO",
 		Owner:              RepositoryOwner{Login: "OWNER"},
 		HasIssuesEnabled:   true,
@@ -130,6 +132,87 @@ func TestGitHubRepo_withParent(t *testing.T) {
 	}, repo)
 	assert.False(t, repo.ViewerCanPush())
 	assert.False(t, repo.ViewerCanTriage())
+}
+
+// TestBaseRepoQueriesSelectDatabaseID guards the 3 queries that build the base
+// repository. Each selection is written by hand, and a field left out of one
+// of them is silently zero rather than an error, so the selection is asserted
+// against the request instead of the response.
+func TestBaseRepoQueriesSelectDatabaseID(t *testing.T) {
+	tests := []struct {
+		name    string
+		matcher httpmock.Matcher
+		body    string
+		call    func(*Client) error
+	}{
+		{
+			name:    "GitHubRepo",
+			matcher: httpmock.GraphQL(`query RepositoryInfo\b`),
+			body:    `{ "data": { "repository": { "id": "REPOID", "databaseId": 1234 } } }`,
+			call: func(client *Client) error {
+				_, err := GitHubRepo(client, ghrepo.New("OWNER", "REPO"))
+				return err
+			},
+		},
+		{
+			name:    "RepoNetwork",
+			matcher: httpmock.GraphQL(`query RepositoryNetwork\b`),
+			body:    `{ "data": { "repo_000": { "id": "REPOID", "databaseId": 1234 } } }`,
+			call: func(client *Client) error {
+				_, err := RepoNetwork(client, []ghrepo.Interface{ghrepo.New("OWNER", "REPO")})
+				return err
+			},
+		},
+		{
+			name:    "IssueRepoInfo",
+			matcher: httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+			body:    `{ "data": { "repository": { "id": "REPOID", "databaseId": 1234 } } }`,
+			call: func(client *Client) error {
+				_, err := IssueRepoInfo(client, ghrepo.New("OWNER", "REPO"))
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpReg := &httpmock.Registry{}
+			defer httpReg.Verify(t)
+
+			var query string
+			httpReg.Register(tt.matcher, httpmock.GraphQLQuery(tt.body, func(q string, _ map[string]interface{}) {
+				query = q
+			}))
+
+			require.NoError(t, tt.call(newTestClient(httpReg)))
+			assert.Contains(t, query, "databaseId")
+		})
+	}
+}
+
+func TestRepoNetworkUnmarshalsDatabaseID(t *testing.T) {
+	httpReg := &httpmock.Registry{}
+	defer httpReg.Verify(t)
+
+	httpReg.Register(
+		httpmock.GraphQL(`query RepositoryNetwork\b`),
+		httpmock.StringResponse(`
+		{ "data": {
+			"viewer": {"login": "OWNER"},
+			"repo_000": {
+				"id": "REPOID",
+				"databaseId": 1234,
+				"name": "REPO",
+				"owner": {"login": "OWNER"},
+				"viewerPermission": "WRITE",
+				"defaultBranchRef": {"name": "main"}
+			}
+		} }`))
+
+	result, err := RepoNetwork(newTestClient(httpReg), []ghrepo.Interface{ghrepo.New("OWNER", "REPO")})
+	require.NoError(t, err)
+	require.Len(t, result.Repositories, 1)
+	assert.Equal(t, int64(1234), result.Repositories[0].DatabaseID)
 }
 
 func TestIssueRepoInfo_notFound(t *testing.T) {

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -406,6 +406,10 @@ func IssueGraphQL(fields []string) string {
 			q = append(q, `projectItems(first:100){nodes{id, project{id,title}, status:fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue{optionId,name}}},totalCount}`)
 		case "milestone":
 			q = append(q, `milestone{number,title,description,dueOn}`)
+		case "repository":
+			// Selects every field PRRepository declares.
+			// TestPRRepositorySelectionMatchesStruct enforces that.
+			q = append(q, `repository{id,name,nameWithOwner,databaseId,viewerPermission}`)
 		case "reactionGroups":
 			q = append(q, `reactionGroups{content,users{totalCount}}`)
 		case "mergeCommit":

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -38,6 +38,20 @@ func TestPullRequestGraphQL(t *testing.T) {
 			fields: []string{"projectItems"},
 			want:   `projectItems(first:100){nodes{id, project{id,title}, status:fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue{optionId,name}}},totalCount}`,
 		},
+		{
+			name:   "repository",
+			fields: []string{"repository"},
+			want:   "repository{id,name,nameWithOwner,databaseId,viewerPermission}",
+		},
+		{
+			// headRepository shares a Go type with the selection above, which
+			// carries two more fields. They are omitted from JSON when empty,
+			// so adding either name here would put them back into the output
+			// of `gh pr view --json headRepository`.
+			name:   "headRepository",
+			fields: []string{"headRepository"},
+			want:   "headRepository{id,name,nameWithOwner}",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -78,6 +92,11 @@ func TestIssueGraphQL(t *testing.T) {
 			name:   "projectItems",
 			fields: []string{"projectItems"},
 			want:   `projectItems(first:100){nodes{id, project{id,title}, status:fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue{optionId,name}}},totalCount}`,
+		},
+		{
+			name:   "repository",
+			fields: []string{"repository"},
+			want:   "repository{id,name,nameWithOwner,databaseId,viewerPermission}",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/internal/config/migration"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/keyring"
 	ghConfig "github.com/cli/go-gh/v2/pkg/config"
 	"github.com/stretchr/testify/require"
@@ -946,4 +947,32 @@ func preMigrationLogin(c *AuthConfig, hostname, username, token, gitProtocol str
 		c.cfg.Set([]string{hostsKey, hostname, gitProtocolKey}, gitProtocol)
 	}
 	return insecureStorageUsed, ghConfig.Write(c.cfg)
+}
+
+func TestActiveTokenType(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  gh.TokenType
+	}{
+		{name: "oauth", token: "gho_test", want: gh.TokenTypeOAuth},
+		{name: "personal access", token: "ghp_test", want: gh.TokenTypePersonalAccess},
+		{name: "fine-grained pat", token: "github_pat_test", want: gh.TokenTypeFineGrainedPAT},
+		{name: "user-to-server", token: "ghu_test", want: gh.TokenTypeUserToServer},
+		{name: "server-to-server", token: "ghs_test", want: gh.TokenTypeServerToServer},
+		{name: "refresh", token: "ghr_test", want: gh.TokenTypeRefresh},
+		{name: "a prefix gh does not know", token: "test", want: gh.TokenTypeUnknown},
+		{name: "no token at all", token: "", want: gh.TokenTypeUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authCfg := newTestAuthConfig(t)
+			if tt.token != "" {
+				require.NoError(t, keyring.Set(keyringServiceName("github.com"), "", tt.token))
+				authCfg.SetActiveToken(tt.token, "keyring")
+			}
+
+			require.Equal(t, tt.want, authCfg.ActiveTokenType("github.com"))
+		})
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/keyring"
@@ -229,6 +230,31 @@ type AuthConfig struct {
 	defaultHostOverride func() (string, string)
 	hostsOverride       func() []string
 	tokenOverride       func(string) (string, string)
+}
+
+// tokenTypesByPrefix maps a token's prefix to what kind of credential it is.
+var tokenTypesByPrefix = []struct {
+	prefix    string
+	tokenType gh.TokenType
+}{
+	{"github_pat_", gh.TokenTypeFineGrainedPAT},
+	{"gho_", gh.TokenTypeOAuth},
+	{"ghp_", gh.TokenTypePersonalAccess},
+	{"ghu_", gh.TokenTypeUserToServer},
+	{"ghs_", gh.TokenTypeServerToServer},
+	{"ghr_", gh.TokenTypeRefresh},
+}
+
+// ActiveTokenType reports what kind of credential the active token is, so a
+// caller that only needs to know that can avoid handling the token.
+func (c *AuthConfig) ActiveTokenType(hostname string) gh.TokenType {
+	token, _ := c.ActiveToken(hostname)
+	for _, t := range tokenTypesByPrefix {
+		if strings.HasPrefix(token, t.prefix) {
+			return t.tokenType
+		}
+	}
+	return gh.TokenTypeUnknown
 }
 
 // ActiveToken will retrieve the active auth token for the given hostname,

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -99,6 +99,24 @@ type Migration interface {
 	Do(*ghConfig.Config) error
 }
 
+// TokenType is the kind of credential a token is, told by its prefix. The
+// zero value covers a token gh does not recognise, including an empty one.
+//
+// See the [token formats] GitHub documents.
+//
+// [token formats]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats
+type TokenType string
+
+const (
+	TokenTypeUnknown        TokenType = ""
+	TokenTypeOAuth          TokenType = "oauth"            // gho_
+	TokenTypePersonalAccess TokenType = "personal access"  // ghp_
+	TokenTypeFineGrainedPAT TokenType = "fine-grained pat" // github_pat_
+	TokenTypeUserToServer   TokenType = "user-to-server"   // ghu_
+	TokenTypeServerToServer TokenType = "server-to-server" // ghs_
+	TokenTypeRefresh        TokenType = "refresh"          // ghr_
+)
+
 // AuthConfig is used for interacting with some persistent configuration for gh,
 // with knowledge on how to access encrypted storage when necessary.
 // Behavior is scoped to authentication specific tasks.
@@ -109,6 +127,14 @@ type AuthConfig interface {
 	// ActiveToken will retrieve the active auth token for the given hostname, searching environment variables,
 	// general configuration, and finally encrypted storage.
 	ActiveToken(hostname string) (token string, source string)
+
+	// ActiveTokenType reports what kind of credential the active token for the
+	// hostname is, so a caller can decide whether it will do without handling
+	// the token itself.
+	//
+	// TODO: gh auth status, AuthTokenWriteable and agent-task each read a
+	// token and match its prefix themselves. They should ask here instead.
+	ActiveTokenType(hostname string) TokenType
 
 	// HasEnvToken returns true when a token has been specified in an environment variable, else returns false.
 	HasEnvToken() bool


### PR DESCRIPTION
Part of the pull request stack tracked in #14186.

### Description

This is the first layer of an eight part stack. The full stack adds an `--attach` flag to six issue and pull request commands. The flag uploads a local media file to GitHub and puts it into the markdown body. If the text already references the local path, `gh` rewrites that path to point at the uploaded asset. Otherwise `gh` appends the file at the end.

This pull request does not change anything a user can see. It adds two things the upper layers need.

The upload endpoint only accepts some kinds of credential. The first commit adds a token type to the `gh` package and a method on the auth config that reports what kind of credential is active for a host, told by the token prefix. A caller can decide whether a credential will work without ever reading the token into memory or passing it around.

The upload endpoint also needs the repository's numeric REST id, and `gh` checks the user's role on the repository before uploading anything. Neither was selected before. The second commit selects both on issues, on pull requests, and on a plain repository lookup, and adds accessors that return zero values when the caller did not request the repository field.

### How did you test this change?

The whole stack was built and exercised by hand. For this layer specifically, `gh pr view --json headRepository` was run against the built binary and against a build of trunk, and the output was byte identical.

That is the regression this shape is designed to avoid. The pull request type reuses one Go struct for both the repository and the head repository.

### Key points

Asking the config for a token kind rather than for the token keeps credentials out of command code. No command in this stack ever handles a token in order to attach a file.

The accessors return zero values rather than an error when the repository field was not requested, because that field is optional in the queries.

The new fields on the shared struct are omitted when empty, and a test row fails if the head repository output ever starts carrying them.

### Notes for reviewers

A note in the code records three other places in `gh` that read a token and match its prefix by hand. Those are `gh auth status`, the check for whether an auth token is writeable, and agent-task. Moving them is not part of this stack.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @BagToad will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
