### PR TITLE
`--attach` stack 2/8: Describe and validate a file `gh` can attach

### DIFF
--- a/internal/attachments/doc.go
+++ b/internal/attachments/doc.go
@@ -1,0 +1,38 @@
+// Package assets implements the --attach flag.
+// It uploads local user assets to GitHub and optionally rewrites user provided
+// markdown references to point at the remote asset path rather than the local
+// path. In the absence of a markdown reference, a new reference is appended to
+// the user provided markdown.
+//
+// An upload cannot be undone. Callers must ensure that the returned markdown
+// is written to a resource (issue, PR, etc.).
+//
+// A caller must build the Uploader before it prompts for anything, so a token
+// or permission that cannot upload stops the command before an editor opens.
+// It must call UploadAndAttach after every possible prompt has been exercised,
+// not before, because nothing that can cancel may follow an upload.
+//
+//	attachmentArgs, err := attachments.FromFlagValues(cmd)
+//	...
+//
+//	// repositoryID and viewerPermission come from the lookup the command
+//	// already makes.
+//	uploader, err := attachments.NewUploader(
+//		httpClient, token, host, repositoryID, viewerPermission)
+//	...
+//
+//	// Every reasonable cancellation possible belongs here.
+//
+//	md, uploaded, err := uploader.UploadAndAttach(ctx, md, attachmentArgs)
+//	if uploaded == 0 {
+//		return err
+//	}
+//
+//	// Write md to target, then report err alongside whatever the write
+//	// returned.
+//
+// UploadAndAttach reports how many assets were successfully uploaded. The
+// caller must write the markdown when that count is above zero, including after
+// a partial failure, because what did upload must be referenced by something.
+// At zero nothing is stranded and nothing is written.
+package attachments

--- a/internal/attachments/userasset.go
+++ b/internal/attachments/userasset.go
@@ -1,0 +1,212 @@
+package attachments
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// bytesPerMB is the multiplier for the limits below, which are declared in
+// megabytes because that is the unit every message states them in.
+const bytesPerMB = 1024 * 1024
+
+// maxImageMB is the largest image gh uploads. The byte form is typed, since it
+// is only ever measured against a file size.
+const (
+	maxImageMB          = 10
+	maxImageBytes int64 = maxImageMB * bytesPerMB
+)
+
+// maxVideoMB is the largest video gh uploads. The real limit depends on the
+// account plan, which gh cannot know before the request, so this is the
+// generous bound and the server refuses the rest.
+const (
+	maxVideoMB          = 100
+	maxVideoBytes int64 = maxVideoMB * bytesPerMB
+)
+
+// contentTypes maps every accepted extension to the content type the endpoint
+// expects, in the order gh lists them back to the user.
+var contentTypes = []struct {
+	ext         string
+	contentType string
+}{
+	{".png", "image/png"},
+	{".jpg", "image/jpeg"},
+	{".jpeg", "image/jpeg"},
+	{".gif", "image/gif"},
+	{".webp", "image/webp"},
+	{".svg", "image/svg+xml"},
+	{".mp4", "video/mp4"},
+	{".mov", "video/quicktime"},
+	{".webm", "video/webm"},
+}
+
+// UserAsset is one validated local file, and everything needed to construct the
+// markdown to reference it once it is uploaded.
+type UserAsset interface {
+	// Path is the file as the user wrote it, so a caller naming it back names
+	// what they typed.
+	Path() string
+
+	file() *asset
+	rendersAsPlayer() bool
+	sizeLimit() (maxBytes int64, maxMB int, kind string)
+	markdown(assetURL string) string
+}
+
+type asset struct {
+	path        string
+	info        fs.FileInfo
+	alt         string
+	contentType string
+}
+
+func (a *asset) file() *asset { return a }
+
+func (a *asset) Path() string { return a.path }
+
+// imageAsset renders as a markdown image.
+type imageAsset struct{ asset }
+
+func (*imageAsset) rendersAsPlayer() bool { return false }
+
+// newImageAsset applies what only holds for an image: the author may write alt
+// text, and the fallback mirrors the web uploader by stripping the extension
+// and replacing the remaining dots with spaces.
+func newImageAsset(f asset, alt string) (UserAsset, error) {
+	a := &imageAsset{f}
+	if err := checkMaxSizeForType(a); err != nil {
+		return nil, err
+	}
+
+	if alt == "" {
+		base := filepath.Base(a.path)
+		alt = strings.ReplaceAll(strings.TrimSuffix(base, filepath.Ext(base)), ".", " ")
+	}
+	a.alt = alt
+
+	return a, nil
+}
+
+func (*imageAsset) sizeLimit() (int64, int, string) {
+	return maxImageBytes, maxImageMB, "images"
+}
+
+func (a *imageAsset) markdown(assetURL string) string {
+	return fmt.Sprintf("![%s](%s)", escapeAlt(a.alt), assetURL)
+}
+
+// videoAsset renders as a player, which markdown has no syntax for: GitHub
+// promotes a bare URL that is the whole content of a paragraph.
+type videoAsset struct{ asset }
+
+func (*videoAsset) rendersAsPlayer() bool { return true }
+
+// newVideoAsset applies what only holds for a video: a player has no alt
+// attribute to fill, so the author cannot supply one, and the name that stands
+// in keeps its extension because it goes where a filename would in a link.
+func newVideoAsset(f asset, alt string) (UserAsset, error) {
+	a := &videoAsset{f}
+	if err := checkMaxSizeForType(a); err != nil {
+		return nil, err
+	}
+
+	if alt != "" {
+		return nil, errors.New("cannot set alt text on video")
+	}
+	a.alt = filepath.Base(a.path)
+
+	return a, nil
+}
+
+func (*videoAsset) sizeLimit() (int64, int, string) {
+	return maxVideoBytes, maxVideoMB, "videos"
+}
+
+func (*videoAsset) markdown(assetURL string) string { return assetURL }
+
+// newAsset validates one attached file.
+func newAsset(path, alt string) (UserAsset, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		// Drop the syscall name so the message names the file, not the
+		// operation gh performed on it.
+		if pathErr, ok := errors.AsType[*fs.PathError](err); ok {
+			return nil, fmt.Errorf("%s: %w", path, pathErr.Err)
+		}
+		return nil, err
+	}
+
+	if fi.IsDir() {
+		return nil, fmt.Errorf("%s is a directory", path)
+	}
+
+	// Stat succeeds on a named pipe and Read then blocks forever.
+	if !fi.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+
+	// Nothing downstream objects to zero bytes, so an empty file uploads and
+	// renders broken.
+	if fi.Size() == 0 {
+		return nil, fmt.Errorf("%s is empty", path)
+	}
+
+	contentType, err := supportedContentType(path)
+	if err != nil {
+		return nil, err
+	}
+
+	f := asset{path: path, info: fi, contentType: contentType}
+
+	if strings.HasPrefix(contentType, "video/") {
+		return newVideoAsset(f, alt)
+	}
+	return newImageAsset(f, alt)
+}
+
+// checkMaxSizeForType rejects a file over the limit for its kind.
+func checkMaxSizeForType(a UserAsset) error {
+	maxBytes, maxMB, kind := a.sizeLimit()
+	if a.file().info.Size() <= maxBytes {
+		return nil
+	}
+	return fmt.Errorf("%s: %s must be under %d MB", a.Path(), kind, maxMB)
+}
+
+// supportedContentType maps a file extension to the content type the endpoint
+// expects. The extension is all gh checks, since the endpoint accepts
+// mislabeled bytes anyway.
+func supportedContentType(path string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, t := range contentTypes {
+		if t.ext == ext {
+			return t.contentType, nil
+		}
+	}
+
+	supported := make([]string, len(contentTypes))
+	for i, t := range contentTypes {
+		supported[i] = strings.TrimPrefix(t.ext, ".")
+	}
+	return "", fmt.Errorf("%s is not a supported file type (supported: %s)", path, strings.Join(supported, ", "))
+}
+
+// altEscaper neutralizes the characters that let alt text break out of the
+// image syntax. Without it, alt text containing `](url)` closes the image early
+// and points it somewhere the author did not choose.
+var altEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`[`, `\[`,
+	`]`, `\]`,
+	"\n", " ",
+	"\r", " ",
+)
+
+func escapeAlt(s string) string {
+	return altEscaper.Replace(s)
+}

--- a/internal/attachments/userasset_test.go
+++ b/internal/attachments/userasset_test.go
@@ -1,0 +1,349 @@
+package attachments
+
+import (
+	"io/fs"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFile creates a file of the given size relative to the test's working
+// directory. Truncate makes a sparse file, so a size over the image limit costs
+// nothing to create.
+func writeFile(t *testing.T, name string, size int64) {
+	t.Helper()
+
+	f, err := os.Create(name)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, f.Truncate(size))
+}
+
+func TestNewAsset(t *testing.T) {
+	tests := []struct {
+		name            string
+		file            string
+		size            int64
+		setup           func(t *testing.T)
+		path            string
+		alt             string
+		wantPath        string
+		wantAlt         string
+		wantContentType string
+		wantErr         string
+	}{
+		{
+			name:            "png",
+			file:            "shot.png",
+			path:            "./shot.png",
+			wantAlt:         "shot",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "jpg",
+			file:            "shot.jpg",
+			path:            "./shot.jpg",
+			wantAlt:         "shot",
+			wantContentType: "image/jpeg",
+		},
+		{
+			name:            "jpeg",
+			file:            "shot.jpeg",
+			path:            "./shot.jpeg",
+			wantAlt:         "shot",
+			wantContentType: "image/jpeg",
+		},
+		{
+			name:            "gif",
+			file:            "shot.gif",
+			path:            "./shot.gif",
+			wantAlt:         "shot",
+			wantContentType: "image/gif",
+		},
+		{
+			name:            "webp",
+			file:            "shot.webp",
+			path:            "./shot.webp",
+			wantAlt:         "shot",
+			wantContentType: "image/webp",
+		},
+		{
+			name:            "svg",
+			file:            "shot.svg",
+			path:            "./shot.svg",
+			wantAlt:         "shot",
+			wantContentType: "image/svg+xml",
+		},
+		{
+			// A video has no alt attribute to fill, so Alt stays empty and
+			// Label carries the filename for a degraded link.
+			name:            "mp4",
+			file:            "repro.mp4",
+			path:            "./repro.mp4",
+			wantAlt:         "repro.mp4",
+			wantContentType: "video/mp4",
+		},
+		{
+			name:            "an image alt drops the extension",
+			file:            "shot.png",
+			path:            "./shot.png",
+			wantAlt:         "shot",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "mov",
+			file:            "repro.mov",
+			path:            "./repro.mov",
+			wantAlt:         "repro.mov",
+			wantContentType: "video/quicktime",
+		},
+		{
+			name:            "webm",
+			file:            "repro.webm",
+			path:            "./repro.webm",
+			wantAlt:         "repro.webm",
+			wantContentType: "video/webm",
+		},
+		{
+			name:            "uppercase extension",
+			file:            "SHOT.PNG",
+			path:            "./SHOT.PNG",
+			wantAlt:         "SHOT",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "alt text supplied",
+			file:            "shot.png",
+			path:            "./shot.png",
+			alt:             "The login error state",
+			wantAlt:         "The login error state",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "no alt text falls back to the filename",
+			file:            "shot.png",
+			path:            "./shot.png",
+			wantAlt:         "shot",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "alt text defaults to the filename with dots as spaces",
+			file:            "Screenshot 2026-08-10 at 5.38.10 PM.png",
+			path:            "./Screenshot 2026-08-10 at 5.38.10 PM.png",
+			wantAlt:         "Screenshot 2026-08-10 at 5 38 10 PM",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "image at exactly the size limit",
+			file:            "big.png",
+			size:            maxImageBytes,
+			path:            "./big.png",
+			wantAlt:         "big",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "video over the image size limit",
+			file:            "clip.mp4",
+			size:            20 * 1024 * 1024,
+			path:            "./clip.mp4",
+			wantAlt:         "clip.mp4",
+			wantContentType: "video/mp4",
+		},
+		{
+			name:            "video at exactly the video size limit",
+			file:            "clip.mp4",
+			size:            maxVideoBytes,
+			path:            "./clip.mp4",
+			wantAlt:         "clip.mp4",
+			wantContentType: "video/mp4",
+		},
+		{
+			name:    "video over the video size limit",
+			file:    "clip.mp4",
+			size:    105 * 1024 * 1024,
+			path:    "./clip.mp4",
+			wantErr: "./clip.mp4: videos must be under 100 MB",
+		},
+		{
+			name:    "image one byte over the limit",
+			file:    "big.png",
+			size:    maxImageBytes + 1,
+			path:    "./big.png",
+			wantErr: "./big.png: images must be under 10 MB",
+		},
+		{
+			name:    "image well over the size limit",
+			file:    "huge.png",
+			size:    14889779,
+			path:    "./huge.png",
+			wantErr: "./huge.png: images must be under 10 MB",
+		},
+		{
+			name:    "unsupported extension",
+			file:    "notes.txt",
+			path:    "./notes.txt",
+			wantErr: "./notes.txt is not a supported file type (supported: png, jpg, jpeg, gif, webp, svg, mp4, mov, webm)",
+		},
+		{
+			name:    "no extension",
+			file:    "notes",
+			path:    "./notes",
+			wantErr: "./notes is not a supported file type (supported: png, jpg, jpeg, gif, webp, svg, mp4, mov, webm)",
+		},
+		{
+			name:    "empty file",
+			file:    "empty.png",
+			size:    0,
+			path:    "./empty.png",
+			wantErr: "./empty.png is empty",
+		},
+		{
+			name: "directory",
+			setup: func(t *testing.T) {
+				require.NoError(t, os.Mkdir("shots.png", 0o755))
+			},
+			path:    "./shots.png",
+			wantErr: "./shots.png is a directory",
+		},
+		{
+			name: "not a regular file",
+			setup: func(t *testing.T) {
+				if runtime.GOOS == "windows" {
+					t.Skip("no stable path to a non-regular file on Windows")
+				}
+			},
+			path:    "/dev/null",
+			wantErr: "/dev/null is not a regular file",
+		},
+		{
+			name:    "alt text on a video",
+			file:    "repro.mp4",
+			path:    "./repro.mp4",
+			alt:     "Screen recording of the crash",
+			wantErr: "cannot set alt text on video",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			if tt.file != "" {
+				size := tt.size
+				if size == 0 && tt.name != "empty file" {
+					size = 1
+				}
+				writeFile(t, tt.file, size)
+			}
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+
+			a, err := newAsset(tt.path, tt.alt)
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			wantPath := tt.wantPath
+			if wantPath == "" {
+				wantPath = tt.path
+			}
+			assert.Equal(t, wantPath, a.Path())
+			assert.Equal(t, tt.wantAlt, a.file().alt)
+			assert.Equal(t, tt.wantContentType, a.file().contentType)
+
+			// The identity the duplicate check compares, which has to be the
+			// file this path led to.
+			wantInfo, err := os.Stat(tt.file)
+			require.NoError(t, err)
+			assert.True(t, os.SameFile(wantInfo, a.file().info))
+		})
+	}
+}
+
+// A missing file reports the path the user typed rather than the syscall gh
+// happened to make. The reason text comes from the operating system, so this
+// checks the shape and the cause instead of the whole string.
+func TestNewAssetMissingFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	_, err := newAsset("./nope.png", "")
+
+	require.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "./nope.png: "), "got %q", err.Error())
+	assert.NotContains(t, err.Error(), "stat ")
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestAssetMarkdown(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		alt         string
+		want        string
+	}{
+		{
+			name:        "image",
+			contentType: "image/png",
+			alt:         "The login error state",
+			want:        "![The login error state](https://example.com/assets/1)",
+		},
+		{
+			name:        "image with empty alt text",
+			contentType: "image/png",
+			want:        "![](https://example.com/assets/1)",
+		},
+		{
+			name:        "video renders as a bare URL so it plays",
+			contentType: "video/mp4",
+			want:        "https://example.com/assets/1",
+		},
+		{
+			// A bare URL is the only form that plays.
+			name:        "a video alt does not reach the embed",
+			contentType: "video/mp4",
+			alt:         "repro.mp4",
+			want:        "https://example.com/assets/1",
+		},
+		{
+			name:        "alt text cannot close the image early",
+			contentType: "image/png",
+			alt:         "![x](https://evil.example.com/x.png)",
+			want:        `![!\[x\](https://evil.example.com/x.png)](https://example.com/assets/1)`,
+		},
+		{
+			name:        "backslashes are escaped",
+			contentType: "image/png",
+			alt:         `a\b`,
+			want:        `![a\\b](https://example.com/assets/1)`,
+		},
+		{
+			name:        "newlines cannot break out of the image",
+			contentType: "image/png",
+			alt:         "first\nsecond\r\nthird",
+			want:        "![first second  third](https://example.com/assets/1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a UserAsset = &imageAsset{asset{contentType: tt.contentType, alt: tt.alt}}
+			if strings.HasPrefix(tt.contentType, "video/") {
+				a = &videoAsset{asset{contentType: tt.contentType, alt: tt.alt}}
+			}
+
+			assert.Equal(t, tt.want, a.markdown("https://example.com/assets/1"))
+		})
+	}
+}
+
+func TestAssetRendersAsPlayer(t *testing.T) {
+	assert.True(t, (&videoAsset{}).rendersAsPlayer())
+	assert.False(t, (&imageAsset{}).rendersAsPlayer())
+}


### PR DESCRIPTION
Part of the pull request stack tracked in #14186.

### Description

This is the second layer of the stack. It adds an internal package for attachments, holding the rules about what a file is and whether `gh` will accept it. Nothing here is reachable from a command yet.

Nine file extensions are accepted. Six are images: png, jpg, jpeg, gif, webp and svg. Three are videos: mp4, mov and webm. Each maps to the content type the upload endpoint expects. The extension is the only thing checked, and it is matched without regard to case.

An image and a video are separate types, because GitHub renders them differently. An image becomes a markdown image embed. A video becomes a bare URL on its own line, which is what GitHub needs in order to show a player. A video has no alt text in that form, so asking for alt text on a video is refused rather than quietly ignored.

Validation reads the file's metadata and never opens the file. It refuses a path that does not exist, a directory, anything that is not a regular file, and an empty file.

### How did you test this change?

The whole stack was built and every one of the nine accepted types was uploaded to a private test repository and downloaded again. The content type sent matched the content type served back in every case, and the bytes were identical in every case. The six image types produced image embeds and the three video types produced bare URLs.

Refusals were exercised by hand as well: an unsupported file type, an image over the size limit, a directory, a missing file, an empty file, and alt text on a video. In each case the command exited with an error and uploaded nothing.

### Key points

Deciding by extension rather than by content is deliberate. The question being asked is how GitHub will render the file, not what the bytes are, and the endpoint accepts mislabelled bytes anyway.

Images are refused over 10 MB and videos over 100 MB. `gh` cannot know the real video limit, because it depends on the account plan. The local limit only catches what could never succeed, and the server reports the rest.

The image and video split lives in the type system rather than in conditionals spread around the package, because the two really do render differently and almost every rule downstream depends on which one it is.

### Notes for reviewers

Nothing in this pull request is reachable from a command. The flag that reaches it arrives further up the stack.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @BagToad will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
