### PR TITLE
`--attach` stack 3/8: Rewrite markdown references to uploaded assets

### DIFF
--- a/internal/attachments/references.go
+++ b/internal/attachments/references.go
@@ -1,0 +1,760 @@
+package attachments
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// This file finds the places a body already points at an attached file, and
+// repoints them. A file the author never mentioned is not its business: it is
+// reported in ToAppend and appended by attach.go, which knows that an image and
+// a video append different markdown.
+//
+// The parts below run in that order: the two entry points, finding the
+// references, working out which attached file each one names, locating its
+// bytes, and making the edit.
+
+// attachmentArg is one file named by an --attach argument, and the URL its
+// contents were uploaded to. It is the command line half of this package; a
+// markdown reference to it is an attachmentRef, and
+// attachmentArgForDestination is where the two meet.
+type attachmentArg struct {
+	// Path is the local path as the flag was written. Matching is on the
+	// absolute path.
+	Path string
+	// URL is where the contents now live. An argument with an empty URL did
+	// not upload, so every reference to it is left as the author wrote it and
+	// it is not reported for appending.
+	URL string
+	// Alt is the text that stands in for the file where the markdown supplies
+	// none of its own: the link text of a video that degrades to a link, which
+	// would otherwise have nothing to click.
+	Alt string
+	// RendersAsPlayer reports whether GitHub turns this file's URL into a
+	// player rather than leaving it an image.
+	RendersAsPlayer bool
+}
+
+// attachedMarkdown is the outcome of attaching, one field per flow. A file the
+// author already referenced is rewritten where they wrote it. A file they never
+// mentioned is left for the caller to append, because appending needs to know
+// how an image and a video each render and this file does not.
+type attachedMarkdown struct {
+	Rewritten string
+	ToAppend  []attachmentArg
+}
+
+// attachableMarkdown is markdown scanned for the files it references, held
+// with the arguments it was scanned against. Attaching works from one of
+// these, so the scan runs once and cannot afterwards be handed a set of
+// arguments the scan never saw.
+type attachableMarkdown struct {
+	markdown string
+	refs     []attachmentRef
+	args     []attachmentArg
+}
+
+// newAttachableMarkdown scans markdown for the files it references, and
+// refuses references that no asset URL can fix.
+func newAttachableMarkdown(md string, attachmentArgs []attachmentArg) (attachableMarkdown, error) {
+	if len(attachmentArgs) == 0 {
+		return attachableMarkdown{markdown: md}, nil
+	}
+	refs, err := scanMarkdownRefs(md, attachmentArgs)
+	if err != nil {
+		return attachableMarkdown{}, err
+	}
+	if err := checkVideoReferenceImages(refs, attachmentArgs); err != nil {
+		return attachableMarkdown{}, err
+	}
+	return attachableMarkdown{markdown: md, refs: refs, args: attachmentArgs}, nil
+}
+
+// attachAssetsToMarkdown points every markdown reference to an attached file
+// at that file's asset URL, and reports which arguments the markdown never
+// referenced.
+//
+//	![alt](./file) alone in a paragraph   image: swap the path   video: the bare URL, which plays
+//	![alt](./file) anywhere else          image: swap the path   video: becomes [alt](URL)
+//	[text](./file)                        swap the path, for images and video alike
+//
+// A reference-style link is rewritten in its definition instead, so every
+// usage of that label follows from the one edit.
+//
+// A path inside a code fence or an inline code span is left alone.
+func attachAssetsToMarkdown(v attachableMarkdown) (attachedMarkdown, error) {
+	md := v.markdown
+	if len(v.args) == 0 {
+		return attachedMarkdown{Rewritten: md}, nil
+	}
+
+	src, refs, attachmentArgs := []byte(md), v.refs, v.args
+
+	var edits []edit
+
+	// Looping over the markdown references to produce a plan for edits.
+	for _, r := range refs {
+		arg := attachmentArgs[r.attachmentArg]
+
+		// It's not been uploaded.
+		if arg.URL == "" {
+			continue
+		}
+
+		// Reference style links get rewritten at their definitions, not inline.
+		if r.referenceStyle() {
+			for _, def := range r.defs {
+				dest, ok := linkReferenceDestination(src, def)
+				if !ok {
+					continue
+				}
+				edits = append(edits, edit{r.attachmentArg, dest, arg.URL})
+			}
+			continue
+		}
+
+		at := r.ranges
+		playerEmbed := arg.RendersAsPlayer && r.isEmbed
+
+		switch {
+		case !playerEmbed:
+			// Only the destination moves, so alt text, titles, and formatting
+			// inside the label survive.
+			edits = append(edits, edit{r.attachmentArg, at.dest, arg.URL})
+
+		case standsAlone(src, r.block, at.node):
+			// A player only renders from a bare URL alone in a paragraph, so
+			// the whole node goes and any alt text is dropped.
+			edits = append(edits, edit{r.attachmentArg, at.node, arg.URL})
+
+		default:
+			// Degrade to a link: only the "!" and the destination move, so a
+			// reference nested in the alt text is still rewritten in place.
+			//
+			// A literal "!" before the embed's own would pair with the "["
+			// left behind and re-form an embed, so it is absorbed into the
+			// same edit and escaped. One already escaped is left alone, since
+			// escaping it twice emits a literal backslash and re-forms the
+			// embed anyway.
+			bang := byteRange{at.node.start, at.node.start + 1}
+			drop := ""
+			if bang.start > 0 && src[bang.start-1] == '!' && !isEscaped(src, bang.start-1) {
+				bang.start--
+				drop = `\!`
+			}
+			edits = append(edits, edit{r.attachmentArg, bang, drop})
+
+			if at.label.start == at.label.stop {
+				// The author wrote no alt text, and a video has none to
+				// inherit, so the link would have nothing to click. The name
+				// newAsset fell back to stands in. It is escaped because a
+				// name may contain the brackets that end a label.
+				edits = append(edits, edit{r.attachmentArg, at.label, escapeAlt(arg.Alt)})
+			}
+			edits = append(edits, edit{r.attachmentArg, at.dest, arg.URL})
+		}
+	}
+
+	out, written := applyEdits(md, edits)
+
+	var unreferenced []attachmentArg
+	for i, a := range attachmentArgs {
+		if a.URL != "" && !written[i] {
+			unreferenced = append(unreferenced, a)
+		}
+	}
+	return attachedMarkdown{Rewritten: out, ToAppend: unreferenced}, nil
+}
+
+// checkVideoReferenceImages returns an error naming every video the markdown
+// embeds through a reference definition. Rewriting one would produce an image
+// embed of a video, which renders as a broken image.
+func checkVideoReferenceImages(refs []attachmentRef, attachmentArgs []attachmentArg) error {
+	var paths []string
+	seen := map[int]bool{}
+	for _, r := range refs {
+		if !r.referenceStyle() || !r.isEmbed {
+			continue
+		}
+		if !attachmentArgs[r.attachmentArg].RendersAsPlayer || seen[r.attachmentArg] {
+			continue
+		}
+		seen[r.attachmentArg] = true
+		paths = append(paths, attachmentArgs[r.attachmentArg].Path)
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	return fmt.Errorf("cannot embed a video as a reference-style image: %s", strings.Join(paths, ", "))
+}
+
+// attachmentRef is one markdown reference to an attached file: the markdown
+// half of this package, paired to an argument by attachmentArgForDestination.
+//
+// It is written either inline, as [text](./file), or through a reference
+// definition. An inline one carries the ranges and block that locate it in the
+// source; a reference-style one carries the definitions holding its
+// destination, and is recognised by defs being non-empty.
+type attachmentRef struct {
+	// attachmentArg indexes the attached file this reference names.
+	attachmentArg int
+	// isEmbed reports whether it was written with a leading "!".
+	isEmbed bool
+
+	ranges refRanges
+	block  ast.Node
+
+	defs []*ast.LinkReferenceDefinition
+}
+
+// referenceStyle reports whether the destination lives in a definition rather
+// than beside the reference.
+func (r attachmentRef) referenceStyle() bool { return len(r.defs) > 0 }
+
+// scanMarkdownRefs finds every place the markdown names one of the attached
+// files.
+func scanMarkdownRefs(md string, attachmentArgs []attachmentArg) ([]attachmentRef, error) {
+	byPath, err := attachmentArgsByPath(attachmentArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	src := []byte(md)
+	doc := goldmark.New().Parser().Parse(text.NewReader(src))
+	defs := linkReferenceDefinitions(doc, len(src))
+
+	var refs []attachmentRef
+
+	err = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		dest, isEmbed, ok := linkDestination(n)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		idx, ok := attachmentArgForDestination(dest, byPath)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		// The nearest block ancestor is what carries position information.
+		var block ast.Node
+		for p := n.Parent(); p != nil; p = p.Parent() {
+			if p.Type() == ast.TypeBlock {
+				block = p
+				break
+			}
+		}
+		_, hi, ok := blockRange(block, len(src))
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		if ranges, ok := inlineRanges(src, n, hi); ok {
+			refs = append(refs, attachmentRef{attachmentArg: idx, isEmbed: isEmbed, ranges: ranges, block: block})
+			return ast.WalkContinue, nil
+		}
+
+		// No destination beside the reference means a reference-style link. Every
+		// definition carrying this destination is rewritten, since a node
+		// records no label to tell them apart and a spare definition renders
+		// nothing.
+		if matches := defs[comparableDestination(dest)]; len(matches) > 0 {
+			refs = append(refs, attachmentRef{attachmentArg: idx, isEmbed: isEmbed, defs: matches})
+		}
+		return ast.WalkContinue, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return refs, nil
+}
+
+func linkDestination(n ast.Node) (dest string, isEmbed bool, ok bool) {
+	switch v := n.(type) {
+	case *ast.Image:
+		return string(v.Destination), true, true
+	case *ast.Link:
+		return string(v.Destination), false, true
+	}
+	return "", false, false
+}
+
+// linkReferenceDefinitions indexes every one in the document by its
+// destination. One inside a code fence or a code span is not parsed as a
+// definition at all, so both are excluded for free.
+func linkReferenceDefinitions(doc ast.Node, size int) map[string][]*ast.LinkReferenceDefinition {
+	out := map[string][]*ast.LinkReferenceDefinition{}
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		def, ok := n.(*ast.LinkReferenceDefinition)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		if _, _, ok := blockRange(def, size); !ok {
+			return ast.WalkContinue, nil
+		}
+		key := comparableDestination(string(def.Destination))
+		out[key] = append(out[key], def)
+		return ast.WalkContinue, nil
+	})
+	return out
+}
+
+// attachmentArgsByPath indexes the attached files by absolute path, ready for
+// attachmentArgForDestination to look one up. An argument with no URL is
+// indexed too, so validation can run before anything has uploaded.
+func attachmentArgsByPath(attachmentArgs []attachmentArg) (map[string]int, error) {
+	byPath := make(map[string]int, len(attachmentArgs))
+	for i, a := range attachmentArgs {
+		if a.Path == "" {
+			continue
+		}
+		abs, err := filepath.Abs(a.Path)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := byPath[abs]; dup {
+			continue
+		}
+		byPath[abs] = i
+	}
+	return byPath, nil
+}
+
+// attachmentArgForDestination is where the two halves of this package meet: it
+// takes a markdown destination and answers which attached file, if any, it
+// names.
+//
+// Only a local path can name one, and markdown offers several spellings for
+// the same path, so each is resolved to an absolute path and looked up.
+func attachmentArgForDestination(dest string, byPath map[string]int) (int, bool) {
+	if dest == "" || strings.HasPrefix(dest, "#") || strings.Contains(dest, "://") {
+		return 0, false
+	}
+	for _, path := range candidatePaths(dest) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			continue
+		}
+		if i, ok := byPath[abs]; ok {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// candidatePaths returns the ways a destination could name a file on disk.
+// goldmark strips angle brackets but leaves backslash escapes and percent
+// encoding intact, and either can stand in for a character legal in a
+// filename. A space must be written as "<./my file.png>" or "./my%20file.png"
+// to parse at all.
+func candidatePaths(dest string) []string {
+	raw := trimAngles(strings.TrimSpace(dest))
+	out := []string{raw}
+	if unescaped := unescapePunctuation(raw); unescaped != raw {
+		out = append(out, unescaped)
+	}
+	for _, s := range append([]string{}, out...) {
+		if decoded, err := url.PathUnescape(s); err == nil && decoded != s {
+			out = append(out, decoded)
+		}
+	}
+	return out
+}
+
+// comparableDestination reduces a link destination to the single form used to
+// decide whether a run of source is the node goldmark reported. Percent
+// encoding is left as written, since goldmark reports it unchanged and both
+// sides of every comparison therefore carry it.
+func comparableDestination(dest string) string {
+	return unescapePunctuation(trimAngles(strings.TrimSpace(dest)))
+}
+
+func trimAngles(s string) string {
+	if len(s) >= 2 && s[0] == '<' && s[len(s)-1] == '>' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// unescapePunctuation drops the backslash from every backslash-escaped ASCII
+// punctuation character, which is how markdown spells a literal one.
+func unescapePunctuation(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	const punct = `!"#$%&'()*+,-./:;<=>?@[\]^_` + "`" + `{|}~`
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] == '\\' && i+1 < len(s) && strings.IndexByte(punct, s[i+1]) >= 0 {
+			i++
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+type byteRange struct {
+	start, stop int
+}
+
+// refRanges locates the raw source that produced an inline link or image.
+type refRanges struct {
+	// node covers the whole thing, from the "!" or "[" through the ")".
+	node byteRange
+	// label covers what sits between the brackets.
+	label byteRange
+	// dest covers the destination, angle brackets included.
+	dest byteRange
+}
+
+// blockRange returns the byte range a block covers in the source.
+func blockRange(b ast.Node, size int) (int, int, bool) {
+	if b == nil {
+		return 0, 0, false
+	}
+	lines := b.Lines()
+	if lines == nil || lines.Len() == 0 {
+		return 0, 0, false
+	}
+	lo, hi := lines.At(0).Start, lines.At(lines.Len()-1).Stop
+	if lo < 0 || hi > size || lo > hi {
+		return 0, 0, false
+	}
+	return lo, hi, true
+}
+
+// inlineRanges locates the source of an inline link or image. goldmark reports
+// where every inline node starts, so the only thing left to find is where it
+// ends, inside a node goldmark has already accepted.
+//
+// A reference-style link carries no destination beside it and reports false,
+// leaving it to the definitions. hi bounds the search to the block.
+func inlineRanges(src []byte, n ast.Node, hi int) (refRanges, bool) {
+	start := n.Pos()
+	if start < 0 || start >= hi {
+		return refRanges{}, false
+	}
+	open := start
+	if src[open] == '!' {
+		open++
+	}
+	if open >= hi || src[open] != '[' {
+		return refRanges{}, false
+	}
+	close, ok := closingBracket(src, open, hi, literalText(n))
+	if !ok || close+1 >= hi || src[close+1] != '(' {
+		return refRanges{}, false
+	}
+	dest := inlineDestination(src, close+2, hi)
+	stop := skipSpace(src, dest.stop, hi)
+	if stop < hi && src[stop] != ')' {
+		if end, ok := scanTitle(src, stop, hi); ok {
+			stop = skipSpace(src, end, hi)
+		}
+	}
+	if stop >= hi || src[stop] != ')' {
+		return refRanges{}, false
+	}
+	return refRanges{
+		node:  byteRange{start, stop + 1},
+		label: byteRange{open + 1, close},
+		dest:  dest,
+	}, true
+}
+
+// closingBracket finds the "]" that ends a label opened at open, counting the
+// brackets of anything nested inside it and ignoring those in literal.
+func closingBracket(src []byte, open, hi int, literal []byteRange) (int, bool) {
+	depth := 0
+	for i := open; i < hi; i++ {
+		if isEscaped(src, i) || within(literal, i) {
+			continue
+		}
+		switch src[i] {
+		case '[':
+			depth++
+		case ']':
+			if depth--; depth == 0 {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// literalText reports the byte ranges inside n that a code span quotes, where a
+// bracket is a character rather than markdown. goldmark parsed them, so their
+// text nodes already say where they are.
+func literalText(n ast.Node) []byteRange {
+	var out []byteRange
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		if _, ok := c.(*ast.CodeSpan); !ok {
+			out = append(out, literalText(c)...)
+			continue
+		}
+		for t := c.FirstChild(); t != nil; t = t.NextSibling() {
+			if text, ok := t.(*ast.Text); ok {
+				out = append(out, byteRange{text.Segment.Start, text.Segment.Stop})
+			}
+		}
+	}
+	return out
+}
+
+// within reports whether i falls inside any of ranges.
+func within(ranges []byteRange, i int) bool {
+	for _, s := range ranges {
+		if i >= s.start && i < s.stop {
+			return true
+		}
+	}
+	return false
+}
+
+// inlineDestination finds the destination written beside a reference, as the
+// "./f.png" of [text](./f.png).
+func inlineDestination(src []byte, i, hi int) byteRange {
+	i = skipSpace(src, i, hi)
+	if i < hi && src[i] == '<' {
+		if stop, ok := scanAngleDest(src, i, hi); ok {
+			return byteRange{i, stop}
+		}
+	}
+	return byteRange{i, scanBareDest(src, i, hi)}
+}
+
+// scanBareDest reads an unbracketed destination, which ends at whitespace or
+// at the ")" closing the link. Parentheses inside the path are part of it as
+// long as they balance.
+func scanBareDest(src []byte, i, hi int) int {
+	depth := 0
+	for i < hi {
+		switch c := src[i]; {
+		case c == '\\':
+			if i+1 < hi {
+				i++
+			}
+		case isSpace(c):
+			return i
+		case c == '(':
+			depth++
+		case c == ')':
+			if depth == 0 {
+				return i
+			}
+			depth--
+		}
+		i++
+	}
+	return i
+}
+
+// scanTitle skips the optional title following a destination and returns the
+// index just past it. i may point at anything: a byte that opens no title
+// leaves the index untouched. A title is delimited by double quotes, single
+// quotes, or parentheses.
+func scanTitle(src []byte, i, hi int) (int, bool) {
+	var closer byte
+	switch src[i] {
+	case '"', '\'':
+		closer = src[i]
+	case '(':
+		closer = ')'
+	default:
+		return i, true
+	}
+	i++
+	for i < hi && src[i] != closer {
+		if src[i] == '\\' && i+1 < hi {
+			i++
+		}
+		i++
+	}
+	if i >= hi {
+		return 0, false
+	}
+	return i + 1, true
+}
+
+// scanAngleDest reads a "<...>" destination beginning at the "<", returning the
+// index just past the closing ">".
+func scanAngleDest(src []byte, i, hi int) (int, bool) {
+	i++
+	for i < hi && src[i] != '>' && src[i] != '\n' {
+		if src[i] == '\\' && i+1 < hi {
+			i++
+		}
+		i++
+	}
+	if i >= hi || src[i] != '>' {
+		return 0, false
+	}
+	return i + 1, true
+}
+
+// linkReferenceDestination finds the destination in a link reference
+// definition, as the "./f.png" of [ref]: ./f.png "a title", so that rewriting
+// it leaves the label and the title as the author wrote them.
+//
+// It reads the destination out of the source and refuses if that disagrees
+// with what goldmark parsed, which means the line is shaped in some way this
+// does not understand and is safer left alone.
+func linkReferenceDestination(src []byte, def *ast.LinkReferenceDefinition) (byteRange, bool) {
+	lo, hi, ok := blockRange(def, len(src))
+	if !ok {
+		return byteRange{}, false
+	}
+
+	// Past the label, which ends at the first unescaped "]:".
+	colon := -1
+	for off, c := range src[lo:hi] {
+		i := lo + off
+		if c == ']' && i+1 < hi && src[i+1] == ':' && !isEscaped(src, i) {
+			colon = i + 1
+			break
+		}
+	}
+	if colon < 0 {
+		return byteRange{}, false
+	}
+
+	start := skipSpace(src, colon+1, hi)
+	if start >= hi {
+		return byteRange{}, false
+	}
+	stop := start
+	if src[stop] == '<' {
+		end, ok := scanAngleDest(src, stop, hi)
+		if !ok {
+			return byteRange{}, false
+		}
+		stop = end
+	} else {
+		stop = scanBareDest(src, stop, hi)
+	}
+
+	// A definition continued onto the next line of a blockquote is the case
+	// that reaches here: the block range still carries the ">" prefix of the
+	// continuation, so the destination read from the source is that marker
+	// rather than the path, and rewriting it would eat the blockquote.
+	if comparableDestination(string(src[start:stop])) != comparableDestination(string(def.Destination)) {
+		return byteRange{}, false
+	}
+	return byteRange{start: start, stop: stop}, true
+}
+
+// isEscaped reports whether the byte at i is preceded by an odd number of
+// backslashes, which is what makes it a literal rather than markup.
+func isEscaped(src []byte, i int) bool {
+	n := 0
+	for j := i - 1; j >= 0 && src[j] == '\\'; j-- {
+		n++
+	}
+	return n%2 == 1
+}
+
+func skipSpace(src []byte, i, hi int) int {
+	for i < hi && isSpace(src[i]) {
+		i++
+	}
+	return i
+}
+
+// isSpace reports whether c is ASCII whitespace, which is what ends an
+// unbracketed markdown destination.
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+// edit describes a replacement of a byte range of the markdown.
+type edit struct {
+	a    int
+	at   byteRange
+	text string
+}
+
+// applyEdits rewrites the markdown back to front, so that an earlier edit cannot
+// shift a later one, and reports which arguments were actually written.
+//
+// Edits overlap when a video embed alone in its paragraph is replaced by a
+// bare URL and its alt text carries a reference of its own. The wider edit
+// wins, and the dropped one's argument is reported unwritten so the caller
+// appends it.
+func applyEdits(md string, edits []edit) (string, map[int]bool) {
+	written := map[int]bool{}
+	if len(edits) == 0 {
+		return md, written
+	}
+
+	sort.SliceStable(edits, func(i, j int) bool {
+		if edits[i].at.start != edits[j].at.start {
+			return edits[i].at.start < edits[j].at.start
+		}
+		return edits[i].at.stop > edits[j].at.stop
+	})
+
+	var kept []edit
+	end := 0
+	for _, e := range edits {
+		if e.at.start < end || e.at.start > e.at.stop || e.at.stop > len(md) {
+			continue
+		}
+		kept = append(kept, e)
+		written[e.a] = true
+		end = e.at.stop
+	}
+
+	out := md
+	for _, e := range slices.Backward(kept) {
+		out = out[:e.at.start] + e.text + out[e.at.stop:]
+	}
+	return out, written
+}
+
+// standsAlone reports whether replacing a node with a bare URL will render as
+// a player.
+//
+// GitHub promotes a bare asset URL to a video exactly when it is the whole
+// content of a paragraph, wherever that paragraph sits: a blockquote or a
+// loose list item qualifies, a URL alone on a source line inside a wrapped
+// paragraph does not. A tight list item holds no paragraph, only a text
+// block, which is why a lone reference there stays a link. goldmark draws the
+// same distinction, so testing for a paragraph is the whole rule.
+func standsAlone(src []byte, block ast.Node, node byteRange) bool {
+	if _, ok := block.(*ast.Paragraph); !ok {
+		return false
+	}
+	lo, hi, ok := blockRange(block, len(src))
+	// The node always falls inside the block that produced it, so the range
+	// test here only keeps the slices below in bounds.
+	if !ok || node.start < lo || node.stop > hi {
+		return false
+	}
+	for _, c := range src[lo:node.start] {
+		if !isSpace(c) {
+			return false
+		}
+	}
+	for _, c := range src[node.stop:hi] {
+		if !isSpace(c) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/attachments/references_fixture_test.go
+++ b/internal/attachments/references_fixture_test.go
@@ -1,0 +1,83 @@
+package attachments
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var update = flag.Bool("update", false, "rewrite the expected output in testdata")
+
+// fixtureAttachmentArgs is the set of attached files testdata/references_input.md is
+// written against. Every asset URL is recognisable on sight so the expected
+// output stays readable, and the paths cover the spellings markdown allows.
+func fixtureAttachmentArgs() []attachmentArg {
+	img := func(path, name string) attachmentArg {
+		return attachmentArg{Path: path, URL: "https://example.com/" + name, Alt: name}
+	}
+	return []attachmentArg{
+		img("./login.png", "login"),
+		{Path: "./repro.mp4", URL: "https://example.com/repro", Alt: "repro.mp4", RendersAsPlayer: true},
+		img("./Screenshot 2026-08-10 at 5.38.10 PM.png", "screenshot"),
+		img("./f(1).png", "parens"),
+		img("./f((1)(2)).png", "nested-parens"),
+		img("./f).png", "escaped-paren"),
+		img("./f", "truncated"),
+		img(`./a\b.png`, "backslash"),
+		img("./a>b.png", "escaped-angle"),
+		img("./login(1).png", "escaped-parens"),
+		img("./f(1.png", "unbalanced-open"),
+		img("./my file.png", "bare-space"),
+		img("./unused.png", "unused"),
+		// An upload that produced no URL. Its reference is left as written and
+		// is not reported for appending, since there is nothing to append.
+		{Path: "./nourl.png", Alt: "nourl"},
+	}
+}
+
+// One markdown document covering every syntax this package handles, so the
+// behaviour can be read as markdown rather than as Go string literals.
+//
+// Run with -update to rewrite the expected output, then read the diff: that is
+// the review, since output regenerated from the code under test agrees with
+// that code by construction.
+func TestAttachAssetsToMarkdownFixture(t *testing.T) {
+	const (
+		input    = "testdata/references_input.md"
+		expected = "testdata/references_expected.md"
+	)
+
+	markdown, err := os.ReadFile(input)
+	require.NoError(t, err)
+
+	attachmentArgs := fixtureAttachmentArgs()
+	v, err := newAttachableMarkdown(string(markdown), attachmentArgs)
+	require.NoError(t, err)
+
+	got, err := attachAssetsToMarkdown(v)
+	require.NoError(t, err)
+
+	if *update {
+		require.NoError(t, os.WriteFile(filepath.Clean(expected), []byte(got.Rewritten), 0o600))
+	}
+
+	want, err := os.ReadFile(expected)
+	require.NoError(t, err, "run go test -update to create it")
+	require.Equal(t, string(want), got.Rewritten)
+
+	// Asserted here rather than in the expected output, since appending them
+	// is the caller's job.
+	var unreferenced []string
+	for _, r := range got.ToAppend {
+		unreferenced = append(unreferenced, r.Path)
+	}
+	// In the order the arguments were passed, which is the contract.
+	require.Equal(t, []string{
+		"./f(1.png",     // an unbalanced "(" does not parse as a destination
+		"./my file.png", // a bare space does not parse as a destination
+		"./unused.png",  // defined but never used, so nothing renders it
+	}, unreferenced)
+}

--- a/internal/attachments/references_test.go
+++ b/internal/attachments/references_test.go
@@ -1,0 +1,846 @@
+package attachments
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	pngURL = "https://github.com/user-attachments/assets/11111111-1111-1111-1111-111111111111"
+	mp4URL = "https://github.com/user-attachments/assets/22222222-2222-2222-2222-222222222222"
+)
+
+func pngArg() attachmentArg {
+	return attachmentArg{Path: "./login.png", URL: pngURL, Alt: "login"}
+}
+
+func mp4Arg() attachmentArg {
+	return attachmentArg{Path: "./repro.mp4", URL: mp4URL, Alt: "repro.mp4", RendersAsPlayer: true}
+}
+
+func TestAttachAssetsToMarkdown(t *testing.T) {
+	absPNG, err := filepath.Abs("./login.png")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name           string
+		markdown       string
+		attachmentArgs []attachmentArg
+		wantMarkdown   string
+		wantToAppend   []attachmentArg
+		wantErr        string
+	}{
+		// The four cells of the image column.
+		{
+			name:           "image embed on its own line keeps its markdown",
+			markdown:       "Before\n\n![the login screen](./login.png)\n\nAfter",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "Before\n\n![the login screen](" + pngURL + ")\n\nAfter",
+		},
+		{
+			name:           "image embed inline keeps its markdown",
+			markdown:       "The screen ![the login screen](./login.png) looks wrong.",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "The screen ![the login screen](" + pngURL + ") looks wrong.",
+		},
+		{
+			name:           "image link stays a link",
+			markdown:       "See [the screenshot](./login.png) for detail.",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "See [the screenshot](" + pngURL + ") for detail.",
+		},
+		{
+			name:           "image never referenced is reported for appending",
+			markdown:       "No references here.",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "No references here.",
+			wantToAppend:   []attachmentArg{pngArg()},
+		},
+
+		// The four cells of the video column.
+		{
+			name:           "video embed alone in its own paragraph becomes a bare url",
+			markdown:       "Watch:\n\n![screen recording](./repro.mp4)\n\nEnd",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "Watch:\n\n" + mp4URL + "\n\nEnd",
+		},
+		{
+			name:           "video embed alone in a paragraph padded with spaces becomes a bare url",
+			markdown:       "  ![screen recording](./repro.mp4)  ",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "  " + mp4URL + "  ",
+		},
+		{
+			name:           "video embed inline degrades to a link",
+			markdown:       "The failure ![screen recording](./repro.mp4) is reproducible.",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "The failure [screen recording](" + mp4URL + ") is reproducible.",
+		},
+		{
+			// Dropping the "!" would leave the preceding one touching the
+			// "[", re-forming an embed of a video, which renders as a broken
+			// image. Escaping it keeps the bang literal.
+			name:           "a bang before a degraded video is escaped so no embed re-forms",
+			markdown:       "Watch this!![demo](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   `Watch this\![demo](` + mp4URL + ")",
+		},
+		{
+			// The preceding bang is already a literal, so escaping it again
+			// would emit a backslash and re-form the embed.
+			name:           "a bang that is already escaped is left as it is",
+			markdown:       `Watch this\!![demo](./repro.mp4)`,
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   `Watch this\![demo](` + mp4URL + ")",
+		},
+		{
+			name:           "a bang before a degraded video at the very start of the markdown is escaped",
+			markdown:       "!![demo](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   `\![demo](` + mp4URL + ")",
+		},
+		{
+			// An image keeps its "!", so its neighbour cannot pair with
+			// anything and only the destination moves.
+			name:           "a bang before an image embed is left alone",
+			markdown:       "Look at this!![the login screen](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "Look at this!![the login screen](" + pngURL + ")",
+		},
+		{
+			// A "]" cannot pair with the following "[" into anything, so the
+			// ordinary deletion is correct here.
+			name:           "a bracket before a degraded video needs no escaping",
+			markdown:       "See ]![demo](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "See ][demo](" + mp4URL + ")",
+		},
+		{
+			name:           "a degraded video at the very start of the markdown keeps the rest of the line",
+			markdown:       "![demo](./repro.mp4) is the recording.",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "[demo](" + mp4URL + ") is the recording.",
+		},
+		{
+			name:           "video link stays a link",
+			markdown:       "See [the recording](./repro.mp4) for detail.",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "See [the recording](" + mp4URL + ") for detail.",
+		},
+		{
+			name:           "video never referenced is reported for appending",
+			markdown:       "No references here.",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "No references here.",
+			wantToAppend:   []attachmentArg{mp4Arg()},
+		},
+
+		// A path that looks like a reference but is not one.
+		{
+			name:           "path inside a fenced code block is left alone",
+			markdown:       "```\n![example](./login.png)\n```\n\n![the real one](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "```\n![example](./login.png)\n```\n\n![the real one](" + pngURL + ")",
+		},
+		{
+			name:           "path inside an inline code byteRange is left alone",
+			markdown:       "Write `![alt](./login.png)` to embed ![the real one](./login.png) here.",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "Write `![alt](./login.png)` to embed ![the real one](" + pngURL + ") here.",
+		},
+		{
+			// The code byteRange holds a "](path)" that a bracket outside it could
+			// pair with, so scanning has to skip the byteRange's bytes or it
+			// rewrites inside the byteRange and leaves the real reference dead.
+			name:           "a code byteRange that could pair with an earlier bracket is left alone",
+			markdown:       "[x `](./login.png)` y [the real one](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "[x `](./login.png)` y [the real one](" + pngURL + ")",
+		},
+		{
+			name:           "an indented code block is left alone",
+			markdown:       "Example:\n\n    ![example](./login.png)\n\n![the real one](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "Example:\n\n    ![example](./login.png)\n\n![the real one](" + pngURL + ")",
+		},
+		{
+			name:           "a remote url is not touched",
+			markdown:       "![hosted](https://example.com/login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![hosted](https://example.com/login.png)",
+			wantToAppend:   []attachmentArg{pngArg()},
+		},
+		{
+			name:           "a local path nobody attached is left as written",
+			markdown:       "![unattached](./other.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![unattached](./other.png)",
+			wantToAppend:   []attachmentArg{pngArg()},
+		},
+		{
+			name:           "an anchor is not treated as a path",
+			markdown:       "[jump](#login.png)",
+			attachmentArgs: []attachmentArg{{Path: "#login.png", URL: pngURL}},
+			wantMarkdown:   "[jump](#login.png)",
+			wantToAppend:   []attachmentArg{{Path: "#login.png", URL: pngURL}},
+		},
+
+		// One file, several references.
+		{
+			name:           "the same file referenced twice is rewritten in both places",
+			markdown:       "![first](./login.png)\n\nSome prose.\n\n![second](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![first](" + pngURL + ")\n\nSome prose.\n\n![second](" + pngURL + ")",
+		},
+		{
+			name:           "the same file referenced twice in one paragraph is rewritten in both places",
+			markdown:       "Compare ![first](./login.png) with ![second](./login.png).",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "Compare ![first](" + pngURL + ") with ![second](" + pngURL + ").",
+		},
+		{
+			name:           "an embed and a link to the same file are told apart",
+			markdown:       "![embed](./login.png) and [link](./login.png).",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![embed](" + pngURL + ") and [link](" + pngURL + ").",
+		},
+
+		// Alt text.
+		{
+			name:           "alt text written in the markdown wins over the flag",
+			markdown:       "![the login screen showing an auth error](./login.png)",
+			attachmentArgs: []attachmentArg{{Path: "./login.png", URL: pngURL, Alt: "alt from the flag"}},
+			wantMarkdown:   "![the login screen showing an auth error](" + pngURL + ")",
+		},
+		{
+			name:           "a video degraded to a link keeps the alt text written in the markdown",
+			markdown:       "Here ![the crash, recorded](./repro.mp4) it is.",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "Here [the crash, recorded](" + mp4URL + ") it is.",
+		},
+		{
+			name:           "a video degraded to a link falls back to the file name when the markdown has no alt text",
+			markdown:       "Here ![](./repro.mp4) it is.",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "Here [repro.mp4](" + mp4URL + ") it is.",
+		},
+		{
+			name:           "a file name that would end the label early is escaped",
+			markdown:       "Here ![](./a]b.mp4) it is.",
+			attachmentArgs: []attachmentArg{{Path: "./a]b.mp4", URL: mp4URL, Alt: `a]b.mp4`, RendersAsPlayer: true}},
+			wantMarkdown:   `Here [a\]b.mp4](` + mp4URL + ") it is.",
+		},
+		{
+			name:           "formatting inside the alt text survives",
+			markdown:       "![the *login* screen](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![the *login* screen](" + pngURL + ")",
+		},
+
+		// Ways markdown spells a path.
+		{
+			name:           "an absolute path in the markdown matches a relative asset",
+			markdown:       "![the login screen](" + absPNG + ")",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![the login screen](" + pngURL + ")",
+		},
+		{
+			name:           "an angle bracketed path with spaces is matched and replaced whole",
+			markdown:       "![shot](<./Screenshot 2026-08-10 at 5.38.10 PM.png>)",
+			attachmentArgs: []attachmentArg{{Path: "./Screenshot 2026-08-10 at 5.38.10 PM.png", URL: pngURL}},
+			wantMarkdown:   "![shot](" + pngURL + ")",
+		},
+		{
+			name:           "a percent encoded path with spaces is matched",
+			markdown:       "![shot](./Screenshot%202026-08-10%20at%205.38.10%20PM.png)",
+			attachmentArgs: []attachmentArg{{Path: "./Screenshot 2026-08-10 at 5.38.10 PM.png", URL: pngURL}},
+			wantMarkdown:   "![shot](" + pngURL + ")",
+		},
+		{
+			name:           "a backslash escaped path is matched",
+			markdown:       `![shot](./login\(1\).png)`,
+			attachmentArgs: []attachmentArg{{Path: "./login(1).png", URL: pngURL}},
+			wantMarkdown:   "![shot](" + pngURL + ")",
+		},
+		{
+			// A backslash is itself escapable punctuation, so "\\" in the
+			// markdown is one literal backslash in the filename.
+			name:           "a path containing an escaped backslash is matched",
+			markdown:       `![shot](./a\\b.png)`,
+			attachmentArgs: []attachmentArg{{Path: `./a\b.png`, URL: pngURL}},
+			wantMarkdown:   "![shot](" + pngURL + ")",
+		},
+		{
+			name:           "a title survives the rewrite",
+			markdown:       `![the login screen](./login.png "Login")`,
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   `![the login screen](` + pngURL + ` "Login")`,
+		},
+		{
+			name:           "a single quoted title survives the rewrite",
+			markdown:       `![the login screen](./login.png 'Login')`,
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   `![the login screen](` + pngURL + ` 'Login')`,
+		},
+		{
+			name:           "a parenthesised title survives the rewrite",
+			markdown:       `![the login screen](./login.png (Login))`,
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   `![the login screen](` + pngURL + ` (Login))`,
+		},
+		{
+			// The escaped quotes are inside the title, so neither closes it.
+			name:           "a title containing escaped quotes survives the rewrite",
+			markdown:       `![the login screen](./login.png "he said \"hi\"")`,
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   `![the login screen](` + pngURL + ` "he said \"hi\"")`,
+		},
+		{},
+		{
+			// The backslash escapes the ")", so it belongs to the path
+			// rather than closing the destination.
+			name:           `an inline path with an escaped ")" is rewritten`,
+			markdown:       `![a](./f\).png)`,
+			attachmentArgs: []attachmentArg{{Path: `./f).png`, URL: pngURL}},
+			wantMarkdown:   `![a](` + pngURL + `)`,
+		},
+		{
+			// The scan walks every "](" in the block, so a malformed one
+			// ahead of the real reference must be rejected rather than
+			// swallowing it.
+			name:           "an unterminated title earlier in the block is skipped",
+			markdown:       `[x](./a.png "oops) then ![the login screen](./login.png)`,
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   `[x](./a.png "oops) then ![the login screen](` + pngURL + `)`,
+		},
+		{
+			name:           "a tail with no closing parenthesis earlier in the block is skipped",
+			markdown:       `[x](./a.png "t" and ![the login screen](./login.png)`,
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   `[x](./a.png "t" and ![the login screen](` + pngURL + `)`,
+		},
+		{
+			// The first "](" holds the same path but no closing parenthesis
+			// after its trailing word, so it is not a link tail at all and
+			// must not be claimed in place of the real reference.
+			name:           "a tail whose destination matches but does not close is skipped",
+			markdown:       `[x](./login.png b) and [the login screen](./login.png)`,
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   `[x](./login.png b) and [the login screen](` + pngURL + `)`,
+		},
+
+		// Structure that could confuse the scan.
+		{
+			name:           "an image nested in a link is told apart from the link",
+			markdown:       "[![the badge](./login.png)](./repro.mp4)",
+			attachmentArgs: []attachmentArg{pngArg(), mp4Arg()},
+			wantMarkdown:   "[![the badge](" + pngURL + ")](" + mp4URL + ")",
+		},
+		{
+			name:           "a thumbnail linking to its own file rewrites both halves",
+			markdown:       "[![the login screen](./login.png)](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "[![the login screen](" + pngURL + ")](" + pngURL + ")",
+		},
+		{
+			name:           "a link inside a video alt text loses to the replacement of the whole embed",
+			markdown:       "![see [the screenshot](./login.png)](./repro.mp4)",
+			attachmentArgs: []attachmentArg{pngArg(), mp4Arg()},
+			wantMarkdown:   mp4URL,
+			// The video swallowed the reference to the image, so the image is
+			// reported for appending rather than quietly dropped.
+			wantToAppend: []attachmentArg{pngArg()},
+		},
+		{
+			// The degrade keeps the label, so a reference nested in it has to
+			// be rewritten too. Rebuilding the node from the label's source
+			// bytes used to leave this local path in the markdown and append the
+			// same file again at the end.
+			name:           "a link inside the alt text of a degraded video is rewritten in place",
+			markdown:       "Here is ![see [the screenshot](./login.png)](./repro.mp4) inline.",
+			attachmentArgs: []attachmentArg{pngArg(), mp4Arg()},
+			wantMarkdown:   "Here is [see [the screenshot](" + pngURL + ")](" + mp4URL + ") inline.",
+		},
+		{
+			name:           "an image inside the alt text of a degraded video is rewritten in place",
+			markdown:       "Here is ![see ![the screenshot](./login.png)](./repro.mp4) inline.",
+			attachmentArgs: []attachmentArg{pngArg(), mp4Arg()},
+			wantMarkdown:   "Here is [see ![the screenshot](" + pngURL + ")](" + mp4URL + ") inline.",
+		},
+		{
+			name:           "a video embedded inside a link to itself keeps the two apart",
+			markdown:       "[![the recording](./repro.mp4)](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "[[the recording](" + mp4URL + ")](" + mp4URL + ")",
+		},
+		{
+			name:           "a bracket inside a code byteRange in the alt text does not confuse the scan",
+			markdown:       "![before `[` after](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![before `[` after](" + pngURL + ")",
+		},
+		{
+			name:           "a reference in a list item is rewritten",
+			markdown:       "- before\n- ![the login screen](./login.png)\n- after",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "- before\n- ![the login screen](" + pngURL + ")\n- after",
+		},
+		{
+			name:           "a video alone in a tight list item stays a labelled link",
+			markdown:       "- ![the recording](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "- [the recording](" + mp4URL + ")",
+		},
+		{
+			// A tight list item holds no paragraph, only a text block, which
+			// is why it does not play while the loose one above does.
+			name:           "a video alone in a loose list item becomes a bare url",
+			markdown:       "- one\n\n- ![the recording](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "- one\n\n- " + mp4URL,
+		},
+		{
+			name:           "a reference in a blockquote is rewritten",
+			markdown:       "> quoting\n> ![the login screen](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "> quoting\n> ![the login screen](" + pngURL + ")",
+		},
+		{
+			name:           "a video alone in a blockquote becomes a bare url",
+			markdown:       "> ![the recording](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "> " + mp4URL,
+		},
+		{
+			name:           "a video alone in a nested blockquote becomes a bare url",
+			markdown:       "> > ![the recording](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "> > " + mp4URL,
+		},
+		{
+			name:           "a video alone in a blockquote inside a list item becomes a bare url",
+			markdown:       "- > ![the recording](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "- > " + mp4URL,
+		},
+		{
+			name:           "a reference in a heading is rewritten",
+			markdown:       "# ![the login screen](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "# ![the login screen](" + pngURL + ")",
+		},
+		{
+			name:           "a video alone in a heading stays a labelled link",
+			markdown:       "# ![the recording](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "# [the recording](" + mp4URL + ")",
+		},
+		{
+			// A bare URL here renders as a plain link showing the raw asset
+			// UUID, so the labelled link is the better of the two.
+			name:           "a video alone on a soft wrapped line stays a labelled link",
+			markdown:       "Watch this:\n![the recording](./repro.mp4)\nand then read on.",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "Watch this:\n[the recording](" + mp4URL + ")\nand then read on.",
+		},
+		{
+			name:           "a video sharing a paragraph inside a blockquote stays a labelled link",
+			markdown:       "> Watch this:\n> ![the recording](./repro.mp4)",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "> Watch this:\n> [the recording](" + mp4URL + ")",
+		},
+
+		// Several files at once.
+		{
+			name:           "referenced and unreferenced files are sorted out",
+			attachmentArgs: []attachmentArg{pngArg(), mp4Arg()},
+			markdown:       "The login screen:\n\n![the login screen](./login.png)\n\nNothing references the video.",
+			wantMarkdown: "The login screen:\n\n![the login screen](" + pngURL +
+				")\n\nNothing references the video.",
+			wantToAppend: []attachmentArg{mp4Arg()},
+		},
+		{
+			name:           "unreferenced files keep the order they were passed",
+			markdown:       "Nothing here.",
+			attachmentArgs: []attachmentArg{mp4Arg(), pngArg()},
+			wantMarkdown:   "Nothing here.",
+			wantToAppend:   []attachmentArg{mp4Arg(), pngArg()},
+		},
+		{
+			name:           "an image and a video in one paragraph are rewritten separately",
+			markdown:       "See ![the login screen](./login.png) and ![the recording](./repro.mp4).",
+			attachmentArgs: []attachmentArg{pngArg(), mp4Arg()},
+			wantMarkdown:   "See ![the login screen](" + pngURL + ") and [the recording](" + mp4URL + ").",
+		},
+
+		// Nothing to do.
+		{
+			name:           "empty markdown reports every asset for appending",
+			markdown:       "",
+			attachmentArgs: []attachmentArg{pngArg(), mp4Arg()},
+			wantMarkdown:   "",
+			wantToAppend:   []attachmentArg{pngArg(), mp4Arg()},
+		},
+		{
+			name:           "markdown with no assets is returned unchanged",
+			markdown:       "Just prose.\n\n![hosted](https://example.com/a.png)",
+			attachmentArgs: nil,
+			wantMarkdown:   "Just prose.\n\n![hosted](https://example.com/a.png)",
+		},
+		{
+			name:           "a file that produced no asset url is left as the author wrote it",
+			markdown:       "![the login screen](./login.png)",
+			attachmentArgs: []attachmentArg{{Path: "./login.png", Alt: "login"}},
+			wantMarkdown:   "![the login screen](./login.png)",
+		},
+
+		// reference-style links, where the destination lives in a definition
+		// rather than at the usage. Rewriting the definition once carries
+		// every usage of that label with it.
+		{
+			name:           "an image written as a reference-style image is rewritten in its definition",
+			markdown:       "![the login screen][shot]\n\n[shot]: ./login.png",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![the login screen][shot]\n\n[shot]: " + pngURL,
+		},
+		{
+			name:           "an image written as a reference-style link is rewritten in its definition",
+			markdown:       "See the [screenshot][shot] for details.\n\n[shot]: ./login.png",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "See the [screenshot][shot] for details.\n\n[shot]: " + pngURL,
+		},
+		{
+			// A link to a video asset is promoted to a player when it stands
+			// alone in a paragraph, so this comes out better than a link.
+			name:           "a video written as a reference-style link is rewritten in its definition",
+			markdown:       "[the recording][clip]\n\n[clip]: ./repro.mp4",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantMarkdown:   "[the recording][clip]\n\n[clip]: " + mp4URL,
+		},
+		{
+			name:           "a video written as a reference-style image is refused",
+			markdown:       "![the recording][clip]\n\n[clip]: ./repro.mp4",
+			attachmentArgs: []attachmentArg{mp4Arg()},
+			wantErr:        "cannot embed a video as a reference-style image: ./repro.mp4",
+		},
+		{
+			name:           "the collapsed reference form is rewritten in its definition",
+			markdown:       "![shot][]\n\n[shot]: ./login.png",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![shot][]\n\n[shot]: " + pngURL,
+		},
+		{
+			name:           "the shortcut reference form is rewritten in its definition",
+			markdown:       "![shot]\n\n[shot]: ./login.png",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![shot]\n\n[shot]: " + pngURL,
+		},
+		{
+			name:           "one definition used by both a link and an image is rewritten once",
+			markdown:       "Both [a link][shot] and ![an image][shot].\n\n[shot]: ./login.png",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "Both [a link][shot] and ![an image][shot].\n\n[shot]: " + pngURL,
+		},
+		{
+			name:           "a definition keeps its title",
+			markdown:       "![the login screen][shot]\n\n[shot]: ./login.png \"Login\"",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![the login screen][shot]\n\n[shot]: " + pngURL + " \"Login\"",
+		},
+		{
+			name:           "an angle bracketed definition path is replaced whole",
+			markdown:       "![shot][s]\n\n[s]: <./Screenshot 2026-08-10 at 5.38.10 PM.png>",
+			attachmentArgs: []attachmentArg{{Path: "./Screenshot 2026-08-10 at 5.38.10 PM.png", URL: pngURL}},
+			wantMarkdown:   "![shot][s]\n\n[s]: " + pngURL,
+		},
+		{
+			// The escaped ">" is part of the filename, not the closing
+			// bracket, so the scan has to step over it.
+			name:           `a definition path with an escaped ">" is replaced whole`,
+			markdown:       `![shot][s]` + "\n\n" + `[s]: <./a\>b.png>`,
+			attachmentArgs: []attachmentArg{{Path: "./a>b.png", URL: pngURL}},
+			wantMarkdown:   "![shot][s]\n\n[s]: " + pngURL,
+		},
+		{
+			name:           "a definition whose angle bracket is never closed is left alone",
+			markdown:       "![shot][s]\n\n[s]: <./login.png",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![shot][s]\n\n[s]: <./login.png",
+			wantToAppend:   []attachmentArg{pngArg()},
+		},
+		{
+			name:           "a tab between a definition path and its title ends the path",
+			markdown:       "![shot][s]\n\n[s]: ./login.png\t\"Login\"",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![shot][s]\n\n[s]: " + pngURL + "\t\"Login\"",
+		},
+		{
+			name:           "a definition in markdown with carriage returns is rewritten",
+			markdown:       "![shot][s]\r\n\r\n[s]: ./login.png\r\n",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![shot][s]\r\n\r\n[s]: " + pngURL + "\r\n",
+		},
+		{
+			// The block byteRanges a carriage return, so the scan walks one while
+			// looking for the reference.
+			name:           "references in a wrapped paragraph with carriage returns are rewritten",
+			markdown:       "a ![x](./login.png) b\r\nc ![y](./login.png) d",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "a ![x](" + pngURL + ") b\r\nc ![y](" + pngURL + ") d",
+		},
+		{
+			// A destination cannot byteRange a line break, so this is not a link
+			// tail and must not be claimed in place of the real reference.
+			name:           "a candidate whose destination byteRanges a carriage return is skipped",
+			markdown:       "See ](./log\r\nin.png) and ![the login screen](./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "See ](./log\r\nin.png) and ![the login screen](" + pngURL + ")",
+		},
+		{
+			// The parentheses are balanced, so they belong to the path rather
+			// than closing the inline destination.
+			name:           "an inline path containing balanced parentheses is rewritten",
+			markdown:       "![a](./f(1).png)",
+			attachmentArgs: []attachmentArg{{Path: "./f(1).png", URL: pngURL}},
+			wantMarkdown:   "![a](" + pngURL + ")",
+		},
+		{
+			name:           "an inline path containing nested balanced parentheses is rewritten",
+			markdown:       "![a](./f((1)(2)).png)",
+			attachmentArgs: []attachmentArg{{Path: "./f((1)(2)).png", URL: pngURL}},
+			wantMarkdown:   "![a](" + pngURL + ")",
+		},
+		{
+			// An unbalanced ")" closes the destination, so the path is only
+			// "./f" and the rest falls out as text. GitHub renders it the
+			// same way.
+			name:           "an unbalanced closing parenthesis ends the destination",
+			markdown:       "![a](./f).png)",
+			attachmentArgs: []attachmentArg{{Path: "./f", URL: pngURL}},
+			wantMarkdown:   "![a](" + pngURL + ").png)",
+		},
+		{
+			// An unbalanced "(" makes the whole thing literal text rather
+			// than a link, so there is nothing to rewrite.
+			name:           "an unbalanced opening parenthesis is not a reference",
+			markdown:       "![a](./f(1.png)",
+			attachmentArgs: []attachmentArg{{Path: "./f(1.png", URL: pngURL}},
+			wantMarkdown:   "![a](./f(1.png)",
+			wantToAppend:   []attachmentArg{{Path: "./f(1.png", URL: pngURL}},
+		},
+		{
+			// A space ends an unbracketed destination, so this is text, not
+			// an image. Angle brackets or percent encoding are the spellings
+			// that work, both covered above.
+			name:           "an unbracketed path with a space is not a reference",
+			markdown:       "![a](./my file.png)",
+			attachmentArgs: []attachmentArg{{Path: "./my file.png", URL: pngURL}},
+			wantMarkdown:   "![a](./my file.png)",
+			wantToAppend:   []attachmentArg{{Path: "./my file.png", URL: pngURL}},
+		},
+		{
+			name:           "an inline angle bracket that is never closed is left alone",
+			markdown:       "![a](<./login.png)",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![a](<./login.png)",
+			wantToAppend:   []attachmentArg{pngArg()},
+		},
+		{
+			// Nothing uses the label, so the definition renders nothing.
+			// Editing it would leave the file invisible instead of appended.
+			name:           "an unused definition is left alone and its file is still appended",
+			markdown:       "No references here.\n\n[shot]: ./login.png",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "No references here.\n\n[shot]: ./login.png",
+			wantToAppend:   []attachmentArg{pngArg()},
+		},
+		{
+			name:           "a definition inside a code fence is left alone",
+			markdown:       "```\n[shot]: ./login.png\n```\n\n![the login screen][shot]",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "```\n[shot]: ./login.png\n```\n\n![the login screen][shot]",
+			wantToAppend:   []attachmentArg{pngArg()},
+		},
+		{
+			name:           "a definition inside an inline code byteRange is left alone",
+			markdown:       "Write `[shot]: ./login.png` to define it.\n\n![the login screen][shot]",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "Write `[shot]: ./login.png` to define it.\n\n![the login screen][shot]",
+			wantToAppend:   []attachmentArg{pngArg()},
+		},
+		{
+			name:           "an inline usage and a reference usage of one file are both rewritten",
+			markdown:       "![inline](./login.png) and [attachmentArg][shot].\n\n[shot]: ./login.png",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![inline](" + pngURL + ") and [attachmentArg][shot].\n\n[shot]: " + pngURL,
+		},
+		{
+			// A node records no label, so a spare definition carrying the same
+			// destination is rewritten too. It renders nothing either way.
+			name:           "a second definition of the same file is rewritten alongside the used one",
+			markdown:       "![the login screen][a]\n\n[a]: ./login.png\n[b]: ./login.png",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "![the login screen][a]\n\n[a]: " + pngURL + "\n[b]: " + pngURL,
+		},
+		{
+			name:           "a definition for a file nobody attached is left alone",
+			markdown:       "![other][o]\n\n[o]: ./other.png",
+			attachmentArgs: []attachmentArg{{Path: "./other.png", Alt: "other"}},
+			wantMarkdown:   "![other][o]\n\n[o]: ./other.png",
+		},
+		{
+			// The block range of a definition continued onto the next line of
+			// a blockquote still carries the ">" prefix, so the destination
+			// read from the source is that marker rather than the path.
+			// Rewriting it would eat the blockquote, so the definition is
+			// left alone and the file is appended instead.
+			name:           "a definition continued onto the next line of a blockquote is left alone",
+			markdown:       "> [shot]:\n> ./login.png\n\n![the login screen][shot]",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "> [shot]:\n> ./login.png\n\n![the login screen][shot]",
+			wantToAppend:   []attachmentArg{pngArg()},
+		},
+		{
+			name:           "a definition inside a blockquote on one line is rewritten",
+			markdown:       "> [shot]: ./login.png\n>\n> ![the login screen][shot]",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "> [shot]: " + pngURL + "\n>\n> ![the login screen][shot]",
+		},
+		{
+			name:           "a definition with its title on the next line keeps the title",
+			markdown:       "[shot]: ./login.png\n  \"Login\"\n\n![the login screen][shot]",
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   "[shot]: " + pngURL + "\n  \"Login\"\n\n![the login screen][shot]",
+		},
+		{
+			// The escaped "]:" inside the label is not where the destination
+			// starts, so the scan has to skip it to find the real one.
+			name:           "a definition whose label contains an escaped bracket is rewritten",
+			markdown:       `[a\]: b]: ./login.png` + "\n\n" + `![the login screen][a\]: b]`,
+			attachmentArgs: []attachmentArg{pngArg()},
+			wantMarkdown:   `[a\]: b]: ` + pngURL + "\n\n" + `![the login screen][a\]: b]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The real flow: validate, then upload, then rewrite. Markdown that
+			// cannot work is refused here, before anything uploads.
+			v, err := newAttachableMarkdown(tt.markdown, tt.attachmentArgs)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			got, err := attachAssetsToMarkdown(v)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantMarkdown, got.Rewritten)
+			require.Equal(t, tt.wantToAppend, got.ToAppend)
+		})
+	}
+}
+
+func TestNewAttachableMarkdown(t *testing.T) {
+	// Nothing has uploaded when this runs, so no argument carries a URL.
+	png := attachmentArg{Path: "./login.png", Alt: "login"}
+	mp4 := attachmentArg{Path: "./repro.mp4", Alt: "repro.mp4", RendersAsPlayer: true}
+	clip := attachmentArg{Path: "./clip.mov", Alt: "clip.mov", RendersAsPlayer: true}
+
+	tests := []struct {
+		name           string
+		markdown       string
+		attachmentArgs []attachmentArg
+		wantErr        string
+	}{
+		{
+			name:           "an image written as a reference-style image is fine",
+			markdown:       "![the login screen][shot]\n\n[shot]: ./login.png",
+			attachmentArgs: []attachmentArg{png},
+		},
+		{
+			name:           "an image written as a reference-style link is fine",
+			markdown:       "See the [screenshot][shot].\n\n[shot]: ./login.png",
+			attachmentArgs: []attachmentArg{png},
+		},
+		{
+			name:           "a video written as a reference-style link is fine",
+			markdown:       "[the recording][clip]\n\n[clip]: ./repro.mp4",
+			attachmentArgs: []attachmentArg{mp4},
+		},
+		{
+			name:           "a video written as a reference-style image is refused",
+			markdown:       "![the recording][clip]\n\n[clip]: ./repro.mp4",
+			attachmentArgs: []attachmentArg{mp4},
+			wantErr:        "cannot embed a video as a reference-style image: ./repro.mp4",
+		},
+		{
+			name:           "every offending video is named",
+			markdown:       "![one][a] and ![two][b]\n\n[a]: ./repro.mp4\n[b]: ./clip.mov",
+			attachmentArgs: []attachmentArg{mp4, clip},
+			wantErr:        "cannot embed a video as a reference-style image: ./repro.mp4, ./clip.mov",
+		},
+		{
+			name:           "a video named once is reported once",
+			markdown:       "![one][a] and ![two][a]\n\n[a]: ./repro.mp4",
+			attachmentArgs: []attachmentArg{mp4},
+			wantErr:        "cannot embed a video as a reference-style image: ./repro.mp4",
+		},
+		{
+			// The degrade rule handles this shape, so it must not be caught
+			// here.
+			name:           "an inline video embed is not a reference-style image",
+			markdown:       "The failure ![screen recording](./repro.mp4) is reproducible.",
+			attachmentArgs: []attachmentArg{mp4},
+		},
+		{
+			name:           "an unused definition for a video is fine",
+			markdown:       "Nothing uses it.\n\n[clip]: ./repro.mp4",
+			attachmentArgs: []attachmentArg{mp4},
+		},
+		{
+			name:           "a video reference image inside a code fence is fine",
+			markdown:       "```\n![clip][c]\n\n[c]: ./repro.mp4\n```",
+			attachmentArgs: []attachmentArg{mp4},
+		},
+		{
+			name:           "markdown with no attachments is fine",
+			markdown:       "Just prose.",
+			attachmentArgs: []attachmentArg{png, mp4},
+		},
+		{
+			name:           "no assets at all is fine",
+			markdown:       "![the recording][clip]\n\n[clip]: ./repro.mp4",
+			attachmentArgs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := newAttachableMarkdown(tt.markdown, tt.attachmentArgs)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.markdown, v.markdown)
+				return
+			}
+			require.EqualError(t, err, tt.wantErr)
+			require.Empty(t, v, "refused markdown must not be usable")
+		})
+	}
+}
+
+// One edit in the definition carries every usage of the label, so nothing is
+// appended a second time.
+func TestAttachAssetsToMarkdownReferenceStyleLink(t *testing.T) {
+	markdown := "See [the screenshot][shot].\n\n[shot]: ./login.png"
+
+	v, err := newAttachableMarkdown(markdown, []attachmentArg{pngArg()})
+	require.NoError(t, err)
+
+	got, err := attachAssetsToMarkdown(v)
+	require.NoError(t, err)
+	require.Equal(t, "See [the screenshot][shot].\n\n[shot]: "+pngURL, got.Rewritten)
+	require.Empty(t, got.ToAppend)
+}

--- a/internal/attachments/testdata/references_expected.md
+++ b/internal/attachments/testdata/references_expected.md
@@ -1,0 +1,178 @@
+# Images
+
+An embed alone in its paragraph:
+
+![the login screen](https://example.com/login)
+
+An embed inline in ![the login screen](https://example.com/login) a sentence.
+
+A link to [the screenshot](https://example.com/login) instead of an embed.
+
+An embed and a link to ![one file](https://example.com/login) and [the same file](https://example.com/login).
+
+Alt text written here wins over the flag: ![the auth error page](https://example.com/login)
+
+Formatting inside the ![*emphasised* alt](https://example.com/login) alt text survives.
+
+A title survives: ![the login screen](https://example.com/login "Login")
+
+A single quoted title: ![the login screen](https://example.com/login 'Login')
+
+A parenthesised title: ![the login screen](https://example.com/login (Login))
+
+A title with escaped quotes: ![the login screen](https://example.com/login "he said \"hi\"")
+
+# Videos
+
+A video alone in its paragraph plays:
+
+https://example.com/repro
+
+A video inline in [the recording](https://example.com/repro) a sentence cannot play.
+
+A video written as a link stays [a link](https://example.com/repro).
+
+A video with no alt text inline [repro.mp4](https://example.com/repro) falls back to the file name.
+
+A bang before a video embed\![the recording](https://example.com/repro) must not re-form an embed.
+
+A bang already escaped\![the recording](https://example.com/repro) is left alone.
+
+A bracket before a video embed][the recording](https://example.com/repro) needs no escaping.
+
+# Paths that need escaping
+
+Angle brackets around spaces: ![the screenshot](https://example.com/screenshot)
+
+Percent encoding for spaces: ![the screenshot](https://example.com/screenshot)
+
+Balanced parentheses: ![a](https://example.com/parens)
+
+Nested balanced parentheses: ![a](https://example.com/nested-parens)
+
+An escaped closing parenthesis: ![a](https://example.com/escaped-paren)
+
+An escaped backslash: ![a](https://example.com/backslash)
+
+Escaped parentheses: ![a](https://example.com/escaped-parens)
+
+# Paths markdown does not parse as a link
+
+An unbalanced closing parenthesis ends the destination: ![a](https://example.com/truncated).png)
+
+An unbalanced opening parenthesis is literal text: ![a](./f(1.png)
+
+An unbracketed space is literal text: ![a](./my file.png)
+
+An unclosed angle bracket is literal text: ![a](<./login.png)
+
+# Nesting
+
+An image nested in a link: [![the badge](https://example.com/login)](https://example.com/repro)
+
+A thumbnail linking to its own file: [![the login screen](https://example.com/login)](https://example.com/login)
+
+A video embedded inside a link to itself: [[the recording](https://example.com/repro)](https://example.com/repro)
+
+A link inside the alt text of a degraded video: here [see [the screenshot](https://example.com/login)](https://example.com/repro) inline.
+
+An image inside the alt text of a degraded video: here [see ![the screenshot](https://example.com/login)](https://example.com/repro) inline.
+
+# Code is never touched
+
+```
+![not a reference](./login.png)
+[not a definition]: ./login.png
+```
+
+Inline `![not a reference](./login.png)` code span.
+
+A code span that could pair with an earlier bracket: [x `](./login.png)` y ![the real one](https://example.com/login)
+
+A bracket inside a code span in the alt text: ![before `[` after](https://example.com/login)
+
+    ![an indented code block](./login.png)
+
+# Malformed tails are skipped
+
+An unterminated title earlier in the block: [x](./login.png "oops) then ![the login screen](https://example.com/login)
+
+A tail that never closes: [x](./login.png b) and [the login screen](https://example.com/login)
+
+# Structure
+
+- a tight list item ![the login screen](https://example.com/login)
+- [the recording](https://example.com/repro)
+
+* one loose item
+
+* https://example.com/repro
+
+> a blockquote ![the login screen](https://example.com/login)
+
+> https://example.com/repro
+
+> > https://example.com/repro
+
+- > https://example.com/repro
+
+# ![the login screen](https://example.com/login)
+
+# [the recording](https://example.com/repro)
+
+Watch this:
+[the recording](https://example.com/repro)
+and then read on.
+
+An image and a video in one paragraph: ![the login screen](https://example.com/login) and [the recording](https://example.com/repro).
+
+# Reference style
+
+An image written as a reference-style image: ![the login screen][shot]
+
+An image written as a reference-style link: see [the screenshot][shot] for detail.
+
+A video written as a reference-style link: [the recording][clip]
+
+The collapsed form: ![shot][]
+
+The shortcut form: ![shot]
+
+An inline usage and a reference usage of one file: ![inline](https://example.com/login) and [reference][shot].
+
+[shot]: https://example.com/login
+[clip]: https://example.com/repro
+[spare]: https://example.com/login
+[titled]: https://example.com/login "Login"
+[angled]: https://example.com/screenshot
+[escaped\]: label]: https://example.com/login
+[angle-escape]: https://example.com/escaped-angle
+[unused]: ./unused.png
+[unattached]: ./other.png
+
+An unclosed angle bracket is not a definition, so it and everything after it
+in this paragraph stays text:
+
+[bad angle]: <./login.png
+
+The titled reference: ![titled][titled]
+
+The angled reference: ![angled][angled]
+
+The escaped label reference: ![escaped][escaped\]: label]
+
+The escaped angle bracket definition: ![escaped angle][angle-escape]
+
+The unattached reference: ![unattached][unattached]
+
+The unclosed angle definition: ![bad][bad angle]
+
+# Left exactly as written
+
+A remote URL: ![hosted](https://example.com/login.png)
+
+An anchor: [jump](#login.png)
+
+A local path nobody attached: ![unattached](./other.png)
+
+A file whose upload produced no URL: ![no url](./nourl.png)

--- a/internal/attachments/testdata/references_input.md
+++ b/internal/attachments/testdata/references_input.md
@@ -1,0 +1,178 @@
+# Images
+
+An embed alone in its paragraph:
+
+![the login screen](./login.png)
+
+An embed inline in ![the login screen](./login.png) a sentence.
+
+A link to [the screenshot](./login.png) instead of an embed.
+
+An embed and a link to ![one file](./login.png) and [the same file](./login.png).
+
+Alt text written here wins over the flag: ![the auth error page](./login.png)
+
+Formatting inside the ![*emphasised* alt](./login.png) alt text survives.
+
+A title survives: ![the login screen](./login.png "Login")
+
+A single quoted title: ![the login screen](./login.png 'Login')
+
+A parenthesised title: ![the login screen](./login.png (Login))
+
+A title with escaped quotes: ![the login screen](./login.png "he said \"hi\"")
+
+# Videos
+
+A video alone in its paragraph plays:
+
+![the recording](./repro.mp4)
+
+A video inline in ![the recording](./repro.mp4) a sentence cannot play.
+
+A video written as a link stays [a link](./repro.mp4).
+
+A video with no alt text inline ![](./repro.mp4) falls back to the file name.
+
+A bang before a video embed!![the recording](./repro.mp4) must not re-form an embed.
+
+A bang already escaped\!![the recording](./repro.mp4) is left alone.
+
+A bracket before a video embed]![the recording](./repro.mp4) needs no escaping.
+
+# Paths that need escaping
+
+Angle brackets around spaces: ![the screenshot](<./Screenshot 2026-08-10 at 5.38.10 PM.png>)
+
+Percent encoding for spaces: ![the screenshot](./Screenshot%202026-08-10%20at%205.38.10%20PM.png)
+
+Balanced parentheses: ![a](./f(1).png)
+
+Nested balanced parentheses: ![a](./f((1)(2)).png)
+
+An escaped closing parenthesis: ![a](./f\).png)
+
+An escaped backslash: ![a](./a\\b.png)
+
+Escaped parentheses: ![a](./login\(1\).png)
+
+# Paths markdown does not parse as a link
+
+An unbalanced closing parenthesis ends the destination: ![a](./f).png)
+
+An unbalanced opening parenthesis is literal text: ![a](./f(1.png)
+
+An unbracketed space is literal text: ![a](./my file.png)
+
+An unclosed angle bracket is literal text: ![a](<./login.png)
+
+# Nesting
+
+An image nested in a link: [![the badge](./login.png)](./repro.mp4)
+
+A thumbnail linking to its own file: [![the login screen](./login.png)](./login.png)
+
+A video embedded inside a link to itself: [![the recording](./repro.mp4)](./repro.mp4)
+
+A link inside the alt text of a degraded video: here ![see [the screenshot](./login.png)](./repro.mp4) inline.
+
+An image inside the alt text of a degraded video: here ![see ![the screenshot](./login.png)](./repro.mp4) inline.
+
+# Code is never touched
+
+```
+![not a reference](./login.png)
+[not a definition]: ./login.png
+```
+
+Inline `![not a reference](./login.png)` code span.
+
+A code span that could pair with an earlier bracket: [x `](./login.png)` y ![the real one](./login.png)
+
+A bracket inside a code span in the alt text: ![before `[` after](./login.png)
+
+    ![an indented code block](./login.png)
+
+# Malformed tails are skipped
+
+An unterminated title earlier in the block: [x](./login.png "oops) then ![the login screen](./login.png)
+
+A tail that never closes: [x](./login.png b) and [the login screen](./login.png)
+
+# Structure
+
+- a tight list item ![the login screen](./login.png)
+- ![the recording](./repro.mp4)
+
+* one loose item
+
+* ![the recording](./repro.mp4)
+
+> a blockquote ![the login screen](./login.png)
+
+> ![the recording](./repro.mp4)
+
+> > ![the recording](./repro.mp4)
+
+- > ![the recording](./repro.mp4)
+
+# ![the login screen](./login.png)
+
+# ![the recording](./repro.mp4)
+
+Watch this:
+![the recording](./repro.mp4)
+and then read on.
+
+An image and a video in one paragraph: ![the login screen](./login.png) and ![the recording](./repro.mp4).
+
+# Reference style
+
+An image written as a reference-style image: ![the login screen][shot]
+
+An image written as a reference-style link: see [the screenshot][shot] for detail.
+
+A video written as a reference-style link: [the recording][clip]
+
+The collapsed form: ![shot][]
+
+The shortcut form: ![shot]
+
+An inline usage and a reference usage of one file: ![inline](./login.png) and [reference][shot].
+
+[shot]: ./login.png
+[clip]: ./repro.mp4
+[spare]: ./login.png
+[titled]: ./login.png "Login"
+[angled]: <./Screenshot 2026-08-10 at 5.38.10 PM.png>
+[escaped\]: label]: ./login.png
+[angle-escape]: <./a\>b.png>
+[unused]: ./unused.png
+[unattached]: ./other.png
+
+An unclosed angle bracket is not a definition, so it and everything after it
+in this paragraph stays text:
+
+[bad angle]: <./login.png
+
+The titled reference: ![titled][titled]
+
+The angled reference: ![angled][angled]
+
+The escaped label reference: ![escaped][escaped\]: label]
+
+The escaped angle bracket definition: ![escaped angle][angle-escape]
+
+The unattached reference: ![unattached][unattached]
+
+The unclosed angle definition: ![bad][bad angle]
+
+# Left exactly as written
+
+A remote URL: ![hosted](https://example.com/login.png)
+
+An anchor: [jump](#login.png)
+
+A local path nobody attached: ![unattached](./other.png)
+
+A file whose upload produced no URL: ![no url](./nourl.png)


### PR DESCRIPTION
Part of the pull request stack tracked in #14186.

### Description

This is the third layer of the stack, and the largest and hardest pull request in it. Nothing here is reachable from a command yet.

Given some markdown and a set of attached files, it finds every reference in the markdown that points at one of those files and rewrites the destination to the uploaded URL. It reports which attachments were never referenced, so the caller can append them.

The code runs in three phases, and it is ordered that way on purpose:

1. Find every reference. The markdown is parsed with goldmark, the parser `gh` already depends on, and each link or image node is asked for its position.
2. Plan the edits. Each reference becomes a byte range and a replacement.
3. Apply the edits, working back to front so the earlier ranges stay valid.

The behaviour that follows from that:

- A reference style definition is rewritten once, at the definition, so every use of that label follows from one edit.
- A path inside a code fence or an inline code span is left exactly as written.
- A plain link stays a link. Only the destination moves, so alt text, titles and formatting inside the label survive.
- A video embedded alone on its own line has the whole node replaced by a bare URL, because that is what GitHub needs to render a player. A video embedded inline degrades to a link instead, since a player cannot render in the middle of a sentence.
- A video written as a reference style image is refused, because rewriting it would produce an image tag pointing at a video.
- The same file referenced twice is uploaded once and both references get the same URL.

The second commit adds one markdown document that exercises every syntax the package handles, together with its expected output.

### How did you test this change?

The whole stack was built and each of the behaviours above was exercised by hand against a private test repository. That covered a reference rewritten in place, a reference style definition with two uses following one edit, a fenced block and an inline code span left untouched, a plain link staying a link, a video alone on a line becoming a bare URL, a video inline becoming a link, a video as a reference style image being refused, an unused definition left alone, a file named in the body but never attached left alone, and the same file referenced twice sharing one uploaded asset.

### Key points

About 110 lines of this are hand written byte scanning. It exists because goldmark reports the position of a node but not the position of the destination inside that node.

The alternative would be to re-render the document from the parsed tree. That would be worse, because it normalises the author's own prose, and someone who wrote a comment by hand should get their comment back rather than a reformatted version of it. A follow up can restructure this around goldmark's node identity and delete some of the scanning. That work is not here.

### Notes for reviewers

Start with the two entry points and read the three phases in order.

The fixture document in the second commit is the fastest way to understand the behaviour. Reading the input and the expected output side by side shows what the package does without reading the scanner at all, which is why it is a separate commit.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @BagToad will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
