### PR TITLE
`--attach` stack 4/8: Upload an asset to GitHub

### DIFF
--- a/internal/attachments/client.go
+++ b/internal/attachments/client.go
@@ -1,0 +1,210 @@
+package attachments
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghinstance"
+	"github.com/cli/cli/v2/internal/safeurl"
+	"github.com/cli/go-gh/v2/pkg/auth"
+)
+
+// Uploader attaches files to one upload target.
+//
+// TODO kw: hold an api.Client here once go-gh can set Content-Type and
+// Content-Length per request. The endpoint requires both and RESTClient sets
+// neither, so the request is built by hand.
+type Uploader struct {
+	httpClient       *http.Client
+	host             string
+	targetRepository int64
+}
+
+// NewUploader prepares uploads against targetRepository, the numeric REST id of
+// the repository the assets are uploaded against, and viewerPermission, the
+// GraphQL viewerPermission field on that same repository. It validates
+// everything an upload needs, so a caller that gets an Uploader back can use
+// it.
+//
+// The host is checked first. On an enterprise server no token and no permission
+// makes an upload work, so any other order would name a fault the user cannot
+// fix. The other checks are free to move.
+func NewUploader(httpClient *http.Client, tokenType gh.TokenType, host string, targetRepository int64, viewerPermission string) (*Uploader, error) {
+	if err := checkHost(host); err != nil {
+		return nil, err
+	}
+
+	if err := checkUploadTokenType(tokenType); err != nil {
+		return nil, err
+	}
+
+	if targetRepository <= 0 {
+		return nil, errors.New("could not determine which repository to attach files to")
+	}
+
+	if err := checkPermission(viewerPermission); err != nil {
+		return nil, err
+	}
+
+	return &Uploader{httpClient: httpClient, host: host, targetRepository: targetRepository}, nil
+}
+
+// checkHost rejects a host that cannot serve the upload endpoint. IsEnterprise
+// is false for ghe.com tenants, so data residency keeps working.
+func checkHost(host string) error {
+	if auth.IsEnterprise(host) {
+		return errors.New("attaching files is not supported on GitHub Enterprise Server")
+	}
+	return nil
+}
+
+// uploadTokenTypes lists the credentials that can attach a file.
+var uploadTokenTypes = []gh.TokenType{
+	gh.TokenTypeOAuth,
+	gh.TokenTypePersonalAccess,
+	gh.TokenTypeFineGrainedPAT,
+}
+
+// checkUploadTokenType rejects a credential that cannot upload. It is an
+// allowlist, so an unlisted kind is rejected rather than sent.
+func checkUploadTokenType(tokenType gh.TokenType) error {
+	if slices.Contains(uploadTokenTypes, tokenType) {
+		return nil
+	}
+	return errors.New("unsupported authentication type")
+}
+
+// uploadPermissions lists the repository permissions that can attach a file.
+// The list matches api.Repository.ViewerCanPush, and it is measured against the
+// upload endpoint: READ and TRIAGE get a 404.
+var uploadPermissions = []string{"ADMIN", "MAINTAIN", "WRITE"}
+
+// checkPermission rejects a permission that cannot upload. It is an allowlist,
+// so an unlisted value is rejected rather than sent.
+func checkPermission(viewerPermission string) error {
+	// A caller that never requested the field hands over an empty string. That
+	// is a different fault from a permission that is too low.
+	if viewerPermission == "" {
+		return errors.New("could not determine your permission on the repository")
+	}
+
+	if slices.Contains(uploadPermissions, viewerPermission) {
+		return nil
+	}
+	return errors.New("attaching files requires write access to the repository")
+}
+
+// upload sends the file's bytes and returns the asset URL to reference
+// from the markdown.
+func (u *Uploader) upload(ctx context.Context, a UserAsset) (string, error) {
+	assetURL, err := u.postAsset(ctx, a.file())
+	if err != nil {
+		return "", newUploadError(err, a)
+	}
+	return assetURL, nil
+}
+
+// postAsset does the request and reads the asset URL back. It takes the file
+// rather than the UserAsset, because nothing about sending the bytes depends on
+// how they render. It is separate so every way it can fail picks up the same
+// explanation on the way out.
+func (u *Uploader) postAsset(ctx context.Context, a *asset) (string, error) {
+	url, err := safeurl.JoinPathWithHostPrefix(ghinstance.UserAssetUploadPrefix(u.host), "user-attachments", "assets")
+	if err != nil {
+		return "", err
+	}
+	url.SetQuery("name", filepath.Base(a.path))
+	url.SetQuery("content_type", a.contentType)
+	url.SetQuery("repository_id", strconv.FormatInt(u.targetRepository, 10))
+
+	open := func() (io.ReadCloser, error) { return os.Open(a.path) }
+
+	f, err := open()
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url.String(), f)
+	if err != nil {
+		return "", err
+	}
+	req.ContentLength = a.info.Size()
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("Accept", "application/vnd.github+json")
+	// Without GetBody a redirect re-reads an exhausted reader.
+	req.GetBody = open
+
+	resp, err := u.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "", api.HandleHTTPError(resp)
+	}
+
+	var asset struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&asset); err != nil {
+		return "", err
+	}
+	if asset.URL == "" {
+		return "", errors.New("the server returned no asset URL")
+	}
+
+	return asset.URL, nil
+}
+
+// newUploadError captures the status code so the message can name what the
+// endpoint refused.
+func newUploadError(err error, a UserAsset) error {
+	uploadErr := &uploadError{Path: a.Path(), err: err}
+	if httpError, ok := errors.AsType[api.HTTPError](err); ok {
+		uploadErr.StatusCode = httpError.StatusCode
+		uploadErr.Message = httpError.Message
+	}
+	return uploadErr
+}
+
+// uploadError reports a failed upload. StatusCode is zero when the request
+// never reached the server.
+type uploadError struct {
+	Path       string
+	StatusCode int
+	// Message is what the endpoint said, which api.HandleHTTPError has already
+	// joined from the top level message and the per field ones.
+	Message string
+	err     error
+}
+
+func (e *uploadError) Error() string {
+	switch e.StatusCode {
+	case http.StatusNotFound:
+		// The endpoint answers 404 rather than 403 when the token cannot write,
+		// so the status code alone points at the wrong problem.
+		return fmt.Sprintf("could not upload %s\nattaching files requires write access to the repository", e.Path)
+	case http.StatusUnprocessableEntity:
+		if e.Message == "" {
+			return fmt.Sprintf("could not upload %s", e.Path)
+		}
+		return fmt.Sprintf("could not upload %s\n%s", e.Path, e.Message)
+	}
+	return fmt.Sprintf("failed to upload %s: %v", e.Path, e.err)
+}
+
+func (e *uploadError) Unwrap() error {
+	return e.err
+}

--- a/internal/attachments/client_test.go
+++ b/internal/attachments/client_test.go
@@ -1,0 +1,480 @@
+package attachments
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testAsset writes a real file, because upload opens the path it is given.
+func testAsset(t *testing.T, name, contentType, body string) UserAsset {
+	t.Helper()
+
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile(name, []byte(body), 0o600))
+	info, err := os.Stat(name)
+	require.NoError(t, err)
+
+	base := asset{path: "./" + name, info: info, contentType: contentType}
+	if strings.HasPrefix(contentType, "video/") {
+		return &videoAsset{base}
+	}
+	return &imageAsset{base}
+}
+
+// newTestUploader builds an uploader whose requests land in reg.
+func newTestUploader(t *testing.T, reg *httpmock.Registry, host string, targetRepository int64) *Uploader {
+	t.Helper()
+
+	uploader, err := NewUploader(&http.Client{Transport: reg}, gh.TokenTypeOAuth, host, targetRepository, "WRITE")
+	require.NoError(t, err)
+	return uploader
+}
+
+func TestUpload(t *testing.T) {
+	a := testAsset(t, "shot.png", "image/png", "the bytes")
+
+	var gotBody []byte
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "user-attachments/assets"),
+		func(req *http.Request) (*http.Response, error) {
+			var err error
+			gotBody, err = io.ReadAll(req.Body)
+			require.NoError(t, err)
+			return httpmock.StatusStringResponse(201, `{"url":"https://github.com/user-attachments/assets/be9b3920"}`)(req)
+		},
+	)
+
+	assetURL, err := newTestUploader(t, reg, "github.com", 1234).upload(context.Background(), a)
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/user-attachments/assets/be9b3920", assetURL)
+	assert.Equal(t, "the bytes", string(gotBody))
+
+	require.Len(t, reg.Requests, 1)
+	req := reg.Requests[0]
+	assert.Equal(t, "POST", req.Method)
+	assert.Equal(t, "uploads.github.com", req.URL.Host)
+	assert.Equal(t, "/user-attachments/assets", req.URL.Path)
+	assert.Equal(t, "shot.png", req.URL.Query().Get("name"))
+	assert.Equal(t, "image/png", req.URL.Query().Get("content_type"))
+	assert.Equal(t, "1234", req.URL.Query().Get("repository_id"))
+	assert.Equal(t, "application/octet-stream", req.Header.Get("Content-Type"))
+	assert.Equal(t, "application/vnd.github+json", req.Header.Get("Accept"))
+	assert.Equal(t, int64(9), req.ContentLength)
+}
+
+func TestUploadHostForTenant(t *testing.T) {
+	a := testAsset(t, "shot.png", "image/png", "x")
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "user-attachments/assets"),
+		httpmock.StatusStringResponse(201, `{"url":"https://acme.ghe.com/user-attachments/assets/1"}`),
+	)
+
+	_, err := newTestUploader(t, reg, "acme.ghe.com", 1).upload(context.Background(), a)
+
+	require.NoError(t, err)
+	require.Len(t, reg.Requests, 1)
+	assert.Equal(t, "uploads.acme.ghe.com", reg.Requests[0].URL.Host)
+}
+
+func TestUploadErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		file        string
+		contentType string
+		status      int
+		response    string
+		// nonJSON labels the stubbed response as something other than JSON.
+		// The endpoint always sends JSON, so only the row about an unreadable
+		// body sets this. Without the JSON label the error body is never
+		// parsed, and a row asserting a message from it would pass for the
+		// wrong reason.
+		nonJSON        bool
+		wantErr        string
+		wantErrPrefix  string
+		wantStatusCode int
+	}{
+		{
+			name:           "no write access",
+			file:           "login.png",
+			contentType:    "image/png",
+			status:         404,
+			response:       `{"message":"Not Found"}`,
+			wantErr:        "could not upload ./login.png\nattaching files requires write access to the repository",
+			wantStatusCode: 404,
+		},
+		{
+			// The server's limit for a video depends on an account plan gh
+			// cannot see, so its own words are what a user can act on.
+			name:           "rejected as too large",
+			file:           "clip.mp4",
+			contentType:    "video/mp4",
+			status:         413,
+			response:       `{"message":"Payload Too Large"}`,
+			wantErrPrefix:  "failed to upload ./clip.mp4: HTTP 413: Payload Too Large",
+			wantStatusCode: 413,
+		},
+		{
+			name:        "rejected with one stated cause",
+			file:        "clip.mp4",
+			contentType: "video/mp4",
+			status:      422,
+			response: `{"message":"Validation Failed","errors":[
+				{"field":"content_type","message":"content_type is not included in the list of allowed content types"}]}`,
+			wantErr:        "could not upload ./clip.mp4\nValidation Failed\ncontent_type is not included in the list of allowed content types",
+			wantStatusCode: 422,
+		},
+		{
+			name:        "rejected with several stated causes",
+			file:        "shot.png",
+			contentType: "image/png",
+			status:      422,
+			response: `{"message":"Validation Failed","errors":[
+				{"field":"content_type","message":"content_type is not included in the list of allowed content types"},
+				{"field":"name","message":"name has a file extension that does not match the content type"}]}`,
+			wantErr:        "could not upload ./shot.png\nValidation Failed\ncontent_type is not included in the list of allowed content types\nname has a file extension that does not match the content type",
+			wantStatusCode: 422,
+		},
+		{
+			name:           "rejected with a cause that carries only a code",
+			file:           "shot.png",
+			contentType:    "image/png",
+			status:         422,
+			response:       `{"message":"Validation Failed","errors":[{"resource":"Asset","field":"name","code":"invalid"}]}`,
+			wantErr:        "could not upload ./shot.png\nValidation Failed\nAsset.name is invalid",
+			wantStatusCode: 422,
+		},
+		{
+			name:           "rejected with no stated cause",
+			file:           "shot.png",
+			contentType:    "image/png",
+			status:         422,
+			response:       `{"message":"Validation Failed","errors":[]}`,
+			wantErr:        "could not upload ./shot.png\nValidation Failed",
+			wantStatusCode: 422,
+		},
+		{
+			name:           "rejected and saying nothing",
+			file:           "shot.png",
+			contentType:    "image/png",
+			status:         422,
+			response:       `{}`,
+			wantErr:        "could not upload ./shot.png",
+			wantStatusCode: 422,
+		},
+		{
+			name:           "rate limited",
+			file:           "shot.png",
+			contentType:    "image/png",
+			status:         429,
+			response:       `{"message":"Too Many Requests"}`,
+			wantErrPrefix:  "failed to upload ./shot.png: ",
+			wantStatusCode: 429,
+		},
+		{
+			name:           "server error",
+			file:           "shot.png",
+			contentType:    "image/png",
+			status:         500,
+			response:       `{"message":"Internal Server Error"}`,
+			wantErrPrefix:  "failed to upload ./shot.png: ",
+			wantStatusCode: 500,
+		},
+		{
+			name:        "no asset URL in the response",
+			file:        "shot.png",
+			contentType: "image/png",
+			status:      201,
+			response:    `{}`,
+			wantErr:     "failed to upload ./shot.png: the server returned no asset URL",
+		},
+		{
+			name:          "unreadable response",
+			file:          "shot.png",
+			contentType:   "image/png",
+			status:        201,
+			response:      `not json`,
+			nonJSON:       true,
+			wantErrPrefix: "failed to upload ./shot.png: ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := testAsset(t, tt.file, tt.contentType, "x")
+
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			responder := httpmock.StatusJSONResponse(tt.status, json.RawMessage(tt.response))
+			if tt.nonJSON {
+				responder = httpmock.StatusStringResponse(tt.status, tt.response)
+			}
+			reg.Register(
+				httpmock.REST("POST", "user-attachments/assets"),
+				responder,
+			)
+
+			_, err := newTestUploader(t, reg, "github.com", 1).upload(context.Background(), a)
+
+			require.Error(t, err)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.Contains(t, err.Error(), tt.wantErrPrefix)
+			}
+
+			var uploadErr *uploadError
+			require.True(t, errors.As(err, &uploadErr))
+			assert.Equal(t, tt.wantStatusCode, uploadErr.StatusCode)
+			assert.Equal(t, "./"+tt.file, uploadErr.Path)
+			// One attempt, whatever the failure. An upload cannot be deleted,
+			// so a retry that the server had already accepted would orphan an
+			// asset nobody can remove.
+			assert.Len(t, reg.Requests, 1)
+		})
+	}
+}
+
+// A file can be removed between the validation that accepted it and the upload
+// that opens it, which is the only way a resolved asset reaches the endpoint
+// with nothing behind it.
+func TestUploadMissingFile(t *testing.T) {
+	a := testAsset(t, "gone.png", "image/png", "the bytes")
+	require.NoError(t, os.Remove("gone.png"))
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	_, err := newTestUploader(t, reg, "github.com", 1).upload(context.Background(), a)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to upload ./gone.png: ")
+	assert.Empty(t, reg.Requests)
+}
+
+func TestNewUploader(t *testing.T) {
+	const badTokenErr = "unsupported authentication type"
+	const badPermissionErr = "attaching files requires write access to the repository"
+
+	tests := []struct {
+		name             string
+		tokenType        gh.TokenType
+		host             string
+		targetRepository int64
+		viewerPermission string
+		wantErr          string
+	}{
+		{
+			name:             "github.com",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "WRITE",
+		},
+		{
+			name:             "data residency tenant",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "acme.ghe.com",
+			targetRepository: 7,
+			viewerPermission: "WRITE",
+		},
+		{
+			name:             "classic personal access token",
+			tokenType:        gh.TokenTypePersonalAccess,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "WRITE",
+		},
+		{
+			name:             "fine-grained personal access token",
+			tokenType:        gh.TokenTypeFineGrainedPAT,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "WRITE",
+		},
+		{
+			name:             "rejects an enterprise server host",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "github.example.com",
+			targetRepository: 42,
+			viewerPermission: "WRITE",
+			wantErr:          "attaching files is not supported on GitHub Enterprise Server",
+		},
+		{
+			// This row defends a message, not an order. On an enterprise server
+			// the token message would tell the user to re-authenticate, and that
+			// remedy does not work there. The other checks are free to move.
+			name:             "reports the host before the token",
+			tokenType:        gh.TokenTypeServerToServer,
+			host:             "github.example.com",
+			targetRepository: 42,
+			viewerPermission: "WRITE",
+			wantErr:          "attaching files is not supported on GitHub Enterprise Server",
+		},
+		{
+			name:             "rejects an App user-to-server token",
+			tokenType:        gh.TokenTypeUserToServer,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "WRITE",
+			wantErr:          badTokenErr,
+		},
+		{
+			name:             "rejects an App server-to-server token",
+			tokenType:        gh.TokenTypeServerToServer,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "WRITE",
+			wantErr:          badTokenErr,
+		},
+		{
+			name:             "rejects a refresh token",
+			tokenType:        gh.TokenTypeRefresh,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "WRITE",
+			wantErr:          badTokenErr,
+		},
+		{
+			// An unrecognised prefix and no token at all reach here the same
+			// way. Which is which is decided by ActiveTokenType.
+			name:             "rejects a credential gh does not recognise",
+			tokenType:        gh.TokenTypeUnknown,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "WRITE",
+			wantErr:          badTokenErr,
+		},
+		{
+			// A caller that never fetched the id hands over a zero, and an
+			// upload cannot be taken back, so it stops before the endpoint.
+			name:             "rejects an unresolved target",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "github.com",
+			targetRepository: 0,
+			viewerPermission: "WRITE",
+			wantErr:          "could not determine which repository to attach files to",
+		},
+		{
+			name:             "rejects a negative target",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "github.com",
+			targetRepository: -1,
+			viewerPermission: "WRITE",
+			wantErr:          "could not determine which repository to attach files to",
+		},
+		{
+			name:             "admin permission",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "ADMIN",
+		},
+		{
+			name:             "maintain permission",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "MAINTAIN",
+		},
+		{
+			name:             "rejects triage permission",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "TRIAGE",
+			wantErr:          badPermissionErr,
+		},
+		{
+			name:             "rejects read permission",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "READ",
+			wantErr:          badPermissionErr,
+		},
+		{
+			name:             "rejects an unrecognized permission",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "github.com",
+			targetRepository: 42,
+			viewerPermission: "WRTIE",
+			wantErr:          badPermissionErr,
+		},
+		{
+			// Only the user can fix a low permission, so an empty string and a
+			// permission that is too low get different messages.
+			name:             "rejects an unrequested permission",
+			tokenType:        gh.TokenTypeOAuth,
+			host:             "github.com",
+			targetRepository: 42,
+			wantErr:          "could not determine your permission on the repository",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Registered with no stubs, so any request at all fails the test.
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			uploader, err := NewUploader(&http.Client{Transport: reg}, tt.tokenType, tt.host, tt.targetRepository, tt.viewerPermission)
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.Nil(t, uploader)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.host, uploader.host)
+				assert.Equal(t, tt.targetRepository, uploader.targetRepository)
+			}
+			// Building an uploader resolves nothing.
+			assert.Empty(t, reg.Requests)
+		})
+	}
+}
+
+func TestCheckHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		wantErr string
+	}{
+		{name: "github.com", host: "github.com"},
+		{name: "data residency tenant", host: "acme.ghe.com"},
+		{name: "localhost", host: "github.localhost"},
+		{
+			name:    "enterprise server",
+			host:    "github.example.com",
+			wantErr: "attaching files is not supported on GitHub Enterprise Server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkHost(tt.host)
+
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}

--- a/internal/ghinstance/host.go
+++ b/internal/ghinstance/host.go
@@ -90,6 +90,15 @@ func GistHost(hostname string) string {
 	return fmt.Sprintf("gist.%s/", hostname)
 }
 
+// UserAssetUploadPrefix returns the URL prefix for user asset uploads.
+// GHES does not support this endpoint.
+func UserAssetUploadPrefix(hostname string) string {
+	if strings.EqualFold(hostname, localhost) {
+		return fmt.Sprintf("http://uploads.%s/", hostname)
+	}
+	return fmt.Sprintf("https://uploads.%s/", hostname)
+}
+
 func HostPrefix(hostname string) string {
 	if strings.EqualFold(hostname, localhost) {
 		return fmt.Sprintf("http://%s/", hostname)

--- a/internal/ghinstance/host_test.go
+++ b/internal/ghinstance/host_test.go
@@ -158,6 +158,31 @@ func TestRESTPrefix(t *testing.T) {
 	}
 }
 
+func TestUserAssetUploadPrefix(t *testing.T) {
+	tests := []struct {
+		host string
+		want string
+	}{
+		{
+			host: "github.com",
+			want: "https://uploads.github.com/",
+		},
+		{
+			host: "tenant.ghe.com",
+			want: "https://uploads.tenant.ghe.com/",
+		},
+		{
+			host: "github.localhost",
+			want: "http://uploads.github.localhost/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			assert.Equal(t, tt.want, UserAssetUploadPrefix(tt.host))
+		})
+	}
+}
+
 func TestCategorizeHost(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Part of the pull request stack tracked in #14186.

### Description

This is the fourth layer of the stack. It adds the uploader that posts a file to GitHub's user attachments endpoint and returns the asset URL, plus a small helper that builds the upload host for a given GitHub host. Nothing here is reachable from a command yet.

Three refusals happen before any request is made, in this order:

1. GitHub Enterprise Server, because the endpoint does not exist there.
2. A kind of credential the endpoint will not accept.
3. A role on the repository below write.

The host is checked first on purpose. On an enterprise server no token and no permission would ever make an upload work, so any other order would name a fault the user cannot fix.

### How did you test this change?

The whole stack was built and files were uploaded to a private test repository from two accounts. One had write access and every upload succeeded. One had read only access, and every command refused before any request left the machine, which was confirmed by counting the requests rather than by trusting the message.

The upload host was also checked against a GitHub Enterprise Cloud tenant host, where it derives from the target host correctly.

### Key points

The uploader never stores the token. It is told what kind of credential is active and nothing more, and the credential actually sent is chosen by the transport from the request host, like all `gh` requests.

The upload host is derived from the target host, so a tenant with data residency uploads to its own host rather than to github.com.

Refusing early matters more here than in most places, because an upload cannot be undone.

### Notes for reviewers

Read the three refusals first, and the reason the host is checked before the rest.

A note in the code explains why the request is built by hand rather than through the usual REST client. The endpoint requires both a content type and a content length on every request, and the shared client sets neither.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @BagToad will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
