### PR TITLE
`--attach` stack 5/8: Add the flag and upload behind it

### DIFF
--- a/internal/attachments/attach.go
+++ b/internal/attachments/attach.go
@@ -1,0 +1,85 @@
+package attachments
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// UploadAndAttach uploads every asset, points the references the markdown
+// already wrote at their asset URLs, and appends the rest. It reports how many
+// assets reached the server.
+//
+// That count is the only reason to write markdown alongside an error. An upload
+// cannot be undone and there is no endpoint to delete one, so markdown that does
+// not reference an uploaded asset orphans it for good. A count of zero means
+// nothing was uploaded and nothing is lost by writing nothing.
+//
+// The markdown is returned unchanged when it could not be rewritten, so a
+// caller that assigns the result in place never destroys what it was given.
+func (u *Uploader) UploadAndAttach(ctx context.Context, md string, assets []UserAsset) (string, int, error) {
+	refs := make([]attachmentArg, len(assets))
+	for i, a := range assets {
+		f := a.file()
+		refs[i] = attachmentArg{Path: f.path, Alt: f.alt, RendersAsPlayer: a.rendersAsPlayer()}
+	}
+
+	attachableMD, err := newAttachableMarkdown(md, refs)
+	if err != nil {
+		return md, 0, err
+	}
+
+	var failures []error
+	uploaded := 0
+	for i, a := range assets {
+		assetURL, err := u.upload(ctx, a)
+		if err != nil {
+			// Stopping at the first failure. It makes recovery much simpler.
+			failures = append(failures, err)
+			break
+		}
+		refs[i].URL = assetURL
+		uploaded++
+	}
+
+	attachedMD, err := attachAssetsToMarkdown(attachableMD)
+	if err != nil {
+		failures = append(failures, err)
+		return md, uploaded, errors.Join(failures...)
+	}
+
+	return appendUnreferenced(attachedMD, assets), uploaded, errors.Join(failures...)
+}
+
+// appendUnreferenced adds a paragraph for every attachment the author never
+// referenced, in the order they were attached. Each one renders itself, since
+// an image appends a markdown embed and a video appends a bare URL so that it
+// plays, which is why this half does not live with the rewriting.
+func appendUnreferenced(attachedMD attachedMarkdown, assets []UserAsset) string {
+	urlByPath := make(map[string]string, len(attachedMD.ToAppend))
+	for _, arg := range attachedMD.ToAppend {
+		urlByPath[arg.Path] = arg.URL
+	}
+
+	out := attachedMD.Rewritten
+	for _, a := range assets {
+		url, ok := urlByPath[a.Path()]
+		if !ok {
+			continue
+		}
+		out = appendParagraph(out, a.markdown(url))
+	}
+	return out
+}
+
+// appendParagraph joins two pieces of markdown as separate paragraphs.
+func appendParagraph(md, addition string) string {
+	md = strings.TrimRight(md, " \t\r\n")
+	if md == "" {
+		return addition
+	}
+	if addition == "" {
+		return md
+	}
+	return md + "\n\n" + addition
+}

--- a/internal/attachments/attach_test.go
+++ b/internal/attachments/attach_test.go
@@ -1,0 +1,331 @@
+package attachments
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFiles puts real files in a temporary working directory, because
+// uploading opens the path it is given.
+func writeFiles(t *testing.T, names ...string) {
+	t.Helper()
+
+	t.Chdir(t.TempDir())
+	for _, name := range names {
+		require.NoError(t, os.WriteFile(name, []byte("the bytes"), 0o600))
+	}
+}
+
+func testUploader(reg *httpmock.Registry) *Uploader {
+	return &Uploader{
+		httpClient:       &http.Client{Transport: reg},
+		host:             "github.com",
+		targetRepository: 1234,
+	}
+}
+
+func TestUploaderUploadAndAttach(t *testing.T) {
+	// Each upload response is consumed in the order the assets were
+	// written, so a status here is a status for that asset.
+	type upload struct {
+		status   int
+		response string
+	}
+
+	tests := []struct {
+		name     string
+		files    []string
+		args     []string
+		body     string
+		uploads  []upload
+		wantBody string
+		// What a caller keys on to decide whether a body is worth writing.
+		wantUploaded int
+		wantErr      string
+	}{
+		{
+			name:         "appends an image to a body",
+			files:        []string{"login.png"},
+			args:         []string{"./login.png"},
+			body:         "See below",
+			uploads:      []upload{{201, `{"url":"https://github.com/user-attachments/assets/1"}`}},
+			wantBody:     "See below\n\n![login](https://github.com/user-attachments/assets/1)",
+			wantUploaded: 1,
+		},
+		{
+			name:    "appends a video as a paragraph of its own",
+			files:   []string{"repro.mp4"},
+			args:    []string{"./repro.mp4"},
+			body:    "Watch this:",
+			uploads: []upload{{201, `{"url":"https://github.com/user-attachments/assets/2"}`}},
+			// A bare URL only renders as a player when nothing shares its
+			// paragraph, so it must not land on the end of the line above.
+			wantBody:     "Watch this:\n\nhttps://github.com/user-attachments/assets/2",
+			wantUploaded: 1,
+		},
+		{
+			name:         "appends to an empty body without leading blank lines",
+			files:        []string{"login.png"},
+			args:         []string{"./login.png"},
+			body:         "",
+			uploads:      []upload{{201, `{"url":"https://github.com/user-attachments/assets/1"}`}},
+			wantBody:     "![login](https://github.com/user-attachments/assets/1)",
+			wantUploaded: 1,
+		},
+		{
+			name:         "does not stack blank lines on a body that ends with them",
+			files:        []string{"login.png"},
+			args:         []string{"./login.png"},
+			body:         "See below\n\n\n",
+			uploads:      []upload{{201, `{"url":"https://github.com/user-attachments/assets/1"}`}},
+			wantBody:     "See below\n\n![login](https://github.com/user-attachments/assets/1)",
+			wantUploaded: 1,
+		},
+		{
+			name:    "appends several assets in the order they were written",
+			files:   []string{"before.png", "after.png", "repro.mp4"},
+			args:    []string{"./before.png#Before the fix", "./after.png#After the fix", "./repro.mp4"},
+			body:    "Compare:",
+			uploads: []upload{{201, `{"url":"https://example.com/1"}`}, {201, `{"url":"https://example.com/2"}`}, {201, `{"url":"https://example.com/3"}`}},
+			wantBody: "Compare:\n\n" +
+				"![Before the fix](https://example.com/1)\n\n" +
+				"![After the fix](https://example.com/2)\n\n" +
+				"https://example.com/3",
+			wantUploaded: 3,
+		},
+		{
+			name:         "rewrites a reference in place instead of appending it",
+			files:        []string{"login.png"},
+			args:         []string{"./login.png"},
+			body:         "The error:\n\n![the login screen](./login.png)\n\nThat is all.",
+			uploads:      []upload{{201, `{"url":"https://example.com/1"}`}},
+			wantBody:     "The error:\n\n![the login screen](https://example.com/1)\n\nThat is all.",
+			wantUploaded: 1,
+		},
+		{
+			name:         "rewrites what the body references and appends what it does not",
+			files:        []string{"login.png", "after.png"},
+			args:         []string{"./login.png", "./after.png"},
+			body:         "![the login screen](./login.png)",
+			uploads:      []upload{{201, `{"url":"https://example.com/1"}`}, {201, `{"url":"https://example.com/2"}`}},
+			wantBody:     "![the login screen](https://example.com/1)\n\n![after](https://example.com/2)",
+			wantUploaded: 2,
+		},
+		{
+			// Three files and two replies: c is never attempted, which the
+			// registry proves by failing on a stub nothing used.
+			name:         "stops at the first failure and writes what got up",
+			files:        []string{"a.png", "b.png", "c.png"},
+			args:         []string{"./a.png", "./b.png", "./c.png"},
+			body:         "Three files",
+			uploads:      []upload{{201, `{"url":"https://example.com/1"}`}, {404, `{"message":"Not Found"}`}},
+			wantBody:     "Three files\n\n![a](https://example.com/1)",
+			wantUploaded: 1,
+			wantErr:      "could not upload ./b.png\nattaching files requires write access to the repository",
+		},
+		{
+			name:         "leaves a failed reference as the author wrote it",
+			files:        []string{"login.png"},
+			args:         []string{"./login.png"},
+			body:         "![the login screen](./login.png)",
+			uploads:      []upload{{404, `{"message":"Not Found"}`}},
+			wantBody:     "![the login screen](./login.png)",
+			wantUploaded: 0,
+			wantErr:      "could not upload ./login.png\nattaching files requires write access to the repository",
+		},
+		{
+			name:         "writes nothing when the first upload fails",
+			files:        []string{"a.png", "b.png"},
+			args:         []string{"./a.png", "./b.png"},
+			body:         "",
+			uploads:      []upload{{404, `{"message":"Not Found"}`}},
+			wantBody:     "",
+			wantUploaded: 0,
+			wantErr:      "could not upload ./a.png\nattaching files requires write access to the repository",
+		},
+		{
+			// Refused before the upload loop, so nothing is stranded, and the
+			// body comes back untouched for a caller that assigns in place.
+			name:         "refuses a video embedded through a reference definition",
+			files:        []string{"repro.mp4"},
+			args:         []string{"./repro.mp4"},
+			body:         "![clip][c]\n\n[c]: ./repro.mp4",
+			wantBody:     "![clip][c]\n\n[c]: ./repro.mp4",
+			wantUploaded: 0,
+			wantErr:      "cannot embed a video as a reference-style image: ./repro.mp4",
+		},
+		{
+			name:         "uploads a video linked through a reference definition",
+			files:        []string{"repro.mp4"},
+			args:         []string{"./repro.mp4"},
+			body:         "[clip][c]\n\n[c]: ./repro.mp4",
+			uploads:      []upload{{201, `{"url":"https://example.com/1"}`}},
+			wantBody:     "[clip][c]\n\n[c]: https://example.com/1",
+			wantUploaded: 1,
+		},
+		{
+			// The only place a UserAsset becomes an attachmentArg, so the only row
+			// that proves the label survives the copy. It has to be an embed,
+			// since a link keeps the label the author wrote and never reaches
+			// the branch that supplies one.
+			name:         "labels a video embed that degrades to a link",
+			files:        []string{"repro.mp4"},
+			args:         []string{"./repro.mp4"},
+			body:         "The crash ![](./repro.mp4) reproduces every time.",
+			uploads:      []upload{{201, `{"url":"https://example.com/1"}`}},
+			wantBody:     "The crash [repro.mp4](https://example.com/1) reproduces every time.",
+			wantUploaded: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeFiles(t, tt.files...)
+
+			assets, err := assetsFromArgs(t, tt.args...)
+			require.NoError(t, err)
+
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			for _, u := range tt.uploads {
+				reg.Register(
+					httpmock.REST("POST", "user-attachments/assets"),
+					httpmock.StatusStringResponse(u.status, u.response),
+				)
+			}
+
+			body, uploaded, err := testUploader(reg).UploadAndAttach(context.Background(), tt.body, assets)
+
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+			}
+			assert.Equal(t, tt.wantBody, body)
+			assert.Equal(t, tt.wantUploaded, uploaded)
+
+			// The bytes go up in the order they were attached, so a failure
+			// stops the ones after it rather than reordering them.
+			if len(tt.uploads) == 0 {
+				assert.Empty(t, reg.Requests, "nothing should have been uploaded")
+				return
+			}
+			require.Len(t, reg.Requests, len(tt.uploads))
+			for i := range reg.Requests {
+				assert.Equal(t, tt.files[i], reg.Requests[i].URL.Query().Get("name"))
+			}
+		})
+	}
+}
+
+func TestUploaderUploadAndAttachUploadsOnceForRepeatedReferences(t *testing.T) {
+	writeFiles(t, "shot.png")
+
+	assets, err := assetsFromArgs(t, "./shot.png")
+	require.NoError(t, err)
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "user-attachments/assets"),
+		httpmock.StatusStringResponse(201, `{"url":"https://example.com/1"}`),
+	)
+
+	body, uploaded, err := testUploader(reg).UploadAndAttach(context.Background(),
+		"![one](./shot.png)\n\ntext\n\n![two](./shot.png)", assets)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, uploaded)
+	assert.Equal(t, "![one](https://example.com/1)\n\ntext\n\n![two](https://example.com/1)", body)
+	assert.Len(t, reg.Requests, 1)
+}
+
+func TestUploaderUploadAndAttachNoAssets(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	body, uploaded, err := testUploader(reg).UploadAndAttach(context.Background(), "unchanged\n", nil)
+
+	require.NoError(t, err)
+	assert.Zero(t, uploaded)
+	assert.Equal(t, "unchanged\n", body)
+	assert.Empty(t, reg.Requests)
+}
+
+func TestAppendParagraph(t *testing.T) {
+	tests := []struct {
+		name     string
+		md       string
+		addition string
+		want     string
+	}{
+		{name: "separates with a blank line", md: "text", addition: "more", want: "text\n\nmore"},
+		{name: "empty markdown", md: "", addition: "more", want: "more"},
+		{name: "whitespace only markdown", md: "  \n\n", addition: "more", want: "more"},
+		{name: "empty addition", md: "text", addition: "", want: "text"},
+		{name: "trailing newlines", md: "text\n\n\n", addition: "more", want: "text\n\nmore"},
+		{name: "trailing spaces", md: "text  ", addition: "more", want: "text\n\nmore"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, appendParagraph(tt.md, tt.addition))
+		})
+	}
+}
+
+func TestUploaderUploadAndAttachDoesNotLeakTheAssetURLIntoAnError(t *testing.T) {
+	writeFiles(t, "a.png", "b.png")
+
+	assets, err := assetsFromArgs(t, "./a.png", "./b.png")
+	require.NoError(t, err)
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "user-attachments/assets"),
+		httpmock.StatusStringResponse(201, `{"url":"https://example.com/secret-asset"}`),
+	)
+	reg.Register(
+		httpmock.REST("POST", "user-attachments/assets"),
+		httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
+	)
+
+	body, uploaded, err := testUploader(reg).UploadAndAttach(context.Background(), "", assets)
+
+	require.Error(t, err)
+	// One asset is up and cannot be deleted, so the caller must write this
+	// body even though the call failed.
+	assert.Equal(t, 1, uploaded)
+	assert.NotContains(t, err.Error(), "secret-asset")
+	assert.Contains(t, body, "secret-asset")
+}
+
+func TestUploaderUploadAndAttachAbsolutePathReference(t *testing.T) {
+	writeFiles(t, "shot.png")
+	abs, err := filepath.Abs("shot.png")
+	require.NoError(t, err)
+
+	assets, err := assetsFromArgs(t, abs)
+	require.NoError(t, err)
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("POST", "user-attachments/assets"),
+		httpmock.StatusStringResponse(201, `{"url":"https://example.com/1"}`),
+	)
+
+	body, uploaded, err := testUploader(reg).UploadAndAttach(context.Background(), "![shot](./shot.png)", assets)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, uploaded)
+	assert.Equal(t, "![shot](https://example.com/1)", body)
+}

--- a/internal/attachments/flags.go
+++ b/internal/attachments/flags.go
@@ -1,0 +1,125 @@
+package attachments
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+const flagName = "attach"
+
+// errEmptyPath is reported for a --attach that named no file, whether the flag
+// held nothing else or the empty value sat beside a real one.
+var errEmptyPath = errors.New("cannot attach an empty path; --attach needs a file path")
+
+// AddFlag registers the repeatable --attach flag on cmd.
+func AddFlag(cmd *cobra.Command) {
+	// A string slice would split on commas, which are legal in filenames.
+	cmd.Flags().StringArray(flagName, nil, "Attach an image or video `file`, in <file>#<alt text> format")
+}
+
+// FromFlagValues validates every file --attach named on cmd, keeping them in
+// the order they were written. It returns nothing when the flag was passed no
+// values, so a caller reads the length rather than asking a second question.
+//
+// A command that does not register --attach cannot have any, and asking for
+// them is a mistake in the command rather than in what the user typed.
+func FromFlagValues(cmd *cobra.Command) ([]UserAsset, error) {
+	flag := cmd.Flags().Lookup(flagName)
+	if flag == nil {
+		return nil, fmt.Errorf("%s does not register --attach", cmd.Name())
+	}
+	if !flag.Changed {
+		return nil, nil
+	}
+	if err := checkFlagConflicts(cmd); err != nil {
+		return nil, err
+	}
+
+	args, err := cmd.Flags().GetStringArray(flagName)
+	if err != nil {
+		return nil, err
+	}
+
+	// --attach "" is a user error.
+	if len(args) == 0 {
+		return nil, errEmptyPath
+	}
+
+	resolvedAssets := make([]UserAsset, 0, len(args))
+	for _, arg := range args {
+		a, err := assetFromArg(arg)
+		if err != nil {
+			return nil, err
+		}
+
+		// The same file under two names is a user error.
+		for _, seen := range resolvedAssets {
+			if os.SameFile(seen.file().info, a.file().info) {
+				return nil, fmt.Errorf("%s and %s are the same file; attached files must be unique", seen.Path(), a.Path())
+			}
+		}
+		resolvedAssets = append(resolvedAssets, a)
+	}
+
+	return resolvedAssets, nil
+}
+
+// assetFromArg turns one --attach argument into a UserAsset.
+func assetFromArg(arg string) (UserAsset, error) {
+	path, alt := parseArg(arg)
+
+	if path == "" {
+		return nil, errEmptyPath
+	}
+
+	if path == "-" {
+		return nil, errors.New("cannot attach standard input; --attach needs a file path")
+	}
+
+	return newAsset(path, alt)
+}
+
+// parseArg splits the `path#alt text` form of an --attach argument. An existing
+// path wins over the delimiter, since `#` is legal in filenames.
+func parseArg(arg string) (path, alt string) {
+	if _, err := os.Stat(arg); err == nil {
+		return arg, ""
+	}
+	// Scan from the last hash to the first, so the longest path that exists
+	// wins. That continues the rule above, where the whole argument is the
+	// longest match of all, and it leaves a hash inside the alt text usable.
+	for i := strings.LastIndex(arg, "#"); i > 0; i = strings.LastIndex(arg[:i], "#") {
+		if _, err := os.Stat(arg[:i]); err == nil {
+			return arg[:i], arg[i+1:]
+		}
+	}
+	// No candidate exists, so the argument names a file that is not there. The
+	// last hash keeps the error naming the path a reader would expect.
+	if idx := strings.LastIndex(arg, "#"); idx > 0 {
+		return arg[:idx], arg[idx+1:]
+	}
+	return arg, ""
+}
+
+// checkFlagConflicts rejects the modes an asset cannot be written in. Only
+// ResolveFlag calls it, so --attach has been passed by the time it runs.
+func checkFlagConflicts(cmd *cobra.Command) error {
+	if web, _ := cmd.Flags().GetBool("web"); web {
+		return cmdutil.FlagErrorf("`--attach` is not supported when using `--web`")
+	}
+
+	if deleteLast, _ := cmd.Flags().GetBool("delete-last"); deleteLast {
+		return cmdutil.FlagErrorf("`--attach` is not supported when using `--delete-last`")
+	}
+
+	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+		return cmdutil.FlagErrorf("`--attach` is not supported when using `--dry-run`")
+	}
+
+	return nil
+}

--- a/internal/attachments/flags_test.go
+++ b/internal/attachments/flags_test.go
@@ -33,6 +33,23 @@ func attachCmd(t *testing.T, withAttach bool, input string) *cobra.Command {
 	return cmd
 }
 
+// Resolved through the public entry point, so a fixture is built the way a
+// command builds one.
+func assetsFromArgs(t *testing.T, args ...string) ([]UserAsset, error) {
+	t.Helper()
+
+	cmd := &cobra.Command{}
+	AddFlag(cmd)
+
+	argv := make([]string, 0, len(args)*2)
+	for _, arg := range args {
+		argv = append(argv, "--attach", arg)
+	}
+	require.NoError(t, cmd.Flags().Parse(argv))
+
+	return FromFlagValues(cmd)
+}
+
 func TestAddFlag(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/attachments/flags_test.go
+++ b/internal/attachments/flags_test.go
@@ -1,0 +1,284 @@
+package attachments
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/google/shlex"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// attachCmd builds a command shaped like the ones that take --attach.
+// withAttach is false for a command that has not registered the flag.
+func attachCmd(t *testing.T, withAttach bool, input string) *cobra.Command {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "comment"}
+	cmd.Flags().Bool("web", false, "")
+	cmd.Flags().Bool("delete-last", false, "")
+	cmd.Flags().Bool("dry-run", false, "")
+
+	if withAttach {
+		AddFlag(cmd)
+	}
+
+	argv, err := shlex.Split(input)
+	require.NoError(t, err)
+	require.NoError(t, cmd.Flags().Parse(argv))
+
+	return cmd
+}
+
+func TestAddFlag(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "not passed",
+			input: "",
+			want:  []string{},
+		},
+		{
+			name:  "one file",
+			input: "--attach ./login.png",
+			want:  []string{"./login.png"},
+		},
+		{
+			name:  "repeated, in the order written",
+			input: "--attach './login.png#FIRST' --attach ./error-state.png",
+			want:  []string{"./login.png#FIRST", "./error-state.png"},
+		},
+		{
+			name:  "a comma is part of the filename",
+			input: "--attach './before,after.png'",
+			want:  []string{"./before,after.png"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := attachCmd(t, true, tt.input)
+
+			// Read the way FromFlagValues does, so this cannot pass while
+			// the flag it describes reads differently.
+			slice, ok := cmd.Flags().Lookup(flagName).Value.(pflag.SliceValue)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, slice.GetSlice())
+			assert.Empty(t, cmd.Flags().Lookup(flagName).Shorthand)
+		})
+	}
+}
+
+func TestFromFlagValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		withAttach bool
+		setup      func(t *testing.T)
+		input      string
+		wantPaths  []string
+		wantErr    string
+		// wantErrIs covers an error whose text the operating system words
+		// differently, so the assertion cannot be on the message.
+		wantErrIs error
+	}{
+		{
+			name:       "not registered",
+			withAttach: false,
+			wantErr:    "comment does not register --attach",
+		},
+		{
+			name:       "registered but not passed",
+			withAttach: true,
+			input:      "",
+		},
+		{
+			name:       "one file",
+			withAttach: true,
+			input:      "--attach ./shot.png",
+			wantPaths:  []string{"./shot.png"},
+		},
+		{
+			name:       "several files, in the order written",
+			withAttach: true,
+			input:      "--attach ./b.png --attach ./a.png",
+			wantPaths:  []string{"./b.png", "./a.png"},
+		},
+		{
+			name:       "a file that does not exist",
+			withAttach: true,
+			input:      "--attach ./gone.png",
+			wantErr:    "./gone.png: ",
+			wantErrIs:  fs.ErrNotExist,
+		},
+		{
+			// pflag reads this flag back as holding nothing at all, so
+			// without the length check the command would post with no
+			// attachment and no error.
+			name:       "a lone empty value",
+			withAttach: true,
+			input:      `--attach ""`,
+			wantErr:    "cannot attach an empty path; --attach needs a file path",
+		},
+		{
+			name:       "an empty value beside a real one",
+			withAttach: true,
+			input:      `--attach ./shot.png --attach ""`,
+			wantErr:    "cannot attach an empty path; --attach needs a file path",
+		},
+		{
+			name:       "standard input",
+			withAttach: true,
+			input:      "--attach -",
+			wantErr:    "cannot attach standard input; --attach needs a file path",
+		},
+		{
+			name:       "a value holding a comma stays one path",
+			withAttach: true,
+			input:      `--attach ./before,after.png`,
+			wantPaths:  []string{"./before,after.png"},
+		},
+		{
+			name:       "web without attach",
+			withAttach: true,
+			input:      "--web",
+		},
+		{
+			name:       "delete-last without attach",
+			withAttach: true,
+			input:      "--delete-last",
+		},
+		{
+			name:       "dry-run without attach",
+			withAttach: true,
+			input:      "--dry-run",
+		},
+		{
+			name:       "web on a command with no attach flag",
+			withAttach: false,
+			input:      "--web",
+			wantErr:    "comment does not register --attach",
+		},
+		{
+			name:       "attach with web",
+			withAttach: true,
+			input:      "--attach ./shot.png --web",
+			wantErr:    "`--attach` is not supported when using `--web`",
+		},
+		{
+			name:       "attach with delete-last",
+			withAttach: true,
+			input:      "--attach ./shot.png --delete-last",
+			wantErr:    "`--attach` is not supported when using `--delete-last`",
+		},
+		{
+			name:       "attach with dry-run",
+			withAttach: true,
+			input:      "--attach ./shot.png --dry-run",
+			wantErr:    "`--attach` is not supported when using `--dry-run`",
+		},
+		{
+			// The conflict is checked before the paths are read, so a caller
+			// cannot reach the disk in a mode the asset could never be written
+			// in.
+			name:       "a flag conflict is reported before a missing file",
+			withAttach: true,
+			input:      "--attach ./gone.png --web",
+			wantErr:    "`--attach` is not supported when using `--web`",
+		},
+		{
+			name:       "keeps the order the arguments were written in",
+			withAttach: true,
+			input:      "--attach './b.png#Second' --attach ./a.png --attach ./c.mp4",
+			wantPaths:  []string{"./b.png", "./a.png", "./c.mp4"},
+		},
+		{
+			name:       "the same file twice",
+			withAttach: true,
+			input:      "--attach ./a.png --attach './a.png#Another caption'",
+			wantErr:    "./a.png and ./a.png are the same file; attached files must be unique",
+		},
+		{
+			name:       "the same file under two different paths",
+			withAttach: true,
+			input:      "--attach ./a.png --attach a.png",
+			wantErr:    "./a.png and a.png are the same file; attached files must be unique",
+		},
+		{
+			name:       "a symlink and the file it points at",
+			withAttach: true,
+			setup: func(t *testing.T) {
+				// Creating one needs a privilege Windows does not grant by
+				// default, so a machine that cannot make a symlink cannot run
+				// this case either.
+				if err := os.Symlink("a.png", "link.png"); err != nil {
+					t.Skipf("cannot create a symlink here: %v", err)
+				}
+			},
+			input:   "--attach ./a.png --attach ./link.png",
+			wantErr: "./a.png and ./link.png are the same file; attached files must be unique",
+		},
+		{
+			name:       "a hard link and the file it shares",
+			withAttach: true,
+			setup: func(t *testing.T) {
+				require.NoError(t, os.Link("a.png", "hard.png"))
+			},
+			input:   "--attach ./a.png --attach ./hard.png",
+			wantErr: "./a.png and ./hard.png are the same file; attached files must be unique",
+		},
+		{
+			// GitHub gives each its own asset URL.
+			name:       "two separate files with identical contents",
+			withAttach: true,
+			input:      "--attach ./a.png --attach ./b.png",
+			wantPaths:  []string{"./a.png", "./b.png"},
+		},
+		{
+			name:       "reports the first invalid file",
+			withAttach: true,
+			input:      "--attach ./a.png --attach ./notes.txt",
+			wantErr:    "./notes.txt is not a supported file type (supported: png, jpg, jpeg, gif, webp, svg, mp4, mov, webm)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			for _, name := range []string{"shot.png", "a.png", "b.png", "c.mp4", "before,after.png", "notes.txt"} {
+				require.NoError(t, os.WriteFile(name, []byte("the bytes"), 0o600))
+			}
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+
+			cmd := attachCmd(t, tt.withAttach, tt.input)
+
+			resolved, err := FromFlagValues(cmd)
+
+			if tt.wantErrIs != nil {
+				require.ErrorIs(t, err, tt.wantErrIs)
+				require.ErrorContains(t, err, tt.wantErr)
+				assert.Nil(t, resolved)
+				return
+			}
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.Nil(t, resolved)
+				return
+			}
+			require.NoError(t, err)
+
+			var paths []string
+			for _, a := range resolved {
+				paths = append(paths, a.Path())
+			}
+			assert.Equal(t, tt.wantPaths, paths)
+		})
+	}
+}

--- a/internal/attachments/test.go
+++ b/internal/attachments/test.go
@@ -1,0 +1,74 @@
+package attachments
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// NewTestAssets returns a UserAsset per name, resolved through --attach, which
+// is the only way a command builds one.
+//
+// It writes each name into a temporary directory and changes the working
+// directory to it for the rest of the test, so the names are relative paths
+// that resolve.
+func NewTestAssets(t *testing.T, names ...string) []UserAsset {
+	t.Helper()
+
+	t.Chdir(t.TempDir())
+
+	argv := make([]string, 0, len(names)*2)
+	for _, name := range names {
+		require.NoError(t, os.WriteFile(name, []byte("the bytes"), 0o600))
+		argv = append(argv, "--attach", "./"+name)
+	}
+
+	cmd := &cobra.Command{}
+	AddFlag(cmd)
+	require.NoError(t, cmd.Flags().Parse(argv))
+
+	assets, err := FromFlagValues(cmd)
+	require.NoError(t, err)
+	return assets
+}
+
+// StubUpload registers one upload of name against repositoryID, answering with
+// status and body.
+//
+// It matches on the query the upload carries, so a request that names the wrong
+// repository or the wrong file matches nothing and the test fails.
+func StubUpload(reg *httpmock.Registry, repositoryID int64, name string, status int, body string) {
+	reg.Register(uploadMatcher(repositoryID, name), httpmock.StatusStringResponse(status, body))
+}
+
+// StubUploadToHost is StubUpload plus the host the request reached. The
+// matchers compare the path only, so the host is asserted in the responder or
+// not at all.
+func StubUploadToHost(t *testing.T, reg *httpmock.Registry, host string, repositoryID int64, name string, status int, body string) {
+	reg.Register(uploadMatcher(repositoryID, name), func(req *http.Request) (*http.Response, error) {
+		assert.Equal(t, host, req.URL.Host)
+		return httpmock.StatusStringResponse(status, body)(req)
+	})
+}
+
+func uploadMatcher(repositoryID int64, name string) httpmock.Matcher {
+	return httpmock.QueryMatcher("POST", "user-attachments/assets", url.Values{
+		"repository_id": []string{strconv.FormatInt(repositoryID, 10)},
+		"name":          []string{name},
+	})
+}
+
+// UploadStub is one stubbed reply from the asset upload endpoint, named for the
+// file it answers for. StubUpload registers one.
+type UploadStub struct {
+	Name   string
+	Status int
+	Body   string
+}


### PR DESCRIPTION
Part of the pull request stack tracked in #14186.

### Description

This is the fifth layer of the stack. The first commit adds the flag and reads its values. The second ties uploading to rewriting and decides when the resulting markdown is safe to write. No command offers the flag yet.

The flag is repeatable and takes a file path, optionally followed by `#` and alt text. Without alt text the file name is used. Every named file is validated before anything is uploaded.

Naming the same file twice is refused, and that includes a file and a symlink to it, and a file and a hard link to it, since both would upload the same bytes twice. An empty value is refused too, which is what a script produces when a variable is unset.

Conflicting flags are checked while the flag is being read, rather than in each command, so a command that offers the flag cannot forget to check them.

The flag is registered as a string array rather than a string slice, because a string slice splits on commas and a comma is legal in a file name:

```go
cmd.Flags().StringArray(flagName, nil, "Attach an image or video `file`, in <file>#<alt text> format")
```

### How did you test this change?

The whole stack was built and the failure path was exercised by hand against a private test repository. Three files were attached with the middle one made unreadable. Exactly one upload request left the machine for three attached files, the command exited non zero and named the file that failed, and the comment was still posted carrying the one file that did upload.

When the only attached file failed, nothing was posted at all and the command said so.

Duplicate detection was exercised with a plain duplicate, with a symlink to the same file, and with a hard link to it.

### Key points

An upload cannot be undone and there is no endpoint to delete an uploaded asset. That single fact drives the design of the second commit.

The function reports how many assets reached the server, and a caller writes the body only when that count is above zero. Markdown that does not reference an uploaded asset would orphan that asset for good. A count of zero means nothing was uploaded, so nothing is lost by writing nothing.

Uploading stops at the first failure and nothing after it is attempted. A reference to a file that did not upload keeps its local path, so a partial failure leaves a body containing links that do not resolve. That is the accepted cost of writing a body that already carries a real uploaded asset, and it is a thing a user will see.

### Notes for reviewers

The count returned by the upload function is the whole safety mechanism. Read that first, then read the callers in the layers above to see how it is used.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @BagToad will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
