### PR TITLE
`--attach` stack 6/8: Add the flag to gh pr comment and gh issue comment

### DIFF
--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -2,6 +2,7 @@ package comment
 
 import (
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/attachments"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
 	issueShared "github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -14,6 +15,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 	opts := &prShared.CommentableOptions{
 		IO:                        f.IOStreams,
 		HttpClient:                f.HttpClient,
+		Config:                    f.Config,
 		EditSurvey:                prShared.CommentableEditSurvey(f.Config, f.IOStreams),
 		InteractiveEditSurvey:     prShared.CommentableInteractiveEditSurvey(f.Config, f.IOStreams),
 		ConfirmSubmitSurvey:       prShared.CommentableConfirmSubmitSurvey(f.Prompter),
@@ -27,14 +29,28 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 	cmd := &cobra.Command{
 		Use:   "comment {<number> | <url>}",
 		Short: "Add a comment to an issue",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Add a comment to a GitHub issue.
 
 			Without the body text supplied through flags, the command will interactively
 			prompt for the comment text.
-		`),
+
+			Use %[1]s--attach%[1]s to upload an image or video. If the body already references an
+			attached file, such as %[1]s![alt](./login.png)%[1]s, that reference is rewritten to point
+			at the uploaded asset. Any attached file the body does not reference is appended
+			to the end of the comment.
+
+			Alt text for an image follows the path after %[1]s#%[1]s, as in
+			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.
+			A reference already in the body keeps the alt text written there. Video renders
+			as a player and has no alt text, so it cannot be given any.
+		`, "`"),
 		Example: heredoc.Doc(`
+			# Add a comment to an issue
 			$ gh issue comment 12 --body "Hi from GitHub CLI"
+
+			# Attach a screenshot, with alt text after "#"
+			$ gh issue comment 12 --attach './login.png#The login error state'
 		`),
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -67,6 +83,9 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 				if opts.EditLast || opts.DeleteLast {
 					fields = append(fields, "comments")
 				}
+				if len(opts.Assets) > 0 {
+					fields = append(fields, "repository")
+				}
 
 				issue, err := issueShared.FindIssueOrPR(httpClient, baseRepo, issueNumber, fields)
 				if err != nil {
@@ -75,7 +94,15 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 
 				return issue, baseRepo, nil
 			}
-			return prShared.CommentablePreRun(cmd, opts)
+			if err := prShared.CommentablePreRun(cmd, opts); err != nil {
+				return err
+			}
+
+			// An asset is not a body, so an edit that only attaches keeps the
+			// comment it is editing.
+			opts.KeepExistingBody = true
+
+			return nil
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			if bodyFile != "" {
@@ -101,6 +128,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 	cmd.Flags().BoolVar(&opts.DeleteLast, "delete-last", false, "Delete the last comment of the current user")
 	cmd.Flags().BoolVar(&opts.DeleteLastConfirmed, "yes", false, "Skip the delete confirmation prompt when --delete-last is provided")
 	cmd.Flags().BoolVar(&opts.CreateIfNone, "create-if-none", false, "Create a new comment if no comments are found. Can be used only with --edit-last")
+	attachments.AddFlag(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -26,13 +29,22 @@ func TestNewCmdComment(t *testing.T) {
 	err := os.WriteFile(tmpFile, []byte("a body from file"), 0600)
 	require.NoError(t, err)
 
+	tmpImage := filepath.Join(t.TempDir(), "login.png")
+	require.NoError(t, os.WriteFile(tmpImage, []byte("the bytes"), 0600))
+
 	tests := []struct {
-		name     string
-		input    string
-		stdin    string
-		output   shared.CommentableOptions
-		wantsErr bool
-		isTTY    bool
+		name             string
+		input            string
+		stdin            string
+		output           shared.CommentableOptions
+		wantsErr         bool
+		wantsErrContains string
+		isTTY            bool
+
+		// Which fields the lookup asks for is decided at construction, so it
+		// can only be proved here.
+		queryWants string
+		queryOmits string
 	}{
 		{
 			name:     "no arguments",
@@ -67,9 +79,10 @@ func TestNewCmdComment(t *testing.T) {
 			name:  "body flag",
 			input: "1 --body test",
 			output: shared.CommentableOptions{
-				Interactive: false,
-				InputType:   shared.InputTypeInline,
-				Body:        "test",
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "test",
+				BodyProvided: true,
 			},
 			isTTY:    true,
 			wantsErr: false,
@@ -79,9 +92,10 @@ func TestNewCmdComment(t *testing.T) {
 			input: "1 --body-file -",
 			stdin: "this is on standard input",
 			output: shared.CommentableOptions{
-				Interactive: false,
-				InputType:   shared.InputTypeInline,
-				Body:        "this is on standard input",
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "this is on standard input",
+				BodyProvided: true,
 			},
 			isTTY:    true,
 			wantsErr: false,
@@ -90,9 +104,10 @@ func TestNewCmdComment(t *testing.T) {
 			name:  "body from file",
 			input: fmt.Sprintf("1 --body-file '%s'", tmpFile),
 			output: shared.CommentableOptions{
-				Interactive: false,
-				InputType:   shared.InputTypeInline,
-				Body:        "a body from file",
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "a body from file",
+				BodyProvided: true,
 			},
 			isTTY:    true,
 			wantsErr: false,
@@ -247,6 +262,99 @@ func TestNewCmdComment(t *testing.T) {
 			isTTY:    true,
 			wantsErr: true,
 		},
+		{
+			name:  "--attach alone is enough of a body to post without prompting",
+			input: fmt.Sprintf("1 --attach '%s'", tmpImage),
+			output: shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeInline,
+				Body:        "",
+			},
+			isTTY:    false,
+			wantsErr: false,
+		},
+		{
+			name:  "--attach with --body keeps the body and records that one was given",
+			input: fmt.Sprintf("1 --body test --attach '%s'", tmpImage),
+			output: shared.CommentableOptions{
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "test",
+				BodyProvided: true,
+			},
+			isTTY:    true,
+			wantsErr: false,
+		},
+		{
+			name:  "--attach with --edit-last is accepted and needs no body",
+			input: fmt.Sprintf("1 --edit-last --attach '%s'", tmpImage),
+			output: shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeInline,
+				Body:        "",
+			},
+			isTTY:    true,
+			wantsErr: false,
+		},
+		{
+			// KeepExistingBody is set either way. BodyProvided is what decides
+			// that this one replaces the comment rather than keeping it.
+			name:  "--attach with --edit-last and --body records the body that replaces the comment",
+			input: fmt.Sprintf("1 --edit-last --body 'a new body' --attach '%s'", tmpImage),
+			output: shared.CommentableOptions{
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "a new body",
+				BodyProvided: true,
+			},
+			isTTY:    true,
+			wantsErr: false,
+		},
+		{
+			name:             "--attach is rejected with --web",
+			input:            fmt.Sprintf("1 --web --attach '%s'", tmpImage),
+			isTTY:            true,
+			wantsErr:         true,
+			wantsErrContains: "`--attach` is not supported when using `--web`",
+		},
+		{
+			name:             "--attach is rejected with --delete-last",
+			input:            fmt.Sprintf("1 --delete-last --attach '%s'", tmpImage),
+			isTTY:            true,
+			wantsErr:         true,
+			wantsErrContains: "`--attach` is not supported when using `--delete-last`",
+		},
+		{
+			// Only the prefix, since the rest comes from the operating system.
+			name:             "--attach rejects a missing file",
+			input:            "1 --attach ./nope.png",
+			isTTY:            true,
+			wantsErr:         true,
+			wantsErrContains: "./nope.png: ",
+		},
+		{
+			name:  "--attach asks the issue lookup for the repository id",
+			input: fmt.Sprintf("1 --attach '%s'", tmpImage),
+			output: shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeInline,
+				Body:        "",
+			},
+			isTTY:      true,
+			queryWants: "databaseId",
+		},
+		{
+			name:  "the issue lookup does not ask for the repository id without --attach",
+			input: "1 --body test",
+			output: shared.CommentableOptions{
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "test",
+				BodyProvided: true,
+			},
+			isTTY:      true,
+			queryOmits: "databaseId",
+		},
 	}
 
 	for _, tt := range tests {
@@ -261,9 +369,39 @@ func TestNewCmdComment(t *testing.T) {
 				_, _ = stdin.WriteString(tt.stdin)
 			}
 
+			checksQuery := tt.queryWants != "" || tt.queryOmits != ""
+
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			var lookupQuery string
+			if checksQuery {
+				reg.Register(
+					httpmock.GraphQL(`query IssueByNumber\b`),
+					func(req *http.Request) (*http.Response, error) {
+						body, err := io.ReadAll(req.Body)
+						require.NoError(t, err)
+						lookupQuery = string(body)
+						return httpmock.StringResponse(`{"data":{"repository":{"hasIssuesEnabled":true,"issue":{
+							"id": "ISSUE-ID",
+							"number": 1,
+							"url": "https://github.com/OWNER/REPO/issues/1",
+							"repository": {
+								"id": "R_kgDOAA",
+								"name": "REPO",
+								"nameWithOwner": "OWNER/REPO",
+								"databaseId": 42
+							}
+						}}}}`)(req)
+					},
+				)
+			}
+
 			f := &cmdutil.Factory{
-				IOStreams: ios,
-				Browser:   &browser.Stub{},
+				IOStreams:  ios,
+				Browser:    &browser.Stub{},
+				HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+				BaseRepo:   func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
+				Config:     testConfig(),
 			}
 
 			argv, err := shlex.Split(tt.input)
@@ -284,6 +422,9 @@ func TestNewCmdComment(t *testing.T) {
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
 				assert.Error(t, err)
+				if tt.wantsErrContains != "" {
+					assert.ErrorContains(t, err, tt.wantsErrContains)
+				}
 				return
 			}
 
@@ -293,6 +434,22 @@ func TestNewCmdComment(t *testing.T) {
 			assert.Equal(t, tt.output.Body, gotOpts.Body)
 			assert.Equal(t, tt.output.DeleteLast, gotOpts.DeleteLast)
 			assert.Equal(t, tt.output.DeleteLastConfirmed, gotOpts.DeleteLastConfirmed)
+			assert.Equal(t, tt.output.BodyProvided, gotOpts.BodyProvided)
+
+			assert.NotNil(t, gotOpts.Config)
+			// Asserted here rather than per row, because no input changes it.
+			assert.True(t, gotOpts.KeepExistingBody)
+
+			if checksQuery {
+				_, _, err := gotOpts.RetrieveCommentable()
+				require.NoError(t, err)
+				if tt.queryWants != "" {
+					assert.Contains(t, lookupQuery, tt.queryWants)
+				}
+				if tt.queryOmits != "" {
+					assert.NotContains(t, lookupQuery, tt.queryOmits)
+				}
+			}
 		})
 	}
 }
@@ -679,6 +836,11 @@ func Test_commentRun(t *testing.T) {
 			assert.Equal(t, tt.stderr, stderr.String())
 		})
 	}
+}
+
+func testConfig() func() (gh.Config, error) {
+	cfg := config.NewMockConfigFromString("hosts:\n  github.com:\n    oauth_token: gho_a_token_that_can_upload\n")
+	return func() (gh.Config, error) { return cfg, nil }
 }
 
 func mockCommentCreate(t *testing.T, reg *httpmock.Registry) {

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -2,6 +2,7 @@ package comment
 
 import (
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/attachments"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -12,6 +13,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	opts := &shared.CommentableOptions{
 		IO:                        f.IOStreams,
 		HttpClient:                f.HttpClient,
+		Config:                    f.Config,
 		EditSurvey:                shared.CommentableEditSurvey(f.Config, f.IOStreams),
 		InteractiveEditSurvey:     shared.CommentableInteractiveEditSurvey(f.Config, f.IOStreams),
 		ConfirmSubmitSurvey:       shared.CommentableConfirmSubmitSurvey(f.Prompter),
@@ -25,14 +27,28 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	cmd := &cobra.Command{
 		Use:   "comment [<number> | <url> | <branch>]",
 		Short: "Add a comment to a pull request",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Add a comment to a GitHub pull request.
 
 			Without the body text supplied through flags, the command will interactively
 			prompt for the comment text.
-		`),
+
+			Use %[1]s--attach%[1]s to upload an image or video. If the body already references an
+			attached file, such as %[1]s![alt](./login.png)%[1]s, that reference is rewritten to point
+			at the uploaded asset. Any attached file the body does not reference is appended
+			to the end of the comment.
+
+			Alt text for an image follows the path after %[1]s#%[1]s, as in
+			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.
+			A reference already in the body keeps the alt text written there. Video renders
+			as a player and has no alt text, so it cannot be given any.
+		`, "`"),
 		Example: heredoc.Doc(`
+			# Add a comment to a pull request
 			$ gh pr comment 13 --body "Hi from GitHub CLI"
+
+			# Attach a screenshot, with alt text after "#"
+			$ gh pr comment 13 --attach './login.png#The login error state'
 		`),
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -49,12 +65,23 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 			}
 			finder := shared.NewFinder(f)
 			opts.RetrieveCommentable = func() (shared.Commentable, ghrepo.Interface, error) {
+				if len(opts.Assets) > 0 {
+					fields = append(fields, "repository")
+				}
 				return finder.Find(shared.FindOptions{
 					Selector: selector,
 					Fields:   fields,
 				})
 			}
-			return shared.CommentablePreRun(cmd, opts)
+			if err := shared.CommentablePreRun(cmd, opts); err != nil {
+				return err
+			}
+
+			// An asset is not a body, so an edit that only attaches keeps the
+			// comment it is editing.
+			opts.KeepExistingBody = true
+
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if bodyFile != "" {
@@ -80,6 +107,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	cmd.Flags().BoolVar(&opts.DeleteLast, "delete-last", false, "Delete the last comment of the current user")
 	cmd.Flags().BoolVar(&opts.DeleteLastConfirmed, "yes", false, "Skip the delete confirmation prompt when --delete-last is provided")
 	cmd.Flags().BoolVar(&opts.CreateIfNone, "create-if-none", false, "Create a new comment if no comments are found. Can be used only with --edit-last")
+	attachments.AddFlag(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -26,13 +29,22 @@ func TestNewCmdComment(t *testing.T) {
 	err := os.WriteFile(tmpFile, []byte("a body from file"), 0600)
 	require.NoError(t, err)
 
+	tmpImage := filepath.Join(t.TempDir(), "login.png")
+	require.NoError(t, os.WriteFile(tmpImage, []byte("the bytes"), 0600))
+
 	tests := []struct {
-		name     string
-		input    string
-		stdin    string
-		output   shared.CommentableOptions
-		wantsErr bool
-		isTTY    bool
+		name             string
+		input            string
+		stdin            string
+		output           shared.CommentableOptions
+		wantsErr         bool
+		wantsErrContains string
+		isTTY            bool
+
+		// Which fields the lookup asks for is decided at construction, so it
+		// can only be proved here.
+		queryWants string
+		queryOmits string
 	}{
 		{
 			name:  "no arguments",
@@ -89,9 +101,10 @@ func TestNewCmdComment(t *testing.T) {
 			name:  "body flag",
 			input: "1 --body test",
 			output: shared.CommentableOptions{
-				Interactive: false,
-				InputType:   shared.InputTypeInline,
-				Body:        "test",
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "test",
+				BodyProvided: true,
 			},
 			isTTY:    true,
 			wantsErr: false,
@@ -101,9 +114,10 @@ func TestNewCmdComment(t *testing.T) {
 			input: "1 --body-file -",
 			stdin: "this is on standard input",
 			output: shared.CommentableOptions{
-				Interactive: false,
-				InputType:   shared.InputTypeInline,
-				Body:        "this is on standard input",
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "this is on standard input",
+				BodyProvided: true,
 			},
 			isTTY:    true,
 			wantsErr: false,
@@ -112,9 +126,10 @@ func TestNewCmdComment(t *testing.T) {
 			name:  "body from file",
 			input: fmt.Sprintf("1 --body-file '%s'", tmpFile),
 			output: shared.CommentableOptions{
-				Interactive: false,
-				InputType:   shared.InputTypeInline,
-				Body:        "a body from file",
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "a body from file",
+				BodyProvided: true,
 			},
 			isTTY:    true,
 			wantsErr: false,
@@ -269,6 +284,99 @@ func TestNewCmdComment(t *testing.T) {
 			isTTY:    true,
 			wantsErr: true,
 		},
+		{
+			name:  "--attach alone is enough of a body to post without prompting",
+			input: fmt.Sprintf("1 --attach '%s'", tmpImage),
+			output: shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeInline,
+				Body:        "",
+			},
+			isTTY:    false,
+			wantsErr: false,
+		},
+		{
+			name:  "--attach with --body keeps the body and records that one was given",
+			input: fmt.Sprintf("1 --body test --attach '%s'", tmpImage),
+			output: shared.CommentableOptions{
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "test",
+				BodyProvided: true,
+			},
+			isTTY:    true,
+			wantsErr: false,
+		},
+		{
+			name:  "--attach with --edit-last is accepted and needs no body",
+			input: fmt.Sprintf("1 --edit-last --attach '%s'", tmpImage),
+			output: shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeInline,
+				Body:        "",
+			},
+			isTTY:    true,
+			wantsErr: false,
+		},
+		{
+			// KeepExistingBody is set either way. BodyProvided is what decides
+			// that this one replaces the comment rather than keeping it.
+			name:  "--attach with --edit-last and --body records the body that replaces the comment",
+			input: fmt.Sprintf("1 --edit-last --body 'a new body' --attach '%s'", tmpImage),
+			output: shared.CommentableOptions{
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "a new body",
+				BodyProvided: true,
+			},
+			isTTY:    true,
+			wantsErr: false,
+		},
+		{
+			name:             "--attach is rejected with --web",
+			input:            fmt.Sprintf("1 --web --attach '%s'", tmpImage),
+			isTTY:            true,
+			wantsErr:         true,
+			wantsErrContains: "`--attach` is not supported when using `--web`",
+		},
+		{
+			name:             "--attach is rejected with --delete-last",
+			input:            fmt.Sprintf("1 --delete-last --attach '%s'", tmpImage),
+			isTTY:            true,
+			wantsErr:         true,
+			wantsErrContains: "`--attach` is not supported when using `--delete-last`",
+		},
+		{
+			// Only the prefix, since the rest comes from the operating system.
+			name:             "--attach rejects a missing file",
+			input:            "1 --attach ./nope.png",
+			isTTY:            true,
+			wantsErr:         true,
+			wantsErrContains: "./nope.png: ",
+		},
+		{
+			name:  "--attach asks the pull request lookup for the repository id",
+			input: fmt.Sprintf("1 --attach '%s'", tmpImage),
+			output: shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeInline,
+				Body:        "",
+			},
+			isTTY:      true,
+			queryWants: "databaseId",
+		},
+		{
+			name:  "the pull request lookup does not ask for the repository id without --attach",
+			input: "1 --body test",
+			output: shared.CommentableOptions{
+				Interactive:  false,
+				InputType:    shared.InputTypeInline,
+				Body:         "test",
+				BodyProvided: true,
+			},
+			isTTY:      true,
+			queryOmits: "databaseId",
+		},
 	}
 
 	for _, tt := range tests {
@@ -283,9 +391,39 @@ func TestNewCmdComment(t *testing.T) {
 				_, _ = stdin.WriteString(tt.stdin)
 			}
 
+			checksQuery := tt.queryWants != "" || tt.queryOmits != ""
+
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			var lookupQuery string
+			if checksQuery {
+				reg.Register(
+					httpmock.GraphQL(`query PullRequestByNumber\b`),
+					func(req *http.Request) (*http.Response, error) {
+						body, err := io.ReadAll(req.Body)
+						require.NoError(t, err)
+						lookupQuery = string(body)
+						return httpmock.StringResponse(`{"data":{"repository":{"pullRequest":{
+							"id": "PR_id",
+							"number": 1,
+							"url": "https://github.com/OWNER/REPO/pull/1",
+							"repository": {
+								"id": "R_kgDOAA",
+								"name": "REPO",
+								"nameWithOwner": "OWNER/REPO",
+								"databaseId": 42
+							}
+						}}}}`)(req)
+					},
+				)
+			}
+
 			f := &cmdutil.Factory{
-				IOStreams: ios,
-				Browser:   &browser.Stub{},
+				IOStreams:  ios,
+				Browser:    &browser.Stub{},
+				HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+				BaseRepo:   func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
+				Config:     testConfig(),
 			}
 
 			argv, err := shlex.Split(tt.input)
@@ -306,6 +444,9 @@ func TestNewCmdComment(t *testing.T) {
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
 				assert.Error(t, err)
+				if tt.wantsErrContains != "" {
+					assert.ErrorContains(t, err, tt.wantsErrContains)
+				}
 				return
 			}
 
@@ -315,11 +456,33 @@ func TestNewCmdComment(t *testing.T) {
 			assert.Equal(t, tt.output.Body, gotOpts.Body)
 			assert.Equal(t, tt.output.DeleteLast, gotOpts.DeleteLast)
 			assert.Equal(t, tt.output.DeleteLastConfirmed, gotOpts.DeleteLastConfirmed)
+			assert.Equal(t, tt.output.BodyProvided, gotOpts.BodyProvided)
+
+			assert.NotNil(t, gotOpts.Config)
+			// Asserted here rather than per row, because no input changes it.
+			assert.True(t, gotOpts.KeepExistingBody)
+
+			if checksQuery {
+				_, _, err := gotOpts.RetrieveCommentable()
+				require.NoError(t, err)
+				if tt.queryWants != "" {
+					assert.Contains(t, lookupQuery, tt.queryWants)
+				}
+				if tt.queryOmits != "" {
+					assert.NotContains(t, lookupQuery, tt.queryOmits)
+				}
+			}
 		})
 	}
 }
 
 func Test_commentRun(t *testing.T) {
+	dir := t.TempDir()
+	shot := filepath.Join(dir, "shot.png")
+	require.NoError(t, os.WriteFile(shot, []byte("shot bytes"), 0600))
+	clip := filepath.Join(dir, "clip.mp4")
+	require.NoError(t, os.WriteFile(clip, []byte("clip bytes"), 0600))
+
 	tests := []struct {
 		name          string
 		input         *shared.CommentableOptions
@@ -329,6 +492,7 @@ func Test_commentRun(t *testing.T) {
 		stdout        string
 		stderr        string
 		wantsErr      bool
+		wantsErrMsg   string
 	}{
 		{
 			name: "creating new comment with interactive editor succeeds",
@@ -341,7 +505,7 @@ func Test_commentRun(t *testing.T) {
 				ConfirmSubmitSurvey:   func() (bool, error) { return true, nil },
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockCommentCreate(t, reg)
+				mockCommentCreate(t, reg, "comment body")
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
 		},
@@ -373,7 +537,7 @@ func Test_commentRun(t *testing.T) {
 				ConfirmSubmitSurvey:   func() (bool, error) { return true, nil },
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockCommentUpdate(t, reg)
+				mockCommentUpdate(t, reg, "comment body")
 			},
 			emptyComments: false,
 			stdout:        "https://github.com/OWNER/REPO/pull/123#issuecomment-111\n",
@@ -392,7 +556,7 @@ func Test_commentRun(t *testing.T) {
 				ConfirmSubmitSurvey:       func() (bool, error) { return true, nil },
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockCommentCreate(t, reg)
+				mockCommentCreate(t, reg, "comment body")
 			},
 			emptyComments: true,
 			stderr:        "No comments found. Creating a new comment.\n",
@@ -448,7 +612,7 @@ func Test_commentRun(t *testing.T) {
 				EditSurvey: func(string) (string, error) { return "comment body", nil },
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockCommentCreate(t, reg)
+				mockCommentCreate(t, reg, "comment body")
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
 		},
@@ -477,7 +641,7 @@ func Test_commentRun(t *testing.T) {
 				EditSurvey: func(string) (string, error) { return "comment body", nil },
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockCommentUpdate(t, reg)
+				mockCommentUpdate(t, reg, "comment body")
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-111\n",
 		},
@@ -494,7 +658,7 @@ func Test_commentRun(t *testing.T) {
 			},
 			emptyComments: true,
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockCommentCreate(t, reg)
+				mockCommentCreate(t, reg, "comment body")
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
 		},
@@ -506,7 +670,7 @@ func Test_commentRun(t *testing.T) {
 				Body:        "comment body",
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockCommentCreate(t, reg)
+				mockCommentCreate(t, reg, "comment body")
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
 		},
@@ -519,7 +683,7 @@ func Test_commentRun(t *testing.T) {
 				EditLast:    true,
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockCommentUpdate(t, reg)
+				mockCommentUpdate(t, reg, "comment body")
 			},
 			emptyComments: false,
 			stdout:        "https://github.com/OWNER/REPO/pull/123#issuecomment-111\n",
@@ -535,7 +699,7 @@ func Test_commentRun(t *testing.T) {
 			},
 			emptyComments: true,
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockCommentCreate(t, reg)
+				mockCommentCreate(t, reg, "comment body")
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
 		},
@@ -659,6 +823,9 @@ func Test_commentRun(t *testing.T) {
 
 		reg := &httpmock.Registry{}
 		defer reg.Verify(t)
+		// An attach run must never look the repository id up on its own.
+		// Excluding the query fails loudly if one is ever reintroduced.
+		reg.Exclude(t, httpmock.GraphQL(`query MapRepositoryNames\b`))
 		if tt.httpStubs != nil {
 			tt.httpStubs(t, reg)
 		}
@@ -690,6 +857,9 @@ func Test_commentRun(t *testing.T) {
 			err := shared.CommentableRun(tt.input)
 			if tt.wantsErr {
 				assert.Error(t, err)
+				if tt.wantsErrMsg != "" {
+					assert.EqualError(t, err, tt.wantsErrMsg)
+				}
 				assert.Equal(t, tt.stderr, stderr.String())
 				return
 			}
@@ -700,7 +870,12 @@ func Test_commentRun(t *testing.T) {
 	}
 }
 
-func mockCommentCreate(t *testing.T, reg *httpmock.Registry) {
+func testConfig() func() (gh.Config, error) {
+	cfg := config.NewMockConfigFromString("hosts:\n  github.com:\n    oauth_token: gho_a_token_that_can_upload\n")
+	return func() (gh.Config, error) { return cfg, nil }
+}
+
+func mockCommentCreate(t *testing.T, reg *httpmock.Registry, wantBody string) {
 	reg.Register(
 		httpmock.GraphQL(`mutation CommentCreate\b`),
 		httpmock.GraphQLMutation(`
@@ -708,12 +883,12 @@ func mockCommentCreate(t *testing.T, reg *httpmock.Registry) {
 			"url": "https://github.com/OWNER/REPO/pull/123#issuecomment-456"
 		} } } } }`,
 			func(inputs map[string]interface{}) {
-				assert.Equal(t, "comment body", inputs["body"])
+				assert.Equal(t, wantBody, inputs["body"])
 			}),
 	)
 }
 
-func mockCommentUpdate(t *testing.T, reg *httpmock.Registry) {
+func mockCommentUpdate(t *testing.T, reg *httpmock.Registry, wantBody string) {
 	reg.Register(
 		httpmock.GraphQL(`mutation CommentUpdate\b`),
 		httpmock.GraphQLMutation(`
@@ -722,7 +897,7 @@ func mockCommentUpdate(t *testing.T, reg *httpmock.Registry) {
 		} } } }`,
 			func(inputs map[string]interface{}) {
 				assert.Equal(t, "id1", inputs["id"])
-				assert.Equal(t, "comment body", inputs["body"])
+				assert.Equal(t, wantBody, inputs["body"])
 			}),
 	)
 }

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -2,12 +2,14 @@ package shared
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/attachments"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
@@ -32,6 +34,8 @@ type Commentable interface {
 	Link() string
 	Identifier() string
 	CurrentUserComments() []api.Comment
+	RepositoryDatabaseID() int64
+	RepositoryViewerPermission() string
 }
 
 type CommentableOptions struct {
@@ -53,16 +57,23 @@ type CommentableOptions struct {
 	CreateIfNone              bool
 	Quiet                     bool
 	Host                      string
+
+	BodyProvided     bool
+	KeepExistingBody bool
+	Assets           []attachments.UserAsset
+	Config           func() (gh.Config, error)
 }
 
 func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {
 	inputFlags := 0
 	if cmd.Flags().Changed("body") {
 		opts.InputType = InputTypeInline
+		opts.BodyProvided = true
 		inputFlags++
 	}
 	if cmd.Flags().Changed("body-file") {
 		opts.InputType = InputTypeInline
+		opts.BodyProvided = true
 		inputFlags++
 	}
 	if web, _ := cmd.Flags().GetBool("web"); web {
@@ -71,6 +82,22 @@ func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {
 	}
 	if editor, _ := cmd.Flags().GetBool("editor"); editor {
 		opts.InputType = InputTypeEditor
+		inputFlags++
+	}
+
+	// Resolved in shared code so a command that registers --attach cannot
+	// forget to.
+	resolved, err := attachments.FromFlagValues(cmd)
+	if err != nil {
+		return err
+	}
+	opts.Assets = resolved
+
+	// An asset is a body input on its own, so `--attach shot.png` alone
+	// posts an image with no text. It is not part of the mutually exclusive
+	// group above, so it only counts when nothing else has.
+	if len(opts.Assets) > 0 && inputFlags == 0 {
+		opts.InputType = InputTypeInline
 		inputFlags++
 	}
 
@@ -115,13 +142,35 @@ func CommentableRun(opts *CommentableOptions) error {
 		return deleteComment(commentable, opts)
 	}
 
+	// Guarded on the assets, because createComment and updateComment return
+	// early on the web path. An unguarded check here would fail a run that
+	// attached nothing.
+	var uploader *attachments.Uploader
+	if len(opts.Assets) > 0 {
+		httpClient, err := opts.HttpClient()
+		if err != nil {
+			return err
+		}
+		cfg, err := opts.Config()
+		if err != nil {
+			return err
+		}
+		// Asked of opts.Host, so the answer is about the host the commentable
+		// was actually fetched from.
+		tokenType := cfg.Authentication().ActiveTokenType(opts.Host)
+		uploader, err = attachments.NewUploader(httpClient, tokenType, opts.Host, commentable.RepositoryDatabaseID(), commentable.RepositoryViewerPermission())
+		if err != nil {
+			return err
+		}
+	}
+
 	// Create new comment, bail before complexities of updating the last comment
 	if !opts.EditLast {
-		return createComment(commentable, opts)
+		return createComment(commentable, opts, uploader)
 	}
 
 	// Update the last comment, handling success or unexpected errors accordingly
-	err = updateComment(commentable, opts)
+	err = updateComment(commentable, opts, uploader)
 	if err == nil {
 		return nil
 	}
@@ -145,10 +194,10 @@ func CommentableRun(opts *CommentableOptions) error {
 		fmt.Fprintln(opts.IO.ErrOut, "No comments found. Creating a new comment.")
 	}
 
-	return createComment(commentable, opts)
+	return createComment(commentable, opts, uploader)
 }
 
-func createComment(commentable Commentable, opts *CommentableOptions) error {
+func createComment(commentable Commentable, opts *CommentableOptions, uploader *attachments.Uploader) error {
 	switch opts.InputType {
 	case InputTypeWeb:
 		openURL := commentable.Link() + "#issuecomment-new"
@@ -185,21 +234,28 @@ func createComment(commentable Commentable, opts *CommentableOptions) error {
 		return err
 	}
 
+	body, write, uploadErr := bodyForWrite(opts, uploader)
+	if !write {
+		return fmt.Errorf("%w\nno comment was posted", uploadErr)
+	}
+
 	apiClient := api.NewClientFromHTTP(httpClient)
-	params := api.CommentCreateInput{Body: opts.Body, SubjectId: commentable.Identifier()}
+	params := api.CommentCreateInput{Body: body, SubjectId: commentable.Identifier()}
 	url, err := api.CommentCreate(apiClient, opts.Host, params)
 	if err != nil {
-		return err
+		// Upload first: an uploaded asset outlives the failed write, and the
+		// user needs to know it exists before hearing the comment did not save.
+		return errors.Join(uploadErr, err)
 	}
 
 	if !opts.Quiet {
 		fmt.Fprintln(opts.IO.Out, url)
 	}
 
-	return nil
+	return uploadErr
 }
 
-func updateComment(commentable Commentable, opts *CommentableOptions) error {
+func updateComment(commentable Commentable, opts *CommentableOptions, uploader *attachments.Uploader) error {
 	comments := commentable.CurrentUserComments()
 	if len(comments) == 0 {
 		return errNoUserComments
@@ -227,6 +283,12 @@ func updateComment(commentable Commentable, opts *CommentableOptions) error {
 			return err
 		}
 		opts.Body = body
+	case InputTypeInline:
+		// An explicit `--body ""` still clears the comment. The editor case
+		// above is seeded with the comment already, so it needs no merge.
+		if opts.KeepExistingBody && !opts.BodyProvided {
+			opts.Body = lastComment.Content()
+		}
 	}
 
 	if opts.Interactive {
@@ -244,18 +306,42 @@ func updateComment(commentable Commentable, opts *CommentableOptions) error {
 		return err
 	}
 
+	body, write, uploadErr := bodyForWrite(opts, uploader)
+	if !write {
+		return fmt.Errorf("%w\nthe comment was not changed", uploadErr)
+	}
+
 	apiClient := api.NewClientFromHTTP(httpClient)
-	params := api.CommentUpdateInput{Body: opts.Body, CommentId: lastComment.Identifier()}
+	params := api.CommentUpdateInput{Body: body, CommentId: lastComment.Identifier()}
 	url, err := api.CommentUpdate(apiClient, opts.Host, params)
 	if err != nil {
-		return err
+		// Upload first, for the same reason as createComment.
+		return errors.Join(uploadErr, err)
 	}
 
 	if !opts.Quiet {
 		fmt.Fprintln(opts.IO.Out, url)
 	}
 
-	return nil
+	return uploadErr
+}
+
+// bodyForWrite uploads the assets and reports whether the body it produced is
+// worth writing. A failed upload that produced nothing writes nothing, since
+// there is nothing to salvage and a comment that promises an attachment it
+// does not have only compounds the failure.
+//
+// Callers must call this after every prompt, since nothing that can prompt or
+// cancel may follow an upload.
+func bodyForWrite(opts *CommentableOptions, uploader *attachments.Uploader) (body string, write bool, err error) {
+	if uploader == nil {
+		return opts.Body, true, nil
+	}
+	body, uploaded, err := uploader.UploadAndAttach(context.Background(), opts.Body, opts.Assets)
+	if err != nil && uploaded == 0 {
+		return "", false, err
+	}
+	return body, true, err
 }
 
 func deleteComment(commentable Commentable, opts *CommentableOptions) error {

--- a/pkg/cmd/pr/shared/commentable_test.go
+++ b/pkg/cmd/pr/shared/commentable_test.go
@@ -1,0 +1,531 @@
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/attachments"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// commentableCmd builds the flag set the comment commands share, so that
+// CommentablePreRun sees the same command shape it does in production.
+// withAttach is false for a command that has not registered --attach, which
+// shared code still has to run on.
+func commentableCmd(t *testing.T, opts *CommentableOptions, withAttach bool, input string) *cobra.Command {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "comment"}
+	cmd.Flags().String("body", "", "")
+	cmd.Flags().String("body-file", "", "")
+	cmd.Flags().Bool("web", false, "")
+	cmd.Flags().Bool("editor", false, "")
+	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "")
+	cmd.Flags().BoolVar(&opts.DeleteLast, "delete-last", false, "")
+	cmd.Flags().BoolVar(&opts.DeleteLastConfirmed, "yes", false, "")
+	cmd.Flags().BoolVar(&opts.CreateIfNone, "create-if-none", false, "")
+	if withAttach {
+		attachments.AddFlag(cmd)
+	}
+
+	argv, err := shlex.Split(input)
+	require.NoError(t, err)
+	require.NoError(t, cmd.Flags().Parse(argv))
+
+	return cmd
+}
+
+func TestCommentablePreRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		withAttach bool
+		canPrompt  bool
+		wantErr    string
+		// wantErrIsNotExist covers an error whose text the operating system
+		// words differently, so the assertion cannot be on the message.
+		wantErrIsNotExist bool
+		wantInputType     InputType
+		wantAssetPaths    []string
+		wantInteractive   bool
+		wantBodyProvided  bool
+	}{
+		{
+			// A change that separates counting the input from resolving it
+			// fails here, since this row asserts both from one run.
+			name:           "attach alone is a body input and is resolved",
+			input:          "--attach ./shot.png",
+			withAttach:     true,
+			wantInputType:  InputTypeInline,
+			wantAssetPaths: []string{"./shot.png"},
+		},
+		{
+			name:             "attach with body is still resolved",
+			input:            "--attach ./shot.png --body 'see below'",
+			withAttach:       true,
+			wantInputType:    InputTypeInline,
+			wantBodyProvided: true,
+			wantAssetPaths:   []string{"./shot.png"},
+		},
+		{
+			name:              "a file that does not exist stops the command",
+			input:             "--attach ./gone.png",
+			withAttach:        true,
+			wantErr:           "./gone.png: ",
+			wantErrIsNotExist: true,
+		},
+		{
+			// `--body ""` clears a comment, and only the flag being present can
+			// say so.
+			name:             "attach with an empty body",
+			input:            "--attach ./shot.png --body ''",
+			withAttach:       true,
+			wantInputType:    InputTypeInline,
+			wantBodyProvided: true,
+			wantAssetPaths:   []string{"./shot.png"}},
+		{
+			name:             "attach with body-file",
+			input:            "--attach ./shot.png --body-file ./body.md",
+			withAttach:       true,
+			wantInputType:    InputTypeInline,
+			wantBodyProvided: true,
+			wantAssetPaths:   []string{"./shot.png"}},
+		{
+			name:           "attach with editor",
+			input:          "--attach ./shot.png --editor",
+			withAttach:     true,
+			wantInputType:  InputTypeEditor,
+			wantAssetPaths: []string{"./shot.png"}},
+		{
+			name:       "attach with web",
+			input:      "--attach ./shot.png --web",
+			withAttach: true,
+			wantErr:    "`--attach` is not supported when using `--web`",
+		},
+		{
+			name:       "a flag conflict is reported before a missing file",
+			input:      "--attach ./gone.png --web",
+			withAttach: true,
+			wantErr:    "`--attach` is not supported when using `--web`",
+		},
+		{
+			name:       "attach with delete-last",
+			input:      "--attach ./shot.png --delete-last --yes",
+			withAttach: true,
+			wantErr:    "`--attach` is not supported when using `--delete-last`",
+		},
+		{
+			// Reaching shared code without registering --attach is a missing
+			// AddFlag call rather than a bad invocation.
+			name:      "attach not registered",
+			input:     "",
+			canPrompt: true,
+			wantErr:   "comment does not register --attach",
+		},
+		{
+			name:    "attach not registered and body passed",
+			input:   "--body 'hello'",
+			wantErr: "comment does not register --attach",
+		},
+		{
+			name:       "attach registered but not passed",
+			input:      "",
+			withAttach: true,
+			wantErr:    "flags required when not running interactively",
+		},
+		{
+			name:       "body and editor still conflict",
+			input:      "--attach ./shot.png --body hello --editor",
+			withAttach: true,
+			wantErr:    "specify only one of `--body`, `--body-file`, `--editor`, or `--web`",
+		},
+		{
+			name:       "delete-last with a body",
+			input:      "--delete-last --yes --body hello",
+			withAttach: true,
+			wantErr:    "should not provide comment body when using `--delete-last`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			require.NoError(t, os.WriteFile("shot.png", []byte("the bytes"), 0o600))
+
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.canPrompt)
+			ios.SetStdoutTTY(tt.canPrompt)
+			ios.SetStderrTTY(tt.canPrompt)
+
+			opts := &CommentableOptions{IO: ios}
+			cmd := commentableCmd(t, opts, tt.withAttach, tt.input)
+
+			err := CommentablePreRun(cmd, opts)
+
+			if tt.wantErr != "" {
+				if tt.wantErrIsNotExist {
+					require.ErrorIs(t, err, fs.ErrNotExist)
+					require.ErrorContains(t, err, tt.wantErr)
+				} else {
+					require.EqualError(t, err, tt.wantErr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantInputType, opts.InputType)
+
+			var assetPaths []string
+			for _, a := range opts.Assets {
+				assetPaths = append(assetPaths, a.Path())
+			}
+			assert.Equal(t, tt.wantAssetPaths, assetPaths)
+			assert.Equal(t, tt.wantInteractive, opts.Interactive)
+			assert.Equal(t, tt.wantBodyProvided, opts.BodyProvided)
+		})
+	}
+}
+
+func TestCommentableRunUploadsAndWritesBodies(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       CommentableOptions
+		attach     []string
+		host       string
+		hostTokens map[string]string
+		// Empty means the default, which can upload.
+		viewerPermission     string
+		repositoryDatabaseID int64
+		uploads              []attachments.UploadStub
+		wantQuery            string
+		writeFails           bool
+		wantBody             string
+		wantStdout           string
+		wantErr              string
+		wantUploads          int
+	}{
+		{
+			name:       "creating with no asset uploads nothing",
+			opts:       CommentableOptions{Body: "just text", InputType: InputTypeInline},
+			wantQuery:  `mutation CommentCreate\b`,
+			wantBody:   "just text",
+			wantStdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
+		},
+		{
+			name:                 "creating uploads the asset and writes the reference",
+			opts:                 CommentableOptions{Body: "see below", InputType: InputTypeInline},
+			attach:               []string{"shot.png"},
+			repositoryDatabaseID: 1234,
+			uploads:              []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			wantQuery:            `mutation CommentCreate\b`,
+			wantBody:             "see below\n\n![shot](https://example.com/1)",
+			wantStdout:           "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
+			wantUploads:          1,
+		},
+		{
+			name:                 "creating writes what uploaded when one upload fails",
+			opts:                 CommentableOptions{Body: "see below", InputType: InputTypeInline},
+			attach:               []string{"a.png", "b.png"},
+			repositoryDatabaseID: 1234,
+			uploads: []attachments.UploadStub{
+				{Name: "a.png", Status: 201, Body: `{"url":"https://example.com/1"}`},
+				{Name: "b.png", Status: 404, Body: `{"message":"Not Found"}`},
+			},
+			wantQuery:   `mutation CommentCreate\b`,
+			wantBody:    "see below\n\n![a](https://example.com/1)",
+			wantStdout:  "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
+			wantErr:     "could not upload ./b.png\nattaching files requires write access to the repository",
+			wantUploads: 2,
+		},
+		{
+			name:                 "creating writes nothing when every upload fails",
+			opts:                 CommentableOptions{Body: "", InputType: InputTypeInline},
+			attach:               []string{"a.png"},
+			repositoryDatabaseID: 1234,
+			uploads:              []attachments.UploadStub{{Name: "a.png", Status: 404, Body: `{"message":"Not Found"}`}},
+			wantErr:              "could not upload ./a.png\nattaching files requires write access to the repository\nno comment was posted",
+			wantUploads:          1,
+		},
+		{
+			name:                 "creating writes nothing when every upload fails and the body has text",
+			opts:                 CommentableOptions{Body: "see below", InputType: InputTypeInline},
+			attach:               []string{"a.png"},
+			repositoryDatabaseID: 1234,
+			uploads:              []attachments.UploadStub{{Name: "a.png", Status: 404, Body: `{"message":"Not Found"}`}},
+			wantErr:              "could not upload ./a.png\nattaching files requires write access to the repository\nno comment was posted",
+			wantUploads:          1,
+		},
+		{
+			name:                 "creating writes nothing when the body fails validation",
+			opts:                 CommentableOptions{Body: "![clip][c]\n\n[c]: ./repro.mp4", InputType: InputTypeInline},
+			attach:               []string{"repro.mp4"},
+			repositoryDatabaseID: 1234,
+			wantErr:              "cannot embed a video as a reference-style image: ./repro.mp4\nno comment was posted",
+		},
+		{
+			name:                 "creating reports the upload and the write when both fail",
+			opts:                 CommentableOptions{Body: "see below", InputType: InputTypeInline},
+			attach:               []string{"a.png", "b.png"},
+			repositoryDatabaseID: 1234,
+			uploads: []attachments.UploadStub{
+				{Name: "a.png", Status: 201, Body: `{"url":"https://example.com/1"}`},
+				{Name: "b.png", Status: 404, Body: `{"message":"Not Found"}`},
+			},
+			wantQuery:   `mutation CommentCreate\b`,
+			writeFails:  true,
+			wantErr:     "could not upload ./b.png\nattaching files requires write access to the repository\nGraphQL: the write failed",
+			wantUploads: 2,
+		},
+		{
+			name: "editing keeps the comment when no body flag was given",
+			opts: CommentableOptions{
+				Body:             "",
+				EditLast:         true,
+				KeepExistingBody: true,
+				InputType:        InputTypeInline,
+			},
+			attach:               []string{"shot.png"},
+			repositoryDatabaseID: 1234,
+			uploads:              []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			wantQuery:            `mutation CommentUpdate\b`,
+			wantBody:             "the original comment\n\n![shot](https://example.com/1)",
+			wantStdout:           "https://github.com/OWNER/REPO/pull/123#issuecomment-111\n",
+			wantUploads:          1,
+		},
+		{
+			name: "editing clears the comment when the body given was empty",
+			opts: CommentableOptions{
+				Body:             "",
+				BodyProvided:     true,
+				EditLast:         true,
+				KeepExistingBody: true,
+				InputType:        InputTypeInline,
+			},
+			attach:               []string{"shot.png"},
+			repositoryDatabaseID: 1234,
+			uploads:              []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			wantQuery:            `mutation CommentUpdate\b`,
+			wantBody:             "![shot](https://example.com/1)",
+			wantStdout:           "https://github.com/OWNER/REPO/pull/123#issuecomment-111\n",
+			wantUploads:          1,
+		},
+		{
+			name: "editing writes nothing when every upload fails and there is no text",
+			opts: CommentableOptions{
+				Body:      "",
+				EditLast:  true,
+				InputType: InputTypeInline,
+			},
+			attach:               []string{"a.png"},
+			repositoryDatabaseID: 1234,
+			uploads:              []attachments.UploadStub{{Name: "a.png", Status: 404, Body: `{"message":"Not Found"}`}},
+			wantErr:              "could not upload ./a.png\nattaching files requires write access to the repository\nthe comment was not changed",
+			wantUploads:          1,
+		},
+		{
+			name: "editing replaces when appending was not asked for",
+			opts: CommentableOptions{
+				Body:      "a replacement",
+				EditLast:  true,
+				InputType: InputTypeInline,
+			},
+			wantQuery:  `mutation CommentUpdate\b`,
+			wantBody:   "a replacement",
+			wantStdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-111\n",
+		},
+		{
+			name: "editing does not append what the editor already carried",
+			opts: CommentableOptions{
+				EditLast:         true,
+				KeepExistingBody: true,
+				InputType:        InputTypeEditor,
+				EditSurvey:       func(initial string) (string, error) { return initial + "\n\nplus an edit", nil },
+			},
+			wantQuery:  `mutation CommentUpdate\b`,
+			wantBody:   "the original comment\n\nplus an edit",
+			wantStdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-111\n",
+		},
+		{
+			// Both write paths return early on the web path, so an unguarded
+			// precondition check would fail this run.
+			name: "the web path on an enterprise host is untouched when nothing is attached",
+			opts: CommentableOptions{
+				InputType:     InputTypeWeb,
+				OpenInBrowser: func(string) error { return nil },
+			},
+			host: "github.example.com",
+		},
+		{
+			name: "a token that cannot upload fails before the editor opens",
+			opts: CommentableOptions{
+				InputType: InputTypeEditor,
+				EditSurvey: func(string) (string, error) {
+					return "", errors.New("the editor must not open")
+				},
+			},
+			attach:               []string{"shot.png"},
+			hostTokens:           map[string]string{"github.com": "ghs_anactionstoken"},
+			repositoryDatabaseID: 1234,
+			wantErr:              "unsupported authentication type",
+		},
+		{
+			// This covers the shared comment path only. A command that builds
+			// its own uploader decides its own token and needs its own row.
+			name:                 "the token comes from the host the commentable was fetched from",
+			opts:                 CommentableOptions{Body: "see below", InputType: InputTypeInline},
+			attach:               []string{"shot.png"},
+			host:                 "acme.ghe.com",
+			hostTokens:           map[string]string{"github.com": "ghs_anactionstoken", "acme.ghe.com": "gho_atenanttoken"},
+			repositoryDatabaseID: 1234,
+			uploads:              []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			wantQuery:            `mutation CommentCreate\b`,
+			wantBody:             "see below\n\n![shot](https://example.com/1)",
+			wantStdout:           "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
+			wantUploads:          1,
+		},
+		{
+			name:                 "read access stops the upload before anything is written",
+			opts:                 CommentableOptions{Body: "see below", InputType: InputTypeInline},
+			attach:               []string{"shot.png"},
+			repositoryDatabaseID: 1234,
+			viewerPermission:     "READ",
+			wantErr:              "attaching files requires write access to the repository",
+		},
+		{
+			// An empty permission means the command forgot to request the
+			// repository field, which is a different fault from too low a
+			// permission, and only one of the two has a remedy.
+			name:                 "an unknown permission stops the upload",
+			opts:                 CommentableOptions{Body: "see below", InputType: InputTypeInline},
+			attach:               []string{"shot.png"},
+			repositoryDatabaseID: 1234,
+			viewerPermission:     "none",
+			wantErr:              "could not determine your permission on the repository",
+		},
+		{
+			name:                 "a missing repository id stops the upload",
+			opts:                 CommentableOptions{Body: "see below", InputType: InputTypeInline},
+			attach:               []string{"shot.png"},
+			repositoryDatabaseID: 0,
+			wantErr:              "could not determine which repository to attach files to",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, stdout, _ := iostreams.Test()
+
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			for _, u := range tt.uploads {
+				attachments.StubUpload(reg, tt.repositoryDatabaseID, u.Name, u.Status, u.Body)
+			}
+
+			var gotBody string
+			if tt.wantQuery != "" && tt.writeFails {
+				reg.Register(
+					httpmock.GraphQL(tt.wantQuery),
+					httpmock.StringResponse(`{"errors":[{"message":"the write failed"}]}`),
+				)
+			} else if tt.wantQuery != "" {
+				response := `{"data":{"addComment":{"commentEdge":{"node":{
+					"url":"https://github.com/OWNER/REPO/pull/123#issuecomment-456"}}}}}`
+				if tt.wantQuery == `mutation CommentUpdate\b` {
+					response = `{"data":{"updateIssueComment":{"issueComment":{
+						"url":"https://github.com/OWNER/REPO/pull/123#issuecomment-111"}}}}`
+				}
+				reg.Register(
+					httpmock.GraphQL(tt.wantQuery),
+					httpmock.GraphQLMutation(response, func(inputs map[string]interface{}) {
+						gotBody, _ = inputs["body"].(string)
+					}),
+				)
+			}
+
+			opts := tt.opts
+			opts.IO = ios
+			opts.HttpClient = func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
+			if len(tt.attach) > 0 {
+				opts.Assets = attachments.NewTestAssets(t, tt.attach...)
+			}
+
+			host := tt.host
+			if host == "" {
+				host = "github.com"
+			}
+
+			hostTokens := tt.hostTokens
+			if hostTokens == nil {
+				hostTokens = map[string]string{host: "gho_atokenthatcanupload"}
+			}
+			opts.Config = func() (gh.Config, error) {
+				return config.NewMockConfigFromString(hostsConfig(hostTokens)), nil
+			}
+			viewerPermission := tt.viewerPermission
+			switch viewerPermission {
+			case "":
+				viewerPermission = "WRITE"
+			case "none":
+				viewerPermission = ""
+			}
+			opts.RetrieveCommentable = func() (Commentable, ghrepo.Interface, error) {
+				return &api.PullRequest{
+					Number: 123,
+					URL:    "https://github.com/OWNER/REPO/pull/123",
+					Repository: &api.PRRepository{
+						DatabaseID:       tt.repositoryDatabaseID,
+						ViewerPermission: viewerPermission,
+					},
+					Comments: api.Comments{Nodes: []api.Comment{{
+						ID:              "id1",
+						Body:            "the original comment",
+						Author:          api.CommentAuthor{Login: "octocat"},
+						URL:             "https://github.com/OWNER/REPO/pull/123#issuecomment-111",
+						ViewerDidAuthor: true,
+					}}},
+				}, ghrepo.NewWithHost("OWNER", "REPO", host), nil
+			}
+
+			err := CommentableRun(&opts)
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantBody, gotBody)
+			assert.Equal(t, tt.wantStdout, stdout.String())
+
+			uploads := 0
+			for _, req := range reg.Requests {
+				if req.URL.Path == "/user-attachments/assets" {
+					uploads++
+				}
+			}
+			assert.Equal(t, tt.wantUploads, uploads, "asset uploads")
+		})
+	}
+}
+
+func hostsConfig(tokens map[string]string) string {
+	var b strings.Builder
+	b.WriteString("hosts:\n")
+	for host, token := range tokens {
+		fmt.Fprintf(&b, "  %s:\n    user: monalisa\n    oauth_token: %s\n", host, token)
+	}
+	return b.String()
+}


### PR DESCRIPTION
Part of the pull request stack tracked in #14186.

### Description

This is the sixth layer of the stack, and the first one where a user can do anything. It adds `--attach` to `gh pr comment` and `gh issue comment`.

The flag uploads a local image or video and puts it in the comment. If the comment body already references the local path, that reference is rewritten to the uploaded asset URL. Otherwise the file is appended at the end. Alt text goes after a `#`, and without it the file name is used.

```
gh issue comment 12 --attach './login.png#The login error state'
```

An image becomes a markdown image embed. A video becomes a bare URL on its own line, which is what GitHub needs to show a player.

An attachment counts as body input on its own, so `--attach` with no `--body` posts a comment that is just the image.

With `--edit-last`, attaching a file keeps the text of the comment being edited and adds the attachment below it. An attachment is not a body, so it does not replace one.

Two combinations are refused. `--attach` with `--web` cannot work, because the browser is doing the writing. `--attach` with `--delete-last` is refused as well.

### How did you test this change?

Both commands were exercised by hand against a private test repository. That covered a comment with an image, a comment with a video, attaching with no body at all, alt text after the hash, a body whose reference was rewritten in place, a fenced code block left untouched, two files in one command, `--edit-last` keeping the existing text, `--edit-last` where the existing comment already named the file so the reference was rewritten instead of appended, and both refused flag combinations.

Everything was run again from a second account with read only access on the repository. Every attach was refused before any upload, and a plain comment with no attachment still worked, so only the attaching is blocked rather than the command.

### Key points

Resolving the flag happens in the shared comment code rather than in each command, so a command that offers the flag cannot forget to check it.

### Notes for reviewers

This is one commit covering two commands, which is worth explaining. Both commands run through the same shared comment code, and that shared code now resolves the flag for whichever command is running. It reports an error if the command has not registered the flag. So the shared change and both registrations have to land together; splitting them would leave whichever command was not wired yet broken.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @BagToad will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
