### PR TITLE
`--attach` stack 7/8: Add the flag to gh pr create and gh pr edit

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cli/cli/v2/api"
 	ghContext "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
+	"github.com/cli/cli/v2/internal/attachments"
 	"github.com/cli/cli/v2/internal/browser"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
@@ -74,6 +75,8 @@ type CreateOptions struct {
 	Template            string
 
 	DryRun bool
+
+	Assets []attachments.UserAsset
 }
 
 // creationRefs is an interface that provides the necessary information for creating a pull request in the API.
@@ -238,6 +241,15 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			request. If the body text mentions %[1]sFixes #123%[1]s or %[1]sCloses #123%[1]s, the referenced issue
 			will automatically get closed when the pull request gets merged.
 
+			Use %[1]s--attach%[1]s to upload an image or video. The attachment is appended to the
+			body. If the body references an attached file, such as %[1]s![alt](./login.png)%[1]s, that
+			reference is rewritten to point at the uploaded asset instead.
+
+			Alt text for an image follows the path after %[1]s#%[1]s, as in
+			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.
+			A reference already in the body keeps the alt text written there. Video renders
+			as a player and has no alt text, so it cannot be given any.
+
 			By default, users with write access to the base repository can push new commits to the
 			head branch of the pull request. Disable this with %[1]s--no-maintainer-edit%[1]s.
 
@@ -250,6 +262,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			$ gh pr create --project "Roadmap"
 			$ gh pr create --base develop --head monalisa:feature
 			$ gh pr create --template "pull_request_template.md"
+			$ gh pr create --attach './login.png#The login error state'
 		`),
 		Args:    cmdutil.NoArgsQuoteReminder,
 		Aliases: []string{"new"},
@@ -331,6 +344,11 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("`--dry-run` is not supported when using `--web`")
 			}
 
+			opts.Assets, err = attachments.FromFlagValues(cmd)
+			if err != nil {
+				return err
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -359,6 +377,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.StringVar(&opts.RecoverFile, "recover", "", "Recover input from a failed run of create")
 	fl.StringVarP(&opts.Template, "template", "T", "", "Template `file` to use as starting body text")
 	fl.BoolVar(&opts.DryRun, "dry-run", false, "Print details instead of creating the PR. May still push git changes.")
+	attachments.AddFlag(cmd)
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "base", "head")
 
@@ -482,6 +501,23 @@ func createRun(opts *CreateOptions) error {
 			ctx.PRRefs.QualifiedHeadRef(), ctx.PRRefs.BaseRef(), existingPR.URL)
 	}
 
+	// Built before the prompts, so a run that cannot upload stops early.
+	var uploader *attachments.Uploader
+	if len(opts.Assets) > 0 {
+		cfg, err := opts.Config()
+		if err != nil {
+			return err
+		}
+		baseRepo := ctx.PRRefs.BaseRepo()
+		host := baseRepo.RepoHost()
+		tokenType := cfg.Authentication().ActiveTokenType(host)
+
+		uploader, err = attachments.NewUploader(httpClient, tokenType, host, baseRepo.DatabaseID, baseRepo.ViewerPermission)
+		if err != nil {
+			return err
+		}
+	}
+
 	message := "\nCreating pull request for %s into %s in %s\n\n"
 	if state.Draft {
 		message = "\nCreating draft pull request for %s into %s in %s\n\n"
@@ -504,7 +540,7 @@ func createRun(opts *CreateOptions) error {
 		if err != nil {
 			return err
 		}
-		return submitPR(*opts, *ctx, *state, projectsV1Support)
+		return submitPR(*opts, *ctx, *state, projectsV1Support, uploader)
 	}
 
 	if opts.RecoverFile != "" {
@@ -586,7 +622,8 @@ func createRun(opts *CreateOptions) error {
 			return err
 		}
 
-		allowPreview := !state.HasMetadata() && shared.ValidURL(openURL) && !opts.DryRun
+		// Preview opens the browser, which cannot carry an upload.
+		allowPreview := !state.HasMetadata() && shared.ValidURL(openURL) && !opts.DryRun && len(opts.Assets) == 0
 		allowMetadata := ctx.PRRefs.BaseRepo().ViewerCanTriage()
 		action, err = shared.ConfirmPRSubmission(opts.Prompter, allowPreview, allowMetadata, state.Draft)
 		if err != nil {
@@ -605,7 +642,7 @@ func createRun(opts *CreateOptions) error {
 				return err
 			}
 
-			action, err = shared.ConfirmPRSubmission(opts.Prompter, !state.HasMetadata() && !opts.DryRun, false, state.Draft)
+			action, err = shared.ConfirmPRSubmission(opts.Prompter, !state.HasMetadata() && !opts.DryRun && len(opts.Assets) == 0, false, state.Draft)
 			if err != nil {
 				return err
 			}
@@ -629,11 +666,11 @@ func createRun(opts *CreateOptions) error {
 
 	if action == shared.SubmitDraftAction {
 		state.Draft = true
-		return submitPR(*opts, *ctx, *state, projectsV1Support)
+		return submitPR(*opts, *ctx, *state, projectsV1Support, uploader)
 	}
 
 	if action == shared.SubmitAction {
-		return submitPR(*opts, *ctx, *state, projectsV1Support)
+		return submitPR(*opts, *ctx, *state, projectsV1Support, uploader)
 	}
 
 	err = errors.New("expected to cancel, preview, or submit")
@@ -1033,7 +1070,7 @@ func getRemotes(opts *CreateOptions) (ghContext.Remotes, error) {
 	return remotes, nil
 }
 
-func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataState, projectV1Support gh.ProjectsV1Support) error {
+func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataState, projectV1Support gh.ProjectsV1Support, uploader *attachments.Uploader) error {
 	client := ctx.Client
 
 	params := map[string]interface{}{
@@ -1062,6 +1099,20 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 		}
 	}
 
+	var uploadErr error
+	if uploader != nil {
+		body, uploaded, err := uploader.UploadAndAttach(context.Background(), state.Body, opts.Assets)
+		// With nothing uploaded, a body that lost the files it was written
+		// around is not what the caller asked to create. The branch is already
+		// pushed by now, so the message says what was not created rather than
+		// claiming the run had no effect.
+		if err != nil && uploaded == 0 {
+			return fmt.Errorf("%w\nno pull request was created", err)
+		}
+		uploadErr = err
+		params["body"] = body
+	}
+
 	opts.IO.StartProgressIndicator()
 	pr, err := api.CreatePullRequest(client, ctx.PRRefs.BaseRepo(), params)
 	opts.IO.StopProgressIndicator()
@@ -1070,11 +1121,16 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 	}
 	if err != nil {
 		if pr != nil {
-			return fmt.Errorf("pull request update failed: %w", err)
+			err = fmt.Errorf("pull request update failed: %w", err)
+		} else {
+			err = fmt.Errorf("pull request create failed: %w", err)
 		}
-		return fmt.Errorf("pull request create failed: %w", err)
+		// A failed upload and a failed create have different remedies, and a
+		// failed create leaves the uploaded assets referenced by nothing, so
+		// that error reads first.
+		return errors.Join(uploadErr, err)
 	}
-	return nil
+	return uploadErr
 }
 
 func renderPullRequestPlain(w io.Writer, params map[string]interface{}, state *shared.IssueMetadataState) error {

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -2,10 +2,13 @@ package create
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -13,6 +16,7 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
+	"github.com/cli/cli/v2/internal/attachments"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
@@ -35,14 +39,22 @@ func TestNewCmdCreate(t *testing.T) {
 	err := os.WriteFile(tmpFile, []byte("a body from file"), 0600)
 	require.NoError(t, err)
 
+	tmpImage := filepath.Join(t.TempDir(), "shot.png")
+	require.NoError(t, os.WriteFile(tmpImage, []byte("the bytes"), 0600))
+
 	tests := []struct {
-		name      string
-		tty       bool
-		stdin     string
-		cli       string
-		config    string
-		wantsErr  bool
-		wantsOpts CreateOptions
+		name        string
+		tty         bool
+		stdin       string
+		cli         string
+		config      string
+		wantsErr    bool
+		wantsErrMsg string
+		// wantErrIsNotExist covers an error whose text the operating system
+		// words differently, so the assertion cannot be on the message.
+		wantErrIsNotExist bool
+		wantAssetPaths    []string
+		wantsOpts         CreateOptions
 	}{
 		{
 			name:     "empty non-tty",
@@ -270,6 +282,37 @@ func TestNewCmdCreate(t *testing.T) {
 				MaintainerCanModify: true,
 			},
 		},
+		{
+			name: "attach resolves the file it names",
+			cli:  fmt.Sprintf("--title mytitle --body mybody --attach '%s'", tmpImage),
+			wantsOpts: CreateOptions{
+				Title:               "mytitle",
+				TitleProvided:       true,
+				Body:                "mybody",
+				BodyProvided:        true,
+				MaintainerCanModify: true,
+			},
+			wantAssetPaths: []string{tmpImage},
+		},
+		{
+			name:              "attach rejects a missing file",
+			cli:               "--title mytitle --body mybody --attach ./nope.png",
+			wantsErr:          true,
+			wantsErrMsg:       "./nope.png: ",
+			wantErrIsNotExist: true,
+		},
+		{
+			name:        "attach is not supported with web",
+			cli:         fmt.Sprintf("--web --attach '%s'", tmpImage),
+			wantsErr:    true,
+			wantsErrMsg: "`--attach` is not supported when using `--web`",
+		},
+		{
+			name:        "attach is not supported with dry-run",
+			cli:         fmt.Sprintf("--title mytitle --body mybody --dry-run --attach '%s'", tmpImage),
+			wantsErr:    true,
+			wantsErrMsg: "`--attach` is not supported when using `--dry-run`",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -304,7 +347,16 @@ func TestNewCmdCreate(t *testing.T) {
 			cmd.SetErr(stderr)
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
-				assert.Error(t, err)
+				if tt.wantsErrMsg != "" {
+					if tt.wantErrIsNotExist {
+						require.ErrorIs(t, err, fs.ErrNotExist)
+						require.ErrorContains(t, err, tt.wantsErrMsg)
+					} else {
+						require.EqualError(t, err, tt.wantsErrMsg)
+					}
+				} else {
+					require.Error(t, err)
+				}
 				return
 			} else {
 				require.NoError(t, err)
@@ -326,6 +378,12 @@ func TestNewCmdCreate(t *testing.T) {
 			assert.Equal(t, tt.wantsOpts.BaseBranch, opts.BaseBranch)
 			assert.Equal(t, tt.wantsOpts.HeadBranch, opts.HeadBranch)
 			assert.Equal(t, tt.wantsOpts.Template, opts.Template)
+
+			var assetPaths []string
+			for _, a := range opts.Assets {
+				assetPaths = append(assetPaths, a.Path())
+			}
+			assert.Equal(t, tt.wantAssetPaths, assetPaths)
 		})
 	}
 }
@@ -344,6 +402,8 @@ func Test_createRun(t *testing.T) {
 		wantErr            string
 		tty                bool
 		customBranchConfig bool
+		// Defaults to WRITE, which can upload.
+		repoPermission string
 	}{
 		{
 			name: "nontty web",
@@ -1560,12 +1620,357 @@ func Test_createRun(t *testing.T) {
 			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
 			expectedErrOut: "",
 		},
+		{
+			name: "the preview action is not offered when a file is attached",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "shot.png")
+				opts.Config = uploadTokenConfig("gho_atokenthatcanupload")
+				return func() {}
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
+				cs.Register(`git rev-parse --show-toplevel`, 0, "")
+			},
+			promptStubs: func(pm *prompter.PrompterMock) {
+				pm.InputFunc = func(p, d string) (string, error) {
+					if p == "Title (required)" {
+						return "my title", nil
+					}
+					return "", prompter.NoSuchPromptErr(p)
+				}
+				pm.MarkdownEditorFunc = func(p, d string, ba bool) (string, error) {
+					if p == "Body" {
+						return "my body", nil
+					}
+					return "", prompter.NoSuchPromptErr(p)
+				}
+				pm.SelectFunc = func(p, _ string, options []string) (int, error) {
+					if p != "What's next?" {
+						return -1, prompter.NoSuchPromptErr(p)
+					}
+					if slices.Contains(options, "Continue in browser") {
+						return -1, errors.New("the menu offered the browser")
+					}
+					return prompter.IndexFor(options, "Submit")
+				}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`query PullRequestTemplates\b`),
+					httpmock.StringResponse(`{ "data": { "repository": { "pullRequestTemplates": [] } } }`))
+				attachments.StubUpload(reg, 1234, "shot.png", 201, `{"url": "https://github.com/user-attachments/assets/ASSET"}`)
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createPullRequest": { "pullRequest": {
+							"URL": "https://github.com/OWNER/REPO/pull/12"
+						} } } }`,
+						func(input map[string]interface{}) {}))
+			},
+			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
+			expectedErrOut: "\nCreating pull request for feature into master in OWNER/REPO\n\n",
+		},
+		{
+			// The second confirmation builds its own preview condition.
+			name: "the preview action is not offered after the metadata survey when a file is attached",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "shot.png")
+				opts.Config = uploadTokenConfig("gho_atokenthatcanupload")
+				return func() {}
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
+				cs.Register(`git rev-parse --show-toplevel`, 0, "")
+			},
+			promptStubs: func(pm *prompter.PrompterMock) {
+				askedForMetadata := false
+				pm.InputFunc = func(p, d string) (string, error) {
+					if p == "Title (required)" {
+						return "my title", nil
+					}
+					return "", prompter.NoSuchPromptErr(p)
+				}
+				pm.MarkdownEditorFunc = func(p, d string, ba bool) (string, error) {
+					if p == "Body" {
+						return "my body", nil
+					}
+					return "", prompter.NoSuchPromptErr(p)
+				}
+				pm.MultiSelectFunc = func(p string, _, _ []string) ([]int, error) {
+					if p == "What would you like to add?" {
+						return []int{}, nil
+					}
+					return nil, prompter.NoSuchPromptErr(p)
+				}
+				pm.SelectFunc = func(p, _ string, options []string) (int, error) {
+					if p != "What's next?" {
+						return -1, prompter.NoSuchPromptErr(p)
+					}
+					if !askedForMetadata {
+						askedForMetadata = true
+						return prompter.IndexFor(options, "Add metadata")
+					}
+					if slices.Contains(options, "Continue in browser") {
+						return -1, errors.New("the menu offered the browser")
+					}
+					return prompter.IndexFor(options, "Submit")
+				}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`query PullRequestTemplates\b`),
+					httpmock.StringResponse(`{ "data": { "repository": { "pullRequestTemplates": [] } } }`))
+				attachments.StubUpload(reg, 1234, "shot.png", 201, `{"url": "https://github.com/user-attachments/assets/ASSET"}`)
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createPullRequest": { "pullRequest": {
+							"URL": "https://github.com/OWNER/REPO/pull/12"
+						} } } }`,
+						func(input map[string]interface{}) {}))
+			},
+			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
+			expectedErrOut: "\nCreating pull request for feature into master in OWNER/REPO\n\n",
+		},
+		{
+			name: "attaching uploads the file and creates the pull request with the rewritten body",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "before ![the shot](./shot.png) after"
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "shot.png")
+				opts.Config = uploadTokenConfig("gho_atokenthatcanupload")
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				attachments.StubUpload(reg, 1234, "shot.png", 201, `{"url": "https://github.com/user-attachments/assets/ASSET"}`)
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createPullRequest": { "pullRequest": {
+							"URL": "https://github.com/OWNER/REPO/pull/12"
+						} } } }`,
+						func(input map[string]interface{}) {
+							assert.Equal(t, "before ![the shot](https://github.com/user-attachments/assets/ASSET) after", input["body"])
+						}))
+			},
+			expectedOut: "https://github.com/OWNER/REPO/pull/12\n",
+		},
+		{
+
+			name: "the token comes from the host the base repository resolves to",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "my body"
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "shot.png")
+				// github.com must keep a token class that cannot upload: make
+				// both usable and this row passes against a command that reads
+				// the wrong host.
+				opts.Config = uploadTokenConfigForHosts(map[string]string{
+					"github.com":   "ghs_anactionstoken",
+					"acme.ghe.com": "gho_atenanttoken",
+				})
+				opts.Remotes = func() (context.Remotes, error) {
+					return context.Remotes{
+						{
+							Remote: &git.Remote{Name: "origin", Resolved: "base"},
+							Repo:   ghrepo.NewWithHost("OWNER", "REPO", "acme.ghe.com"),
+						},
+					}, nil
+				}
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				attachments.StubUploadToHost(t, reg, "uploads.acme.ghe.com", 1234, "shot.png", 201, `{"url": "https://acme.ghe.com/user-attachments/assets/ASSET"}`)
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createPullRequest": { "pullRequest": {
+							"URL": "https://acme.ghe.com/OWNER/REPO/pull/12"
+						} } } }`,
+						func(input map[string]interface{}) {
+							assert.Equal(t, "my body\n\n![shot](https://acme.ghe.com/user-attachments/assets/ASSET)", input["body"])
+						}))
+			},
+			expectedOut: "https://acme.ghe.com/OWNER/REPO/pull/12\n",
+		},
+		{
+			name: "a token that cannot upload stops the command before it prompts",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "shot.png")
+				opts.Config = uploadTokenConfig("not_a_token_that_can_upload")
+				return func() {}
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
+			},
+			promptStubs: func(pm *prompter.PrompterMock) {
+				pm.InputFunc = func(p, d string) (string, error) {
+					return "", errors.New("the command prompted before it checked the token")
+				}
+				pm.SelectFunc = func(p, _ string, options []string) (int, error) {
+					return -1, errors.New("the command prompted before it checked the token")
+				}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Exclude(t, httpmock.REST("POST", "user-attachments/assets"))
+				reg.Exclude(t, httpmock.GraphQL(`mutation PullRequestCreate\b`))
+			},
+			wantErr: "unsupported authentication type",
+		},
+		{
+			name: "an upload that partly succeeded still creates the pull request and reports the failure",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "my body"
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "good.png", "bad.png")
+				opts.Config = uploadTokenConfig("gho_atokenthatcanupload")
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				attachments.StubUpload(reg, 1234, "good.png", 201, `{"url": "https://github.com/user-attachments/assets/ASSET"}`)
+				attachments.StubUpload(reg, 1234, "bad.png", 404, `{}`)
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createPullRequest": { "pullRequest": {
+							"URL": "https://github.com/OWNER/REPO/pull/12"
+						} } } }`,
+						func(input map[string]interface{}) {
+							assert.Equal(t, "my body\n\n![good](https://github.com/user-attachments/assets/ASSET)", input["body"])
+						}))
+			},
+			expectedOut: "https://github.com/OWNER/REPO/pull/12\n",
+			wantErr:     "could not upload ./bad.png\nattaching files requires write access to the repository",
+		},
+		{
+			name: "the only upload failing creates no pull request",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "See the screenshot below"
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "shot.png")
+				opts.Config = uploadTokenConfig("gho_atokenthatcanupload")
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				attachments.StubUpload(reg, 1234, "shot.png", 404, `{}`)
+				reg.Exclude(t, httpmock.GraphQL(`mutation PullRequestCreate\b`))
+			},
+			wantErr: "could not upload ./shot.png\nattaching files requires write access to the repository\nno pull request was created",
+		},
+		{
+			name: "a body the attachment cannot be written into creates no pull request",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "![clip][ref]\n\n[ref]: ./clip.mp4"
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "clip.mp4")
+				opts.Config = uploadTokenConfig("gho_atokenthatcanupload")
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Exclude(t, httpmock.REST("POST", "user-attachments/assets"))
+				reg.Exclude(t, httpmock.GraphQL(`mutation PullRequestCreate\b`))
+			},
+			wantErr: "cannot embed a video as a reference-style image: ./clip.mp4\nno pull request was created",
+		},
+		{
+			name: "a create that fails after an upload failed reports both",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "my body"
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "good.png", "bad.png")
+				opts.Config = uploadTokenConfig("gho_atokenthatcanupload")
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				attachments.StubUpload(reg, 1234, "good.png", 201, `{"url": "https://github.com/user-attachments/assets/ASSET"}`)
+				attachments.StubUpload(reg, 1234, "bad.png", 404, `{}`)
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.StringResponse(`{"errors":[{"message":"the create failed"}]}`))
+			},
+			wantErr: "could not upload ./bad.png\nattaching files requires write access to the repository\npull request create failed: GraphQL: the create failed",
+		},
+		{
+			name: "a permission that cannot upload stops the command before it prompts",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "shot.png")
+				opts.Config = uploadTokenConfig("gho_atokenthatcanupload")
+				return func() {}
+			},
+			repoPermission: "READ",
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
+			},
+			promptStubs: func(pm *prompter.PrompterMock) {
+				pm.InputFunc = func(p, d string) (string, error) {
+					return "", errors.New("the command prompted before it checked the permission")
+				}
+				pm.SelectFunc = func(p, _ string, options []string) (int, error) {
+					return -1, errors.New("the command prompted before it checked the permission")
+				}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Exclude(t, httpmock.REST("POST", "user-attachments/assets"))
+				reg.Exclude(t, httpmock.GraphQL(`mutation PullRequestCreate\b`))
+			},
+			wantErr: "attaching files requires write access to the repository",
+		},
+		{
+			// Triage is the highest permission the endpoint still refuses.
+			name: "a triage permission cannot upload",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "my body"
+				opts.HeadBranch = "feature"
+				opts.Assets = attachments.NewTestAssets(t, "shot.png")
+				opts.Config = uploadTokenConfig("gho_atokenthatcanupload")
+				return func() {}
+			},
+			repoPermission: "TRIAGE",
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Exclude(t, httpmock.REST("POST", "user-attachments/assets"))
+				reg.Exclude(t, httpmock.GraphQL(`mutation PullRequestCreate\b`))
+			},
+			wantErr: "attaching files requires write access to the repository",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			branch := "feature"
 			reg := &httpmock.Registry{}
-			reg.StubRepoInfoResponse("OWNER", "REPO", "master")
+			repoPermission := tt.repoPermission
+			if repoPermission == "" {
+				repoPermission = "WRITE"
+			}
+			reg.StubRepoInfoResponseWithPermission("OWNER", "REPO", "master", repoPermission)
 			defer reg.Verify(t)
 			if tt.httpStubs != nil {
 				tt.httpStubs(reg, t)
@@ -1645,6 +2050,9 @@ func Test_createRun(t *testing.T) {
 			}
 			if tt.wantErr != "" {
 				assert.EqualError(t, err, tt.wantErr)
+				if tt.expectedOut != "" {
+					assert.Equal(t, tt.expectedOut, output.String())
+				}
 			} else {
 				assert.NoError(t, err)
 				if tt.expectedOut != "" {
@@ -1657,6 +2065,26 @@ func Test_createRun(t *testing.T) {
 				assert.Equal(t, tt.expectedBrowse, output.BrowsedURL)
 			}
 		})
+	}
+}
+
+// The token's prefix decides whether the uploader accepts it, so a row varies
+// the prefix.
+func uploadTokenConfig(token string) func() (gh.Config, error) {
+	return uploadTokenConfigForHosts(map[string]string{"github.com": token})
+}
+
+// A row can give the default host a different token from the host its base
+// repository resolves to.
+func uploadTokenConfigForHosts(tokens map[string]string) func() (gh.Config, error) {
+	var b strings.Builder
+	b.WriteString("hosts:\n")
+	for host, token := range tokens {
+		fmt.Fprintf(&b, "  %s:\n    user: monalisa\n    oauth_token: %s\n", host, token)
+	}
+
+	return func() (gh.Config, error) {
+		return config.NewMockConfigFromString(b.String()), nil
 	}
 }
 

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -1,6 +1,8 @@
 package edit
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -9,6 +11,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/attachments"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -36,6 +39,9 @@ type EditOptions struct {
 	SelectorArg string
 	Interactive bool
 
+	Assets []attachments.UserAsset
+	Config func() (gh.Config, error)
+
 	shared.Editable
 }
 
@@ -43,6 +49,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	opts := &EditOptions{
 		IO:              f.IOStreams,
 		HttpClient:      f.HttpClient,
+		Config:          f.Config,
 		Surveyor:        surveyor{P: f.Prompter},
 		Fetcher:         fetcher{},
 		EditorRetriever: editorRetriever{config: f.Config},
@@ -64,6 +71,16 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			Editing a pull request's projects requires authorization with the %[1]sproject%[1]s scope.
 			To authorize, run %[1]sgh auth refresh -s project%[1]s.
 
+			Use %[1]s--attach%[1]s to upload an image or video. Without a body flag the pull
+			request keeps the body it already has and the attachment is appended to it. If the
+			body references an attached file, such as %[1]s![alt](./login.png)%[1]s, that reference
+			is rewritten to point at the uploaded asset instead.
+
+			Alt text for an image follows the path after %[1]s#%[1]s, as in
+			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.
+			A reference already in the body keeps the alt text written there. Video renders
+			as a player and has no alt text, so it cannot be given any.
+
 			The %[1]s--add-assignee%[1]s and %[1]s--remove-assignee%[1]s flags both support
 			the following special values:
 			- %[1]s@me%[1]s: assign or unassign yourself
@@ -79,6 +96,9 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 
 			# Use a file as the body
 			$ gh pr edit 23 --body-file body.txt
+
+			# Append a screenshot to the body, with alt text after "#"
+			$ gh pr edit 23 --attach './login.png#The login error state'
 
 			# Manage labels
 			$ gh pr edit 23 --add-label "bug,help wanted" --remove-label "core"
@@ -189,7 +209,13 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 				// see the `Editable.MilestoneId` method.
 			}
 
-			if !opts.Editable.Dirty() {
+			resolved, err := attachments.FromFlagValues(cmd)
+			if err != nil {
+				return err
+			}
+			opts.Assets = resolved
+
+			if !opts.Editable.Dirty() && len(opts.Assets) == 0 {
 				opts.Interactive = true
 			}
 
@@ -219,6 +245,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd.Flags().StringSliceVar(&opts.Editable.Projects.Remove, "remove-project", nil, "Remove the pull request from projects by `title`")
 	cmd.Flags().StringVarP(&opts.Editable.Milestone.Value, "milestone", "m", "", "Edit the milestone the pull request belongs to by `name`")
 	cmd.Flags().BoolVar(&removeMilestone, "remove-milestone", false, "Remove the milestone association from the pull request")
+	attachments.AddFlag(cmd)
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "base")
 
@@ -265,6 +292,10 @@ func editRun(opts *EditOptions) error {
 		Detector: opts.Detector,
 	}
 
+	if len(opts.Assets) > 0 {
+		findOptions.Fields = append(findOptions.Fields, "repository")
+	}
+
 	issueFeatures, err := opts.Detector.IssueFeatures()
 	if err != nil {
 		return err
@@ -280,6 +311,23 @@ func editRun(opts *EditOptions) error {
 	pr, repo, err := opts.Finder.Find(findOptions)
 	if err != nil {
 		return err
+	}
+
+	// Built before the prompts, so a run that cannot upload stops early.
+	var uploader *attachments.Uploader
+	if len(opts.Assets) > 0 {
+		cfg, err := opts.Config()
+		if err != nil {
+			return err
+		}
+		// A URL selector names its own host, so this can differ from the
+		// default host.
+		host := repo.RepoHost()
+		tokenType := cfg.Authentication().ActiveTokenType(host)
+		uploader, err = attachments.NewUploader(httpClient, tokenType, host, pr.RepositoryDatabaseID(), pr.RepositoryViewerPermission())
+		if err != nil {
+			return err
+		}
 	}
 
 	editable := opts.Editable
@@ -353,16 +401,45 @@ func editRun(opts *EditOptions) error {
 		}
 	}
 
+	var uploadErr error
+	if uploader != nil {
+		// A body the caller supplied replaces the pull request's, including an
+		// empty one.
+		body := editable.Body.Value
+		if !editable.Body.Edited {
+			body = editable.Body.Default
+		}
+
+		// Nothing that can prompt or cancel may follow this.
+		var uploaded int
+		body, uploaded, uploadErr = uploader.UploadAndAttach(context.Background(), body, opts.Assets)
+
+		// With nothing uploaded, even a body the caller typed goes unwritten:
+		// its references are still local paths, which render broken. The other
+		// fields are innocent of the upload, so they proceed either way.
+		editable.Body.Edited = uploaded > 0
+		if uploaded > 0 {
+			editable.Body.Value = body
+		}
+
+		// The URL below is this command's success signal, so a run that writes
+		// nothing at all must not print it.
+		if !editable.Dirty() {
+			return errors.Join(uploadErr, errors.New("the pull request was not changed"))
+		}
+	}
+
 	opts.IO.StartProgressIndicator()
 	err = updatePullRequest(httpClient, repo, pr.ID, pr.Number, editable)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
-		return err
+		// A failed write does not undo an upload, so both are reported.
+		return errors.Join(uploadErr, err)
 	}
 
 	fmt.Fprintln(opts.IO.Out, pr.URL)
 
-	return nil
+	return uploadErr
 }
 
 // reviewerSearchFunc is intended to be an arg for MultiSelectWithSearch

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -2,13 +2,17 @@ package edit
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/attachments"
+	"github.com/cli/cli/v2/internal/config"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -26,11 +30,15 @@ func TestNewCmdEdit(t *testing.T) {
 	err := os.WriteFile(tmpFile, []byte("a body from file"), 0600)
 	require.NoError(t, err)
 
+	tmpImage := filepath.Join(t.TempDir(), "shot.png")
+	require.NoError(t, os.WriteFile(tmpImage, []byte("the bytes"), 0600))
+
 	tests := []struct {
 		name             string
 		input            string
 		stdin            string
 		output           EditOptions
+		wantAssetPaths   []string
 		expectedBaseRepo ghrepo.Interface
 		wantsErr         bool
 	}{
@@ -297,6 +305,35 @@ func TestNewCmdEdit(t *testing.T) {
 			input:    "23 --milestone foo --remove-milestone",
 			wantsErr: true,
 		},
+		{
+			name:  "attach alone runs without prompting",
+			input: fmt.Sprintf("23 --attach '%s'", tmpImage),
+			output: EditOptions{
+				SelectorArg: "23",
+				Interactive: false,
+			},
+			wantAssetPaths: []string{tmpImage},
+		},
+		{
+			name:  "attach with body records the body that replaces the old one",
+			input: fmt.Sprintf("23 --body 'a new body' --attach '%s'", tmpImage),
+			output: EditOptions{
+				SelectorArg: "23",
+				Interactive: false,
+				Editable: shared.Editable{
+					Body: shared.EditableString{
+						Value:  "a new body",
+						Edited: true,
+					},
+				},
+			},
+			wantAssetPaths: []string{tmpImage},
+		},
+		{
+			name:     "attach rejects a missing file",
+			input:    "23 --attach ./nope.png",
+			wantsErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -338,6 +375,13 @@ func TestNewCmdEdit(t *testing.T) {
 			assert.Equal(t, tt.output.SelectorArg, gotOpts.SelectorArg)
 			assert.Equal(t, tt.output.Interactive, gotOpts.Interactive)
 			assert.Equal(t, tt.output.Editable, gotOpts.Editable)
+
+			var assetPaths []string
+			for _, a := range gotOpts.Assets {
+				assetPaths = append(assetPaths, a.Path())
+			}
+			assert.Equal(t, tt.wantAssetPaths, assetPaths)
+
 			if tt.expectedBaseRepo != nil {
 				baseRepo, err := gotOpts.BaseRepo()
 				require.NoError(t, err)
@@ -356,8 +400,19 @@ func Test_editRun(t *testing.T) {
 		name      string
 		input     *EditOptions
 		httpStubs func(*testing.T, *httpmock.Registry)
-		stdout    string
-		stderr    string
+		attach    []string
+		// Empty means the default token, which can upload.
+		token string
+		// Overrides token, for a row that needs more than one host.
+		hostTokens map[string]string
+		uploads    []attachments.UploadStub
+		// Empty means the row does not care which host was reached.
+		wantUploadHost     string
+		wantLookupFields   []string
+		wantNoLookupFields []string
+		stdout             string
+		stderr             string
+		wantErr            string
 	}{
 		{
 			name: "non-interactive",
@@ -1153,6 +1208,431 @@ func Test_editRun(t *testing.T) {
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123\n",
 		},
+		{
+			name: "cancelling the editor uploads nothing",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: true,
+				Surveyor: testSurveyor{
+					fieldsToEdit: func(e *shared.Editable) error {
+						e.Body.Edited = true
+						return nil
+					},
+					editFields: func(e *shared.Editable, editorCmd string) error {
+						return errors.New("the user quit the editor")
+					},
+				},
+				Fetcher:         testFetcher{},
+				EditorRetriever: testEditorRetriever{},
+			},
+			attach: []string{"shot.png"},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Exclude(t, httpmock.REST("POST", "user-attachments/assets"))
+			},
+			wantErr: "the user quit the editor",
+		},
+		{
+			name: "a token that cannot upload fails before any prompt",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: true,
+				Surveyor: testSurveyor{
+					fieldsToEdit: func(e *shared.Editable) error {
+						return errors.New("no prompt may run")
+					},
+					editFields: func(e *shared.Editable, editorCmd string) error {
+						return errors.New("no prompt may run")
+					},
+				},
+				Fetcher:         testFetcher{},
+				EditorRetriever: testEditorRetriever{},
+			},
+			attach:  []string{"shot.png"},
+			token:   "ghs_anactionstoken",
+			wantErr: "unsupported authentication type",
+		},
+		{
+			name: "attaching with no body flag keeps the body already on the pull request",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Fetcher:     testFetcher{},
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockPullRequestUpdateWithBody(t, reg, "the original body\n\n![shot](https://example.com/1)")
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "an empty body flag clears the body and leaves the attachment",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Body: shared.EditableString{
+						Value:  "",
+						Edited: true,
+					},
+				},
+				Fetcher: testFetcher{},
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockPullRequestUpdateWithBody(t, reg, "![shot](https://example.com/1)")
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "attaching does not double what the editor already carried",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: true,
+				Surveyor: testSurveyor{
+					fieldsToEdit: func(e *shared.Editable) error {
+						e.Body.Edited = true
+						return nil
+					},
+					editFields: func(e *shared.Editable, editorCmd string) error {
+						e.Body.Value = e.Body.Default + "\n\nplus an edit"
+						return nil
+					},
+				},
+				Fetcher:         testFetcher{},
+				EditorRetriever: testEditorRetriever{},
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockPullRequestUpdateWithBody(t, reg, "the original body\n\nplus an edit\n\n![shot](https://example.com/1)")
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "an upload that partly succeeded writes the part that uploaded",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Fetcher:     testFetcher{},
+			},
+			attach: []string{"a.png", "b.png"},
+			uploads: []attachments.UploadStub{
+				{Name: "a.png", Status: 201, Body: `{"url":"https://example.com/1"}`},
+				{Name: "b.png", Status: 404, Body: `{"message":"Not Found"}`},
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockPullRequestUpdateWithBody(t, reg, "the original body\n\n![a](https://example.com/1)")
+			},
+			stdout:  "https://github.com/OWNER/REPO/pull/123\n",
+			wantErr: "could not upload ./b.png\nattaching files requires write access to the repository",
+		},
+		{
+			name: "a sole failed upload leaves the body alone and still edits the title",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Title: shared.EditableString{Value: "new title", Edited: true},
+				},
+				Fetcher: testFetcher{},
+			},
+			attach:  []string{"a.png"},
+			uploads: []attachments.UploadStub{{Name: "a.png", Status: 404, Body: `{"message":"Not Found"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockPullRequestUpdateWithoutBody(t, reg, "new title")
+			},
+			stdout:  "https://github.com/OWNER/REPO/pull/123\n",
+			wantErr: "could not upload ./a.png\nattaching files requires write access to the repository",
+		},
+		{
+			name: "a validation failure leaves the body alone and still edits the title",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "important work\n\n![demo][d]\n\n[d]: ./demo.mp4",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Title: shared.EditableString{Value: "new title", Edited: true},
+				},
+				Fetcher: testFetcher{},
+			},
+			attach: []string{"demo.mp4"},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Exclude(t, httpmock.REST("POST", "user-attachments/assets"))
+				mockPullRequestUpdateWithoutBody(t, reg, "new title")
+			},
+			stdout:  "https://github.com/OWNER/REPO/pull/123\n",
+			wantErr: "cannot embed a video as a reference-style image: ./demo.mp4",
+		},
+		{
+			name: "an attach that writes nothing does not print the URL",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Fetcher:     testFetcher{},
+			},
+			attach:  []string{"a.png"},
+			uploads: []attachments.UploadStub{{Name: "a.png", Status: 404, Body: `{"message":"Not Found"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Exclude(t, httpmock.GraphQL(`mutation PullRequestUpdate\b`))
+			},
+			wantErr: "could not upload ./a.png\nattaching files requires write access to the repository\nthe pull request was not changed",
+		},
+		{
+			name: "an upload failure and a write failure are both reported",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Title: shared.EditableString{Value: "new title", Edited: true},
+				},
+				Fetcher: testFetcher{},
+			},
+			attach:  []string{"a.png"},
+			uploads: []attachments.UploadStub{{Name: "a.png", Status: 404, Body: `{"message":"Not Found"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestUpdate\b`),
+					httpmock.StatusStringResponse(500, `{"message":"the write failed"}`),
+				)
+			},
+			wantErr: "could not upload ./a.png\nattaching files requires write access to the repository\nnon-200 OK status code:  body: \"{\\\"message\\\":\\\"the write failed\\\"}\"",
+		},
+		{
+			// This predates --attach, which is why the not-changed message the
+			// row above covers is guarded on something being attached.
+			name: "an interactive run that selects nothing still prints the URL",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:  "https://github.com/OWNER/REPO/pull/123",
+					Body: "the original body",
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: true,
+				Surveyor: testSurveyor{
+					fieldsToEdit: func(e *shared.Editable) error { return nil },
+					editFields:   func(e *shared.Editable, editorCmd string) error { return nil },
+				},
+				Fetcher:         testFetcher{},
+				EditorRetriever: testEditorRetriever{},
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Exclude(t, httpmock.GraphQL(`mutation PullRequestUpdate\b`))
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "a failed upload drops even a body the caller typed",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Title: shared.EditableString{Value: "new title", Edited: true},
+					Body:  shared.EditableString{Value: "see ![a](./a.png)", Edited: true},
+				},
+				Fetcher: testFetcher{},
+			},
+			attach:  []string{"a.png"},
+			uploads: []attachments.UploadStub{{Name: "a.png", Status: 404, Body: `{"message":"Not Found"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockPullRequestUpdateWithoutBody(t, reg, "new title")
+			},
+			stdout:  "https://github.com/OWNER/REPO/pull/123\n",
+			wantErr: "could not upload ./a.png\nattaching files requires write access to the repository",
+		},
+		{
+			// The default host deliberately holds a token that cannot upload,
+			// so tidying these fixture tokens weakens the row without failing it.
+			name: "the token comes from the host the pull request was fetched from",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "https://acme.ghe.com/OWNER/REPO/pull/123",
+				Finder: shared.NewMockFinder("https://acme.ghe.com/OWNER/REPO/pull/123", &api.PullRequest{
+					URL:        "https://acme.ghe.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.NewWithHost("OWNER", "REPO", "acme.ghe.com")),
+				Interactive: false,
+				Fetcher:     testFetcher{},
+			},
+			attach:         []string{"shot.png"},
+			hostTokens:     map[string]string{"github.com": "ghs_anactionstoken", "acme.ghe.com": "gho_atenanttoken"},
+			uploads:        []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			wantUploadHost: "uploads.acme.ghe.com",
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockPullRequestUpdateWithBody(t, reg, "the original body\n\n![shot](https://example.com/1)")
+			},
+			stdout: "https://acme.ghe.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "a missing repository id stops the upload",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Repository: &api.PRRepository{DatabaseID: 0, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Fetcher:     testFetcher{},
+			},
+			attach:  []string{"shot.png"},
+			wantErr: "could not determine which repository to attach files to",
+		},
+		{
+			name: "read access stops the upload",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "READ"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Fetcher:     testFetcher{},
+			},
+			attach:  []string{"shot.png"},
+			wantErr: "attaching files requires write access to the repository",
+		},
+		{
+			name: "attaching asks the pull request lookup for the repository id",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:        "https://github.com/OWNER/REPO/pull/123",
+					Body:       "the original body",
+					Repository: &api.PRRepository{DatabaseID: 1234, ViewerPermission: "WRITE"},
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Fetcher:     testFetcher{},
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockPullRequestUpdate(reg)
+			},
+			wantLookupFields: []string{"repository"},
+			stdout:           "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "a run that attaches nothing does not write the body",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:  "https://github.com/OWNER/REPO/pull/123",
+					Body: "the original body",
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Labels: shared.EditableSlice{
+						Add:    []string{"bug"},
+						Remove: []string{"docs"},
+						Edited: true,
+					},
+				},
+				Fetcher: testFetcher{},
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Exclude(t, httpmock.GraphQL(`mutation PullRequestUpdate\b`))
+				mockRepoMetadata(reg, mockRepoMetadataOptions{labels: true})
+				mockPullRequestUpdateLabels(reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "the lookup does not ask for the repository id without an attachment",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL:  "https://github.com/OWNER/REPO/pull/123",
+					Body: "the original body",
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Title: shared.EditableString{
+						Value:  "new title",
+						Edited: true,
+					},
+				},
+				Fetcher: testFetcher{},
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockPullRequestUpdate(reg)
+			},
+			wantNoLookupFields: []string{"repository"},
+			stdout:             "https://github.com/OWNER/REPO/pull/123\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1163,7 +1643,16 @@ func Test_editRun(t *testing.T) {
 
 			reg := &httpmock.Registry{}
 			defer reg.Verify(t)
-			tt.httpStubs(t, reg)
+			for _, u := range tt.uploads {
+				if tt.wantUploadHost != "" {
+					attachments.StubUploadToHost(t, reg, tt.wantUploadHost, 1234, u.Name, u.Status, u.Body)
+					continue
+				}
+				attachments.StubUpload(reg, 1234, u.Name, u.Status, u.Body)
+			}
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
 
 			httpClient := func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
 			baseRepo := func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil }
@@ -1172,12 +1661,67 @@ func Test_editRun(t *testing.T) {
 			tt.input.HttpClient = httpClient
 			tt.input.BaseRepo = baseRepo
 
+			// NewTestAssets moves into a temporary directory, so it runs before
+			// anything else reads a relative path.
+			if len(tt.attach) > 0 {
+				tt.input.Assets = attachments.NewTestAssets(t, tt.attach...)
+			}
+
+			// The host comes from the pull request the row's finder returns, so
+			// a row can hold a token for a host the config's default is not.
+			hostTokens := tt.hostTokens
+			if hostTokens == nil {
+				token := tt.token
+				if token == "" {
+					token = "gho_atokenthatcanupload"
+				}
+				hostTokens = map[string]string{"github.com": token}
+			}
+			tt.input.Config = func() (gh.Config, error) {
+				return config.NewMockConfigFromString(hostsConfig(hostTokens)), nil
+			}
+
+			var lookupFields []string
+			tt.input.Finder = fieldCapturingFinder{PRFinder: tt.input.Finder, fields: &lookupFields}
+
 			err := editRun(tt.input)
-			assert.NoError(t, err)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
 			assert.Equal(t, tt.stdout, stdout.String())
 			assert.Equal(t, tt.stderr, stderr.String())
+
+			for _, field := range tt.wantLookupFields {
+				assert.Contains(t, lookupFields, field)
+			}
+			for _, field := range tt.wantNoLookupFields {
+				assert.NotContains(t, lookupFields, field)
+			}
 		})
 	}
+}
+
+// fieldCapturingFinder records the fields a run asks the pull request lookup
+// for, then delegates to the finder it wraps.
+type fieldCapturingFinder struct {
+	shared.PRFinder
+	fields *[]string
+}
+
+func (f fieldCapturingFinder) Find(opts shared.FindOptions) (*api.PullRequest, ghrepo.Interface, error) {
+	*f.fields = opts.Fields
+	return f.PRFinder.Find(opts)
+}
+
+func hostsConfig(tokens map[string]string) string {
+	var b strings.Builder
+	b.WriteString("hosts:\n")
+	for host, token := range tokens {
+		fmt.Fprintf(&b, "  %s:\n    user: monalisa\n    oauth_token: %s\n", host, token)
+	}
+	return b.String()
 }
 
 type mockRepoMetadataOptions struct {
@@ -1312,6 +1856,27 @@ func mockPullRequestUpdate(reg *httpmock.Registry) {
 	reg.Register(
 		httpmock.GraphQL(`mutation PullRequestUpdate\b`),
 		httpmock.StringResponse(`{}`))
+}
+
+func mockPullRequestUpdateWithBody(t *testing.T, reg *httpmock.Registry, wantBody string) {
+	reg.Register(
+		httpmock.GraphQL(`mutation PullRequestUpdate\b`),
+		httpmock.GraphQLMutation(`{}`, func(inputs map[string]interface{}) {
+			assert.Equal(t, wantBody, inputs["body"])
+		}),
+	)
+}
+
+// A dropped body is absent from the input, which is not the same as a body sent
+// with its old value.
+func mockPullRequestUpdateWithoutBody(t *testing.T, reg *httpmock.Registry, wantTitle string) {
+	reg.Register(
+		httpmock.GraphQL(`mutation PullRequestUpdate\b`),
+		httpmock.GraphQLMutation(`{}`, func(inputs map[string]interface{}) {
+			assert.Equal(t, wantTitle, inputs["title"])
+			assert.NotContains(t, inputs, "body")
+		}),
+	)
 }
 
 func mockPullRequestUpdateApiActors(reg *httpmock.Registry) {

--- a/pkg/httpmock/legacy.go
+++ b/pkg/httpmock/legacy.go
@@ -7,19 +7,24 @@ import (
 // TODO: clean up methods in this file when there are no more callers
 
 func (r *Registry) StubRepoInfoResponse(owner, repo, branch string) {
+	r.StubRepoInfoResponseWithPermission(owner, repo, branch, "WRITE")
+}
+
+func (r *Registry) StubRepoInfoResponseWithPermission(owner, repo, branch, permission string) {
 	r.Register(
 		GraphQL(`query RepositoryInfo\b`),
 		StringResponse(fmt.Sprintf(`
 		{ "data": { "repository": {
 			"id": "REPOID",
+			"databaseId": 1234,
 			"name": "%s",
 			"owner": {"login": "%s"},
 			"description": "",
 			"defaultBranchRef": {"name": "%s"},
 			"hasIssuesEnabled": true,
-			"viewerPermission": "WRITE"
+			"viewerPermission": "%s"
 		} } }
-		`, repo, owner, branch)))
+		`, repo, owner, branch, permission)))
 }
 
 func (r *Registry) StubIssueRepoInfoResponse(owner, repo string) {


### PR DESCRIPTION
Part of the pull request stack tracked in #14186.

### Description

This is the seventh layer of the stack. It adds `--attach` to `gh pr create` and `gh pr edit`, one commit each.

```
gh pr create --title "Fix the login screen" --attach ./after.png
```

On create, the body can come from `--body`, from `--body-file`, from standard input, from a text editor, or from `--fill`, which builds the body from the commits. All of them work with an attachment, and a reference written in any of them is rewritten in place.

On edit, using only `--attach` with no body flag keeps the existing body and adds the attachment below it. If the existing body already references the file, the reference is rewritten in place and nothing is appended.

Two combinations are refused on create. `--attach` with `--web` cannot work. `--attach` with `--dry-run` is refused because a dry run should not upload anything, and an upload cannot be undone.

### How did you test this change?

Both commands were exercised by hand against a private test repository. That covered a pull request created with an image, one created with a video, one created from a body file whose reference was rewritten, and one created with `--fill` where the generated body was kept and the asset appended below it rather than replacing it.

On edit it covered appending to an existing body, and editing where the reference already in the body was rewritten in place. Both refused flag combinations were checked.

A failed rewrite was also exercised. A body that embeds a video through a reference style definition cannot be rewritten, and in that case the command exited non zero, the existing body was left exactly as it was, and nothing was printed to standard output.

### Key points

The failure case is the one worth reading closely. When the markdown cannot be rewritten, the existing body survives untouched and no URL is printed, so the run does not read as a success to a script.

### Notes for reviewers

The two commits are independent and can be read in either order. Editing is the more interesting of the two, because it has an existing body to preserve and creating does not.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @BagToad will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
