### PR TITLE
`--attach` stack 8/8: Add the flag to gh issue create and gh issue edit

### DIFF
--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/attachments"
 	"github.com/cli/cli/v2/internal/browser"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
@@ -54,6 +56,8 @@ type CreateOptions struct {
 	Parent      string
 	BlockedBy   []string
 	Blocking    []string
+
+	Assets []attachments.UserAsset
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
@@ -75,6 +79,15 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		Long: heredoc.Docf(`
 			Create an issue on GitHub.
 
+			Use %[1]s--attach%[1]s to upload an image or video. The attachment is appended to the
+			body. If the body references an attached file, such as %[1]s![alt](./login.png)%[1]s, that
+			reference is rewritten to point at the uploaded asset instead.
+
+			Alt text for an image follows the path after %[1]s#%[1]s, as in
+			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.
+			A reference already in the body keeps the alt text written there. Video renders
+			as a player and has no alt text, so it cannot be given any.
+
 			Adding an issue to projects requires authorization with the %[1]sproject%[1]s scope.
 			To authorize, run %[1]sgh auth refresh -s project%[1]s.
 
@@ -84,6 +97,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh issue create --title "I found a bug" --body "Nothing works"
+			$ gh issue create --attach './login.png#The login error state'
 			$ gh issue create --label "bug,help wanted"
 			$ gh issue create --label bug --label "help wanted"
 			$ gh issue create --assignee monalisa,hubot
@@ -134,6 +148,11 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("must provide `--title` and `--body` when not running interactively")
 			}
 
+			opts.Assets, err = attachments.FromFlagValues(cmd)
+			if err != nil {
+				return err
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -156,6 +175,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd.Flags().StringVar(&opts.Parent, "parent", "", "Add the new issue as a sub-issue of the specified parent `number` or URL")
 	cmd.Flags().StringSliceVar(&opts.BlockedBy, "blocked-by", nil, "Mark the new issue as blocked by these issue `numbers` or URLs")
 	cmd.Flags().StringSliceVar(&opts.Blocking, "blocking", nil, "Mark the new issue as blocking these issue `numbers` or URLs")
+	attachments.AddFlag(cmd)
 
 	return cmd
 }
@@ -258,6 +278,23 @@ func createRun(opts *CreateOptions) (err error) {
 		return
 	}
 
+	// Built before the first survey, so a run that cannot upload stops early.
+	var uploader *attachments.Uploader
+	if len(opts.Assets) > 0 {
+		var cfg gh.Config
+		cfg, err = opts.Config()
+		if err != nil {
+			return
+		}
+		host := baseRepo.RepoHost()
+		tokenType := cfg.Authentication().ActiveTokenType(host)
+
+		uploader, err = attachments.NewUploader(httpClient, tokenType, host, repo.DatabaseID, repo.ViewerPermission)
+		if err != nil {
+			return
+		}
+	}
+
 	action := prShared.SubmitAction
 	templateNameForSubmit := ""
 	var openURL string
@@ -327,7 +364,8 @@ func createRun(opts *CreateOptions) (err error) {
 			return
 		}
 
-		allowPreview := !tb.HasMetadata() && prShared.ValidURL(openURL)
+		// Preview opens the browser, which cannot carry an upload.
+		allowPreview := !tb.HasMetadata() && prShared.ValidURL(openURL) && len(opts.Assets) == 0
 		action, err = prShared.ConfirmIssueSubmission(opts.Prompter, allowPreview, repo.ViewerCanTriage())
 		if err != nil {
 			err = fmt.Errorf("unable to confirm: %w", err)
@@ -350,7 +388,7 @@ func createRun(opts *CreateOptions) (err error) {
 				return
 			}
 
-			action, err = prShared.ConfirmIssueSubmission(opts.Prompter, !tb.HasMetadata(), false)
+			action, err = prShared.ConfirmIssueSubmission(opts.Prompter, !tb.HasMetadata() && len(opts.Assets) == 0, false)
 			if err != nil {
 				return
 			}
@@ -404,6 +442,21 @@ func createRun(opts *CreateOptions) (err error) {
 		err = prShared.AddMetadataToIssueParams(apiClient, baseRepo, params, &tb, projectsV1Support)
 		if err != nil {
 			return
+		}
+
+		// With nothing uploaded the body would promise an attachment that does
+		// not exist, so no issue is created. Once anything has uploaded the
+		// issue is created and the failures are reported.
+		if uploader != nil {
+			body, uploaded, uploadErr := uploader.UploadAndAttach(context.Background(), tb.Body, opts.Assets)
+			if uploadErr != nil && uploaded == 0 {
+				err = uploadErr
+				return
+			}
+			params["body"] = body
+			if uploadErr != nil {
+				defer func() { err = errors.Join(uploadErr, err) }()
+			}
 		}
 
 		var newIssue *api.Issue

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/attachments"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
@@ -34,14 +36,22 @@ func TestNewCmdCreate(t *testing.T) {
 	err := os.WriteFile(tmpFile, []byte("a body from file"), 0600)
 	require.NoError(t, err)
 
+	tmpImage := filepath.Join(t.TempDir(), "shot.png")
+	require.NoError(t, os.WriteFile(tmpImage, []byte("the bytes"), 0600))
+
 	tests := []struct {
-		name      string
-		tty       bool
-		stdin     string
-		cli       string
-		config    string
-		wantsErr  bool
-		wantsOpts CreateOptions
+		name        string
+		tty         bool
+		stdin       string
+		cli         string
+		config      string
+		wantsErr    bool
+		wantsErrMsg string
+		// wantErrIsNotExist covers an error whose text the operating system
+		// words differently, so the assertion cannot be on the message.
+		wantErrIsNotExist bool
+		wantsOpts         CreateOptions
+		wantAssetPaths    []string
 	}{
 		{
 			name:     "empty non-tty",
@@ -253,6 +263,32 @@ func TestNewCmdCreate(t *testing.T) {
 				Blocking: []string{"300"},
 			},
 		},
+		{
+			name:     "attach flag",
+			tty:      false,
+			cli:      fmt.Sprintf(`-t mytitle -b mybody --attach '%s'`, tmpImage),
+			wantsErr: false,
+			wantsOpts: CreateOptions{
+				Title: "mytitle",
+				Body:  "mybody",
+			},
+			wantAssetPaths: []string{tmpImage},
+		},
+		{
+			name:        "attach flag with web",
+			tty:         false,
+			cli:         fmt.Sprintf(`-t mytitle -b mybody --web --attach '%s'`, tmpImage),
+			wantsErr:    true,
+			wantsErrMsg: "`--attach` is not supported when using `--web`",
+		},
+		{
+			name:              "attach flag naming a file that does not exist",
+			tty:               false,
+			cli:               `-t mytitle -b mybody --attach ./nope.png`,
+			wantsErr:          true,
+			wantsErrMsg:       "./nope.png: ",
+			wantErrIsNotExist: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -287,11 +323,18 @@ func TestNewCmdCreate(t *testing.T) {
 			cmd.SetErr(io.Discard)
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
-				assert.Error(t, err)
+				require.Error(t, err)
+				if tt.wantsErrMsg != "" {
+					if tt.wantErrIsNotExist {
+						require.ErrorIs(t, err, fs.ErrNotExist)
+						require.ErrorContains(t, err, tt.wantsErrMsg)
+					} else {
+						require.EqualError(t, err, tt.wantsErrMsg)
+					}
+				}
 				return
-			} else {
-				require.NoError(t, err)
 			}
+			require.NoError(t, err)
 
 			assert.Equal(t, "", stdout.String())
 			assert.Equal(t, "", stderr.String())
@@ -306,6 +349,12 @@ func TestNewCmdCreate(t *testing.T) {
 			assert.Equal(t, tt.wantsOpts.Parent, opts.Parent)
 			assert.Equal(t, tt.wantsOpts.BlockedBy, opts.BlockedBy)
 			assert.Equal(t, tt.wantsOpts.Blocking, opts.Blocking)
+
+			var assetPaths []string
+			for _, a := range opts.Assets {
+				assetPaths = append(assetPaths, a.Path())
+			}
+			assert.Equal(t, tt.wantAssetPaths, assetPaths)
 		})
 	}
 }
@@ -314,8 +363,11 @@ func Test_createRun(t *testing.T) {
 	tests := []struct {
 		name        string
 		opts        CreateOptions
+		attach      []string
+		host        string
+		config      string
 		httpStubs   func(*testing.T, *httpmock.Registry)
-		promptStubs func(*prompter.PrompterMock)
+		promptStubs func(*testing.T, *prompter.PrompterMock)
 		wantsStdout string
 		wantsStderr string
 		wantsBrowse string
@@ -542,7 +594,7 @@ func Test_createRun(t *testing.T) {
 				Title:       "test `gh issue create` actor assignees",
 				Body:        "Actor assignees allow users and bots to be assigned to issues",
 			},
-			promptStubs: func(pm *prompter.PrompterMock) {
+			promptStubs: func(_ *testing.T, pm *prompter.PrompterMock) {
 				firstConfirmSubmission := true
 				pm.InputFunc = func(message, defaultValue string) (string, error) {
 					switch message {
@@ -621,7 +673,7 @@ func Test_createRun(t *testing.T) {
 				Title:       "test `gh issue create` user assignees",
 				Body:        "User assignees allow only users to be assigned to issues",
 			},
-			promptStubs: func(pm *prompter.PrompterMock) {
+			promptStubs: func(_ *testing.T, pm *prompter.PrompterMock) {
 				firstConfirmSubmission := true
 				pm.InputFunc = func(message, defaultValue string) (string, error) {
 					switch message {
@@ -737,7 +789,7 @@ func Test_createRun(t *testing.T) {
 				Title:       "feature request",
 				Body:        "would be nice to have",
 			},
-			promptStubs: func(pm *prompter.PrompterMock) {
+			promptStubs: func(_ *testing.T, pm *prompter.PrompterMock) {
 				pm.SelectFunc = func(message, defaultValue string, options []string) (int, error) {
 					switch message {
 					case "Issue type":
@@ -927,6 +979,360 @@ func Test_createRun(t *testing.T) {
 			wantsStdout: "https://github.com/OWNER/REPO/issues/123\n",
 			wantsStderr: "\nCreating issue in OWNER/REPO\n\n",
 		},
+		{
+			name: "attaching writes the body the upload produced",
+			opts: CreateOptions{
+				Detector: &fd.EnabledDetectorMock{},
+				Title:    "mytitle",
+				Body:     "a body",
+			},
+			attach: []string{"shot.png"},
+			httpStubs: func(t *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"databaseId": 1234,
+							"hasIssuesEnabled": true,
+							"viewerPermission": "WRITE"
+						} } }`))
+				attachments.StubUpload(r, 1234, "shot.png", 200, `{ "url": "https://github.com/user-attachments/assets/AAA" }`)
+				r.Register(
+					httpmock.GraphQL(`mutation IssueCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createIssue": { "issue": {
+							"URL": "https://github.com/OWNER/REPO/issues/12"
+						} } } }`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, "a body\n\n![shot](https://github.com/user-attachments/assets/AAA)", inputs["body"])
+						}))
+			},
+			wantsStdout: "https://github.com/OWNER/REPO/issues/12\n",
+			wantsStderr: "\nCreating issue in OWNER/REPO\n\n",
+		},
+		{
+			name: "attaching sends the repository id the lookup returned",
+			opts: CreateOptions{
+				Detector: &fd.EnabledDetectorMock{},
+				Title:    "mytitle",
+				Body:     "a body",
+			},
+			attach: []string{"shot.png"},
+			httpStubs: func(t *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"databaseId": 4321,
+							"hasIssuesEnabled": true,
+							"viewerPermission": "WRITE"
+						} } }`))
+				attachments.StubUpload(r, 4321, "shot.png", 200, `{ "url": "https://github.com/user-attachments/assets/AAA" }`)
+				r.Register(
+					httpmock.GraphQL(`mutation IssueCreate\b`),
+					httpmock.StringResponse(`
+						{ "data": { "createIssue": { "issue": {
+							"URL": "https://github.com/OWNER/REPO/issues/12"
+						} } } }`))
+			},
+			wantsStdout: "https://github.com/OWNER/REPO/issues/12\n",
+			wantsStderr: "\nCreating issue in OWNER/REPO\n\n",
+		},
+		{
+			name: "attaching without write access stops before any prompt or write",
+			opts: CreateOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				Interactive: true,
+				Title:       "mytitle",
+				Body:        "a body",
+			},
+			attach: []string{"shot.png"},
+			promptStubs: func(_ *testing.T, pm *prompter.PrompterMock) {
+				pm.SelectFunc = func(message, defaultValue string, options []string) (int, error) {
+					return 0, fmt.Errorf("prompted before checking the permission: %s", message)
+				}
+			},
+			httpStubs: func(_ *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"databaseId": 1234,
+							"hasIssuesEnabled": true,
+							"viewerPermission": "READ"
+						} } }`))
+			},
+			wantsErr: "attaching files requires write access to the repository",
+		},
+		{
+			name: "attaching without a repository id stops before it writes",
+			opts: CreateOptions{
+				Detector: &fd.EnabledDetectorMock{},
+				Title:    "mytitle",
+				Body:     "a body",
+			},
+			attach: []string{"shot.png"},
+			httpStubs: func(_ *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"hasIssuesEnabled": true,
+							"viewerPermission": "WRITE"
+						} } }`))
+			},
+			wantsErr: "could not determine which repository to attach files to",
+		},
+		{
+			name: "the only upload failing creates no issue",
+			opts: CreateOptions{
+				Detector: &fd.EnabledDetectorMock{},
+				Title:    "mytitle",
+				Body:     "a body",
+			},
+			attach: []string{"shot.png"},
+			httpStubs: func(t *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"databaseId": 1234,
+							"hasIssuesEnabled": true,
+							"viewerPermission": "WRITE"
+						} } }`))
+				attachments.StubUpload(r, 1234, "shot.png", 404, `{ "message": "Not Found" }`)
+				r.Exclude(t, httpmock.GraphQL(`mutation IssueCreate\b`))
+			},
+			wantsErr: "could not upload ./shot.png\nattaching files requires write access to the repository",
+		},
+		{
+			name: "an upload that fails alongside one that succeeds still creates the issue",
+			opts: CreateOptions{
+				Detector: &fd.EnabledDetectorMock{},
+				Title:    "mytitle",
+				Body:     "a body",
+			},
+			attach: []string{"first.png", "second.png"},
+			httpStubs: func(t *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"databaseId": 1234,
+							"hasIssuesEnabled": true,
+							"viewerPermission": "WRITE"
+						} } }`))
+				attachments.StubUpload(r, 1234, "first.png", 200, `{ "url": "https://github.com/user-attachments/assets/AAA" }`)
+				attachments.StubUpload(r, 1234, "second.png", 404, `{ "message": "Not Found" }`)
+				r.Register(
+					httpmock.GraphQL(`mutation IssueCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createIssue": { "issue": {
+							"URL": "https://github.com/OWNER/REPO/issues/12"
+						} } } }`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, "a body\n\n![first](https://github.com/user-attachments/assets/AAA)", inputs["body"])
+						}))
+			},
+			wantsErr: "could not upload ./second.png\nattaching files requires write access to the repository",
+		},
+		{
+			name: "a create that fails after an upload failed reports both",
+			opts: CreateOptions{
+				Detector: &fd.EnabledDetectorMock{},
+				Title:    "mytitle",
+				Body:     "a body",
+			},
+			attach: []string{"first.png", "second.png"},
+			httpStubs: func(_ *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"databaseId": 1234,
+							"hasIssuesEnabled": true,
+							"viewerPermission": "WRITE"
+						} } }`))
+				attachments.StubUpload(r, 1234, "first.png", 200, `{ "url": "https://github.com/user-attachments/assets/AAA" }`)
+				attachments.StubUpload(r, 1234, "second.png", 404, `{ "message": "Not Found" }`)
+				r.Register(
+					httpmock.GraphQL(`mutation IssueCreate\b`),
+					httpmock.StringResponse(`{ "errors": [{ "message": "the create failed" }] }`))
+			},
+			wantsErr: "could not upload ./second.png\nattaching files requires write access to the repository\nGraphQL: the create failed",
+		},
+		{
+			name: "a body the attachment cannot be written into creates no issue",
+			opts: CreateOptions{
+				Detector: &fd.EnabledDetectorMock{},
+				Title:    "mytitle",
+				// A video cannot embed as a reference-style image.
+				Body: "![clip][1]\n\n[1]: ./clip.mp4",
+			},
+			attach: []string{"clip.mp4"},
+			httpStubs: func(t *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"databaseId": 1234,
+							"hasIssuesEnabled": true,
+							"viewerPermission": "WRITE"
+						} } }`))
+				r.Exclude(t, httpmock.REST("POST", "user-attachments/assets"))
+				r.Exclude(t, httpmock.GraphQL(`mutation IssueCreate\b`))
+			},
+			wantsErr: "cannot embed a video as a reference-style image: ./clip.mp4",
+		},
+		{
+			name: "the token comes from the host the base repository resolved to",
+			opts: CreateOptions{
+				Detector: &fd.EnabledDetectorMock{},
+				Title:    "mytitle",
+				Body:     "a body",
+			},
+			attach: []string{"shot.png"},
+			host:   "acme.ghe.com",
+			// The default host holds a token class that cannot upload, so
+			// making both usable disarms half the row.
+			config: heredoc.Doc(`
+				hosts:
+				  github.com:
+				    user: monalisa
+				    oauth_token: ghs_anactionstoken
+				  acme.ghe.com:
+				    user: monalisa
+				    oauth_token: gho_atenanttoken
+			`),
+			httpStubs: func(t *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"databaseId": 1234,
+							"hasIssuesEnabled": true,
+							"viewerPermission": "WRITE"
+						} } }`))
+				attachments.StubUploadToHost(t, r, "uploads.acme.ghe.com", 1234, "shot.png", 200, `{ "url": "https://acme.ghe.com/user-attachments/assets/AAA" }`)
+				r.Register(
+					httpmock.GraphQL(`mutation IssueCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createIssue": { "issue": {
+							"URL": "https://acme.ghe.com/OWNER/REPO/issues/12"
+						} } } }`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, "a body\n\n![shot](https://acme.ghe.com/user-attachments/assets/AAA)", inputs["body"])
+						}))
+			},
+			wantsStdout: "https://acme.ghe.com/OWNER/REPO/issues/12\n",
+			wantsStderr: "\nCreating issue in OWNER/REPO\n\n",
+		},
+		{
+			name: "attaching leaves the browser preview off the menu",
+			opts: CreateOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				Interactive: true,
+				Title:       "mytitle",
+				Body:        "a body",
+			},
+			attach: []string{"shot.png"},
+			promptStubs: func(t *testing.T, pm *prompter.PrompterMock) {
+				pm.SelectFunc = func(message, defaultValue string, options []string) (int, error) {
+					switch message {
+					case "What's next?":
+						assert.NotContains(t, options, "Continue in browser")
+						return prompter.IndexFor(options, "Submit")
+					default:
+						return 0, fmt.Errorf("unexpected select prompt: %s", message)
+					}
+				}
+			},
+			httpStubs: func(_ *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"databaseId": 1234,
+							"hasIssuesEnabled": true,
+							"viewerPermission": "WRITE"
+						} } }`))
+				attachments.StubUpload(r, 1234, "shot.png", 200, `{ "url": "https://github.com/user-attachments/assets/AAA" }`)
+				r.Register(
+					httpmock.GraphQL(`mutation IssueCreate\b`),
+					httpmock.StringResponse(`
+						{ "data": { "createIssue": { "issue": {
+							"URL": "https://github.com/OWNER/REPO/issues/12"
+						} } } }`))
+			},
+			wantsStdout: "https://github.com/OWNER/REPO/issues/12\n",
+			wantsStderr: "\nCreating issue in OWNER/REPO\n\n",
+		},
+		{
+			name: "attaching leaves the browser preview off the menu shown after the metadata survey",
+			opts: CreateOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				Interactive: true,
+				Title:       "mytitle",
+				Body:        "a body",
+			},
+			attach: []string{"shot.png"},
+			promptStubs: func(t *testing.T, pm *prompter.PrompterMock) {
+				firstConfirmSubmission := true
+				pm.MultiSelectFunc = func(message string, defaults []string, options []string) ([]int, error) {
+					switch message {
+					// HasMetadata stays false, the only state where the second
+					// menu could offer a preview.
+					case "What would you like to add?":
+						return nil, nil
+					default:
+						return nil, fmt.Errorf("unexpected multi-select prompt: %s", message)
+					}
+				}
+				pm.SelectFunc = func(message, defaultValue string, options []string) (int, error) {
+					switch message {
+					case "What's next?":
+						if firstConfirmSubmission {
+							firstConfirmSubmission = false
+							return prompter.IndexFor(options, "Add metadata")
+						}
+						assert.NotContains(t, options, "Continue in browser")
+						return prompter.IndexFor(options, "Submit")
+					default:
+						return 0, fmt.Errorf("unexpected select prompt: %s", message)
+					}
+				}
+			},
+			httpStubs: func(_ *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+					httpmock.StringResponse(`
+						{ "data": { "repository": {
+							"id": "REPOID",
+							"databaseId": 1234,
+							"hasIssuesEnabled": true,
+							"viewerPermission": "WRITE"
+						} } }`))
+				attachments.StubUpload(r, 1234, "shot.png", 200, `{ "url": "https://github.com/user-attachments/assets/AAA" }`)
+				r.Register(
+					httpmock.GraphQL(`mutation IssueCreate\b`),
+					httpmock.StringResponse(`
+						{ "data": { "createIssue": { "issue": {
+							"URL": "https://github.com/OWNER/REPO/issues/12"
+						} } } }`))
+			},
+			wantsStdout: "https://github.com/OWNER/REPO/issues/12\n",
+			wantsStderr: "\nCreating issue in OWNER/REPO\n\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -943,8 +1349,12 @@ func Test_createRun(t *testing.T) {
 			opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: httpReg}, nil
 			}
+			host := tt.host
+			if host == "" {
+				host = "github.com"
+			}
 			opts.BaseRepo = func() (ghrepo.Interface, error) {
-				return ghrepo.New("OWNER", "REPO"), nil
+				return ghrepo.NewWithHost("OWNER", "REPO", host), nil
 			}
 			browser := &browser.Stub{}
 			opts.Browser = browser
@@ -952,7 +1362,20 @@ func Test_createRun(t *testing.T) {
 			prompterMock := &prompter.PrompterMock{}
 			opts.Prompter = prompterMock
 			if tt.promptStubs != nil {
-				tt.promptStubs(prompterMock)
+				tt.promptStubs(t, prompterMock)
+			}
+
+			// NewTestAssets moves into a temporary directory, so it runs before
+			// anything else reads a relative path.
+			if len(tt.attach) > 0 {
+				opts.Assets = attachments.NewTestAssets(t, tt.attach...)
+			}
+			opts.Config = func() (gh.Config, error) {
+				cfg := tt.config
+				if cfg == "" {
+					cfg = fmt.Sprintf("hosts:\n  %s:\n    user: monalisa\n    oauth_token: gho_atokenthatcanupload\n", host)
+				}
+				return config.NewMockConfigFromString(cfg), nil
 			}
 
 			err := createRun(opts)
@@ -971,7 +1394,6 @@ func Test_createRun(t *testing.T) {
 }
 
 /*** LEGACY TESTS ***/
-
 func runCommand(rt http.RoundTripper, isTTY bool, cli string, pm *prompter.PrompterMock) (*test.CmdOut, error) {
 	return runCommandWithRootDirOverridden(rt, isTTY, cli, "", pm)
 }

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -1,6 +1,8 @@
 package edit
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/attachments"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -47,6 +50,9 @@ type EditOptions struct {
 	AddBlocking     []string
 	RemoveBlocking  []string
 
+	Assets []attachments.UserAsset
+	Config func() (gh.Config, error)
+
 	prShared.Editable
 }
 
@@ -54,6 +60,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	opts := &EditOptions{
 		IO:                 f.IOStreams,
 		HttpClient:         f.HttpClient,
+		Config:             f.Config,
 		DetermineEditor:    func() (string, error) { return cmdutil.DetermineEditor(f.Config) },
 		FieldsToEditSurvey: prShared.FieldsToEditSurvey,
 		EditFieldsSurvey:   prShared.EditFieldsSurvey,
@@ -73,6 +80,16 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			Editing issues' projects requires authorization with the %[1]sproject%[1]s scope.
 			To authorize, run %[1]sgh auth refresh -s project%[1]s.
 
+			Use %[1]s--attach%[1]s to upload an image or video to a single issue. Without a body
+			flag the issue keeps the body it already has and the attachment is appended to it.
+			If the body references an attached file, such as %[1]s![alt](./login.png)%[1]s, that
+			reference is rewritten to point at the uploaded asset instead.
+
+			Alt text for an image follows the path after %[1]s#%[1]s, as in
+			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.
+			A reference already in the body keeps the alt text written there. Video renders
+			as a player and has no alt text, so it cannot be given any.
+
 			The %[1]s--add-assignee%[1]s and %[1]s--remove-assignee%[1]s flags both support
 			the following special values:
 			- %[1]s@me%[1]s: assign or unassign yourself
@@ -87,6 +104,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			$ gh issue edit 23 --milestone "Version 1"
 			$ gh issue edit 23 --remove-milestone
 			$ gh issue edit 23 --body-file body.txt
+			$ gh issue edit 23 --attach './login.png#The login error state'
 			$ gh issue edit 23 34 --add-label "help wanted"
 			$ gh issue edit 23 --type Bug
 			$ gh issue edit 23 --remove-type
@@ -185,20 +203,18 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 				opts.Editable.IssueType.Edited = true
 			}
 
-			// hasDeferredFlags covers edit flags that flow through the
-			// deferred update path rather than the prShared.Editable struct,
-			// so they would otherwise be invisible to Editable.Dirty() below.
-			// Note that --type (set) is intentionally absent: it lights up
-			// opts.Editable.IssueType.Edited above, which Editable.Dirty()
-			// already picks up. Only --remove-type needs to be listed here.
-			hasDeferredFlags := opts.RemoveIssueType ||
-				flags.Changed("parent") || opts.RemoveParent ||
-				len(opts.AddSubIssues) > 0 || len(opts.RemoveSubIssues) > 0 ||
-				len(opts.AddBlockedBy) > 0 || len(opts.RemoveBlockedBy) > 0 ||
-				len(opts.AddBlocking) > 0 || len(opts.RemoveBlocking) > 0
+			resolved, err := attachments.FromFlagValues(cmd)
+			if err != nil {
+				return err
+			}
+			opts.Assets = resolved
+
+			// An empty --parent resolves to no work, so it counts as an edit
+			// only here, where passing the flag at all suppresses the survey.
+			hasDeferredFlags := opts.hasDeferredEdits() || flags.Changed("parent")
 
 			// Drop into interactive mode only if the user passed no edit flags at all.
-			if !opts.Editable.Dirty() && !hasDeferredFlags {
+			if !opts.Editable.Dirty() && !hasDeferredFlags && len(opts.Assets) == 0 {
 				opts.Interactive = true
 			}
 
@@ -212,6 +228,10 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 
 			if len(opts.IssueNumbers) > 1 && len(opts.AddSubIssues) > 0 {
 				return cmdutil.FlagErrorf("`--add-sub-issue` cannot be used when editing multiple issues")
+			}
+
+			if len(opts.IssueNumbers) > 1 && len(opts.Assets) > 0 {
+				return cmdutil.FlagErrorf("`--attach` cannot be used when editing multiple issues")
 			}
 
 			if runF != nil {
@@ -243,8 +263,21 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd.Flags().StringSliceVar(&opts.RemoveBlockedBy, "remove-blocked-by", nil, "Remove 'blocked by' relationships by issue `number` or URL")
 	cmd.Flags().StringSliceVar(&opts.AddBlocking, "add-blocking", nil, "Add 'blocking' relationships by issue `number` or URL")
 	cmd.Flags().StringSliceVar(&opts.RemoveBlocking, "remove-blocking", nil, "Remove 'blocking' relationships by issue `number` or URL")
+	attachments.AddFlag(cmd)
 
 	return cmd
+}
+
+// hasDeferredEdits reports whether the run asks for an edit that the deferred
+// update path applies, which Editable.Dirty() cannot see. Setting --type is
+// absent because it sets Editable.IssueType.Edited, which Dirty() already
+// covers; only --remove-type arrives here.
+func (opts *EditOptions) hasDeferredEdits() bool {
+	return opts.RemoveIssueType ||
+		opts.Parent != "" || opts.RemoveParent ||
+		len(opts.AddSubIssues) > 0 || len(opts.RemoveSubIssues) > 0 ||
+		len(opts.AddBlockedBy) > 0 || len(opts.RemoveBlockedBy) > 0 ||
+		len(opts.AddBlocking) > 0 || len(opts.RemoveBlocking) > 0
 }
 
 func editRun(opts *EditOptions) error {
@@ -310,11 +343,31 @@ func editRun(opts *EditOptions) error {
 	if opts.Parent != "" || opts.RemoveParent {
 		lookupFields = append(lookupFields, "parent")
 	}
+	if len(opts.Assets) > 0 {
+		lookupFields = append(lookupFields, "repository")
+	}
 
 	// Get all specified issues and make sure they are within the same repo.
 	issues, err := issueShared.FindIssuesOrPRs(httpClient, baseRepo, opts.IssueNumbers, lookupFields)
 	if err != nil {
 		return err
+	}
+
+	// NewCmdEdit rejects --attach for more than one issue, so issues[0] is the
+	// only issue. This is the earliest its repository id and permission exist,
+	// so a run that cannot upload stops before any write.
+	var uploader *attachments.Uploader
+	if len(opts.Assets) > 0 {
+		cfg, err := opts.Config()
+		if err != nil {
+			return err
+		}
+		host := baseRepo.RepoHost()
+		tokenType := cfg.Authentication().ActiveTokenType(host)
+		uploader, err = attachments.NewUploader(httpClient, tokenType, host, issues[0].RepositoryDatabaseID(), issues[0].RepositoryViewerPermission())
+		if err != nil {
+			return err
+		}
 	}
 
 	// Fetch editable shared fields once for all issues.
@@ -331,6 +384,32 @@ func editRun(opts *EditOptions) error {
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
+	}
+
+	var uploadErr error
+	if uploader != nil {
+		// A body the caller supplied replaces the issue's, including an empty
+		// one.
+		body := editable.Body.Value
+		if !editable.Body.Edited {
+			body = issues[0].Body
+		}
+
+		// This sits outside the loop below so each file uploads once, and
+		// Clone carries the merged body into the issue. Nothing that can
+		// prompt or cancel may follow an upload.
+		var uploaded int
+		body, uploaded, uploadErr = uploader.UploadAndAttach(context.Background(), body, opts.Assets)
+
+		if uploaded > 0 {
+			editable.Body.Value = body
+			editable.Body.Edited = true
+		} else {
+			// The caller's body was written to carry an attachment that never
+			// arrived, so it does not replace what the issue has. Every other
+			// field the caller asked for still applies.
+			editable.Body.Edited = false
+		}
 	}
 
 	// Update all issues in parallel.
@@ -435,8 +514,14 @@ func editRun(opts *EditOptions) error {
 	}
 
 	sort.Strings(editedIssueURLs)
-	for _, editedIssueURL := range editedIssueURLs {
-		fmt.Fprintln(opts.IO.Out, editedIssueURL)
+	// Attaching is the only edit this command drops after parsing the flags,
+	// so it is the only way to reach here with nothing written. An upload that
+	// placed a file sets the body edited, so a dirty editable means a write.
+	nothingWritten := len(opts.Assets) > 0 && !editable.Dirty() && !opts.hasDeferredEdits()
+	if !nothingWritten {
+		for _, editedIssueURL := range editedIssueURLs {
+			fmt.Fprintln(opts.IO.Out, editedIssueURL)
+		}
 	}
 
 	// Print a sorted list of failures to stderr.
@@ -451,10 +536,12 @@ func editRun(opts *EditOptions) error {
 	}
 
 	if len(failedIssueErrors) > 0 {
-		return fmt.Errorf("failed to update %s", text.Pluralize(len(failedIssueErrors), "issue"))
+		// A failed upload and a failed write have different remedies, so the
+		// write failure cannot stand in for both.
+		return errors.Join(uploadErr, fmt.Errorf("failed to update %s", text.Pluralize(len(failedIssueErrors), "issue")))
 	}
 
-	return nil
+	return uploadErr
 }
 
 // lookupIssueTypeID resolves the chosen issue type to its node ID using the

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -5,13 +5,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/attachments"
+	"github.com/cli/cli/v2/internal/config"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -30,13 +36,21 @@ func TestNewCmdEdit(t *testing.T) {
 	err := os.WriteFile(tmpFile, []byte("a body from file"), 0600)
 	require.NoError(t, err)
 
+	tmpImage := filepath.Join(t.TempDir(), "shot.png")
+	require.NoError(t, os.WriteFile(tmpImage, []byte("the bytes"), 0600))
+
 	tests := []struct {
 		name             string
 		input            string
 		stdin            string
 		output           EditOptions
 		expectedBaseRepo ghrepo.Interface
+		wantAssetPaths   []string
 		wantsErr         bool
+		wantsErrMsg      string
+		// wantErrIsNotExist covers an error whose text the operating system
+		// words differently, so the assertion cannot be on the message.
+		wantErrIsNotExist bool
 	}{
 		{
 			name:     "no argument",
@@ -384,6 +398,43 @@ func TestNewCmdEdit(t *testing.T) {
 				RemoveBlocking: []string{"300"},
 			},
 		},
+		{
+			name:  "attach flag",
+			input: fmt.Sprintf("23 --attach '%s'", tmpImage),
+			output: EditOptions{
+				IssueNumbers: []int{23},
+				Interactive:  false,
+			},
+			wantAssetPaths: []string{tmpImage},
+		},
+		{
+			name:  "attach flag beside another edit flag",
+			input: fmt.Sprintf("23 --add-label bug --attach '%s'", tmpImage),
+			output: EditOptions{
+				IssueNumbers: []int{23},
+				Interactive:  false,
+				Editable: prShared.Editable{
+					Labels: prShared.EditableSlice{
+						Add:    []string{"bug"},
+						Edited: true,
+					},
+				},
+			},
+			wantAssetPaths: []string{tmpImage},
+		},
+		{
+			name:        "attach flag with more than one issue",
+			input:       fmt.Sprintf("23 34 --attach '%s'", tmpImage),
+			wantsErr:    true,
+			wantsErrMsg: "`--attach` cannot be used when editing multiple issues",
+		},
+		{
+			name:              "attach flag naming a file that does not exist",
+			input:             "23 --attach ./nope.png",
+			wantsErr:          true,
+			wantsErrMsg:       "./nope.png: ",
+			wantErrIsNotExist: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -418,6 +469,14 @@ func TestNewCmdEdit(t *testing.T) {
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
 				require.Error(t, err)
+				if tt.wantsErrMsg != "" {
+					if tt.wantErrIsNotExist {
+						require.ErrorIs(t, err, fs.ErrNotExist)
+						require.ErrorContains(t, err, tt.wantsErrMsg)
+					} else {
+						require.EqualError(t, err, tt.wantsErrMsg)
+					}
+				}
 				return
 			}
 
@@ -433,6 +492,13 @@ func TestNewCmdEdit(t *testing.T) {
 			assert.Equal(t, tt.output.RemoveBlockedBy, gotOpts.RemoveBlockedBy)
 			assert.Equal(t, tt.output.AddBlocking, gotOpts.AddBlocking)
 			assert.Equal(t, tt.output.RemoveBlocking, gotOpts.RemoveBlocking)
+
+			var assetPaths []string
+			for _, a := range gotOpts.Assets {
+				assetPaths = append(assetPaths, a.Path())
+			}
+			assert.Equal(t, tt.wantAssetPaths, assetPaths)
+
 			if tt.expectedBaseRepo != nil {
 				baseRepo, err := gotOpts.BaseRepo()
 				require.NoError(t, err)
@@ -448,12 +514,24 @@ func TestNewCmdEdit(t *testing.T) {
 
 func Test_editRun(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     *EditOptions
-		httpStubs func(*testing.T, *httpmock.Registry)
-		stdout    string
-		stderr    string
-		wantErr   bool
+		name       string
+		input      *EditOptions
+		httpStubs  func(*testing.T, *httpmock.Registry)
+		attach     []string
+		host       string
+		hostTokens map[string]string
+		uploads    []attachments.UploadStub
+		// The lookup builds its field list from a set, so the order varies and
+		// a row cannot assert the whole query.
+		wantLookupSelections   []string
+		wantNoLookupSelections []string
+		stdout                 string
+		stderr                 string
+		wantErr                bool
+		wantErrMsg             string
+		// Used instead of wantErrMsg when the subject is which errors survive,
+		// leaving their wording to the layer that formats them.
+		wantErrContains []string
 	}{
 		{
 			name: "non-interactive",
@@ -1240,6 +1318,350 @@ func Test_editRun(t *testing.T) {
 				https://github.com/OWNER/REPO/issue/456
 			`),
 		},
+		{
+			name: "attaching with no body flag keeps the body already on the issue",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				mockIssueUpdateWithBody(t, reg, "the original body\n\n![shot](https://example.com/1)")
+			},
+			stdout: "https://github.com/OWNER/REPO/issue/123\n",
+		},
+		{
+			name: "a body flag replaces the body the attachment is then appended to",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				Editable: prShared.Editable{
+					Body: prShared.EditableString{
+						Value:  "a new body",
+						Edited: true,
+					},
+				},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				mockIssueUpdateWithBody(t, reg, "a new body\n\n![shot](https://example.com/1)")
+			},
+			stdout: "https://github.com/OWNER/REPO/issue/123\n",
+		},
+		{
+			name: "an empty body flag clears the body and leaves the attachment",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				Editable: prShared.Editable{
+					Body: prShared.EditableString{
+						Value:  "",
+						Edited: true,
+					},
+				},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				mockIssueUpdateWithBody(t, reg, "![shot](https://example.com/1)")
+			},
+			stdout: "https://github.com/OWNER/REPO/issue/123\n",
+		},
+		{
+			name: "a run that attaches nothing does not write the body",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				Editable: prShared.Editable{
+					Title: prShared.EditableString{
+						Value:  "a new title",
+						Edited: true,
+					},
+				},
+				FetchOptions: prShared.FetchOptions,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				reg.Register(
+					httpmock.GraphQL(`mutation IssueUpdate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "updateIssue": { "__typename": "" } } }`,
+						func(inputs map[string]interface{}) {
+							assert.NotContains(t, inputs, "body")
+						}),
+				)
+			},
+			stdout: "https://github.com/OWNER/REPO/issue/123\n",
+		},
+		{
+			name: "a permission that cannot upload fails before the write",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach: []string{"shot.png"},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "READ")
+				reg.Exclude(t, httpmock.GraphQL(`mutation IssueUpdate\b`))
+			},
+			wantErr:    true,
+			wantErrMsg: "attaching files requires write access to the repository",
+		},
+		{
+			name: "a missing repository id fails before the write",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach: []string{"shot.png"},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 0, "WRITE")
+				reg.Exclude(t, httpmock.GraphQL(`mutation IssueUpdate\b`))
+			},
+			wantErr:    true,
+			wantErrMsg: "could not determine which repository to attach files to",
+		},
+		{
+			name: "attaching asks the issue lookup for the repository fields",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				mockIssueUpdate(t, reg)
+			},
+			wantLookupSelections: []string{"databaseId", "viewerPermission"},
+			stdout:               "https://github.com/OWNER/REPO/issue/123\n",
+		},
+		{
+			name: "the lookup does not ask for the repository fields without an attachment",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				Editable: prShared.Editable{
+					Title: prShared.EditableString{
+						Value:  "a new title",
+						Edited: true,
+					},
+				},
+				FetchOptions: prShared.FetchOptions,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGet(t, reg)
+				mockIssueUpdate(t, reg)
+			},
+			wantNoLookupSelections: []string{"databaseId", "viewerPermission"},
+			stdout:                 "https://github.com/OWNER/REPO/issue/123\n",
+		},
+		{
+			name: "a partial upload writes the body so the uploaded asset is not orphaned",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach: []string{"first.png", "second.png"},
+			uploads: []attachments.UploadStub{
+				{Name: "first.png", Status: 201, Body: `{"url":"https://example.com/1"}`},
+				{Name: "second.png", Status: 404, Body: `{}`},
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				mockIssueUpdateWithBody(t, reg, "the original body\n\n![first](https://example.com/1)")
+			},
+			stdout:          "https://github.com/OWNER/REPO/issue/123\n",
+			wantErr:         true,
+			wantErrContains: []string{"./second.png"},
+		},
+		{
+			name: "a sole failed upload does not write the body",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 404, Body: `{}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				reg.Exclude(t, httpmock.GraphQL(`mutation IssueUpdate\b`))
+			},
+			wantErr:         true,
+			wantErrContains: []string{"./shot.png"},
+		},
+		{
+			name: "a body that fails validation is left alone",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach: []string{"clip.mp4"},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "![clip][ref]\n\n[ref]: ./clip.mp4", 1234, "WRITE")
+				reg.Exclude(t, httpmock.REST("POST", "user-attachments/assets"))
+				reg.Exclude(t, httpmock.GraphQL(`mutation IssueUpdate\b`))
+			},
+			wantErr:         true,
+			wantErrContains: []string{"cannot embed a video as a reference-style image"},
+		},
+		{
+			name: "a body flag is not written on its own when nothing uploaded",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				Editable: prShared.Editable{
+					Body: prShared.EditableString{
+						Value:  "See below",
+						Edited: true,
+					},
+				},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 404, Body: `{}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				reg.Exclude(t, httpmock.GraphQL(`mutation IssueUpdate\b`))
+			},
+			wantErr:         true,
+			wantErrContains: []string{"./shot.png"},
+		},
+		{
+			name: "another field is written when nothing uploaded",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				Editable: prShared.Editable{
+					Title: prShared.EditableString{
+						Value:  "a new title",
+						Edited: true,
+					},
+				},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 404, Body: `{}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				reg.Register(
+					httpmock.GraphQL(`mutation IssueUpdate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "updateIssue": { "__typename": "" } } }`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, "a new title", inputs["title"])
+							assert.NotContains(t, inputs, "body")
+						}),
+				)
+			},
+			stdout:          "https://github.com/OWNER/REPO/issue/123\n",
+			wantErr:         true,
+			wantErrContains: []string{"./shot.png"},
+		},
+		{
+			name: "a deferred edit is written when nothing uploaded",
+			input: &EditOptions{
+				Detector:        &fd.EnabledDetectorMock{},
+				IssueNumbers:    []int{123},
+				RemoveIssueType: true,
+				FetchOptions:    prShared.FetchOptions,
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 404, Body: `{}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				reg.Exclude(t, httpmock.GraphQL(`mutation IssueUpdate\b`))
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateIssueIssueType\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "updateIssueIssueType": { "issue": { "id": "123" } } } }`,
+						func(inputs map[string]interface{}) {}),
+				)
+			},
+			stdout:          "https://github.com/OWNER/REPO/issue/123\n",
+			wantErr:         true,
+			wantErrContains: []string{"./shot.png"},
+		},
+		{
+			name: "an interactive run that edits nothing still reports the issue",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				Interactive:  true,
+				FieldsToEditSurvey: func(p prShared.EditPrompter, eo *prShared.Editable) error {
+					return nil
+				},
+				EditFieldsSurvey: func(p prShared.EditPrompter, eo *prShared.Editable, _ string) error {
+					return nil
+				},
+				DetermineEditor: func() (string, error) { return "vim", nil },
+				FetchOptions:    prShared.FetchOptions,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGet(t, reg)
+				reg.Exclude(t, httpmock.GraphQL(`mutation IssueUpdate\b`))
+			},
+			stdout: "https://github.com/OWNER/REPO/issue/123\n",
+		},
+		{
+			name: "the token comes from the host the issue was fetched from",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach: []string{"shot.png"},
+			// A ghe.com tenant rather than a GHES host, which NewUploader
+			// refuses before it looks at the token at all.
+			host:       "acme.ghe.com",
+			hostTokens: map[string]string{"github.com": "ghs_anactionstoken", "acme.ghe.com": "gho_atenanttoken"},
+			uploads:    []attachments.UploadStub{{Name: "shot.png", Status: 201, Body: `{"url":"https://example.com/1"}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				mockIssueUpdateWithBody(t, reg, "the original body\n\n![shot](https://example.com/1)")
+			},
+			stdout: "https://github.com/OWNER/REPO/issue/123\n",
+		},
+		{
+			name: "a failed write does not swallow a failed upload",
+			input: &EditOptions{
+				Detector:     &fd.EnabledDetectorMock{},
+				IssueNumbers: []int{123},
+				Editable: prShared.Editable{
+					Title: prShared.EditableString{
+						Value:  "a new title",
+						Edited: true,
+					},
+				},
+				FetchOptions: prShared.FetchOptions,
+			},
+			attach:  []string{"shot.png"},
+			uploads: []attachments.UploadStub{{Name: "shot.png", Status: 413, Body: `{}`}},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockIssueGetWithRepository(reg, "the original body", 1234, "WRITE")
+				reg.Register(
+					httpmock.GraphQL(`mutation IssueUpdate\b`),
+					httpmock.StatusStringResponse(500, `{}`),
+				)
+			},
+			stderr:          `failed to update https://github\.com/OWNER/REPO/issue/123`,
+			wantErr:         true,
+			wantErrContains: []string{"./shot.png", "failed to update 1 issue"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1248,32 +1670,131 @@ func Test_editRun(t *testing.T) {
 			ios.SetStdinTTY(true)
 			ios.SetStderrTTY(true)
 
+			host := tt.host
+			if host == "" {
+				host = "github.com"
+			}
+
 			reg := &httpmock.Registry{}
 			defer reg.Verify(t)
+			for _, u := range tt.uploads {
+				attachments.StubUploadToHost(t, reg, "uploads."+host, 1234, u.Name, u.Status, u.Body)
+			}
 			tt.httpStubs(t, reg)
 
-			httpClient := func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
-			baseRepo := func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil }
+			recorder := &graphQLRecorder{inner: reg}
+			httpClient := func() (*http.Client, error) {
+				return &http.Client{Transport: recorder}, nil
+			}
+			baseRepo := func() (ghrepo.Interface, error) {
+				return ghrepo.NewWithHost("OWNER", "REPO", host), nil
+			}
 
 			tt.input.IO = ios
 			tt.input.HttpClient = httpClient
 			tt.input.BaseRepo = baseRepo
 
+			// NewTestAssets moves into a temporary directory, so it runs before
+			// anything else reads a relative path.
+			if len(tt.attach) > 0 {
+				tt.input.Assets = attachments.NewTestAssets(t, tt.attach...)
+			}
+
+			hostTokens := tt.hostTokens
+			if hostTokens == nil {
+				hostTokens = map[string]string{host: "gho_atokenthatcanupload"}
+			}
+			tt.input.Config = func() (gh.Config, error) {
+				return config.NewMockConfigFromString(hostsConfig(hostTokens)), nil
+			}
+
 			err := editRun(tt.input)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
+				if tt.wantErrMsg != "" {
+					require.EqualError(t, err, tt.wantErrMsg)
+				}
+				for _, substring := range tt.wantErrContains {
+					assert.ErrorContains(t, err, substring)
+				}
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tt.stdout, stdout.String())
 			// Use regex match since mock errors and service errors will differ.
 			assert.Regexp(t, tt.stderr, stderr.String())
+
+			queries := recorder.recorded()
+			for _, selection := range tt.wantLookupSelections {
+				assert.Contains(t, queries, selection)
+			}
+			for _, selection := range tt.wantNoLookupSelections {
+				assert.NotContains(t, queries, selection)
+			}
 		})
 	}
 }
 
+// graphQLRecorder records the GraphQL queries a run sends, then delegates to
+// the registry it wraps. A run can look up several things at once, so the
+// mutex guards the recorded queries against concurrent requests.
+type graphQLRecorder struct {
+	inner http.RoundTripper
+
+	mu      sync.Mutex
+	queries []string
+}
+
+func (g *graphQLRecorder) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil && strings.HasSuffix(req.URL.Path, "/graphql") {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body = io.NopCloser(bytes.NewReader(body))
+		g.mu.Lock()
+		g.queries = append(g.queries, string(body))
+		g.mu.Unlock()
+	}
+	return g.inner.RoundTrip(req)
+}
+
+// recorded returns every query seen so far, joined for substring matching.
+func (g *graphQLRecorder) recorded() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return strings.Join(g.queries, "\n")
+}
+
+// hostsConfig renders a config holding one token per host.
+func hostsConfig(tokens map[string]string) string {
+	var b strings.Builder
+	b.WriteString("hosts:\n")
+	for host, token := range tokens {
+		fmt.Fprintf(&b, "  %s:\n    user: monalisa\n    oauth_token: %s\n", host, token)
+	}
+	return b.String()
+}
+
 func mockIssueGet(_ *testing.T, reg *httpmock.Registry) {
 	mockIssueNumberGet(nil, reg, 123)
+}
+
+// mockIssueGetWithRepository stubs the issue lookup with a body and the two
+// repository fields the uploader reads. A row states both, so an empty
+// permission is a value a row can ask for.
+func mockIssueGetWithRepository(reg *httpmock.Registry, body string, databaseID int64, viewerPermission string) {
+	reg.Register(
+		httpmock.GraphQL(`query IssueByNumber\b`),
+		httpmock.StringResponse(fmt.Sprintf(`
+			{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
+				"id": "123",
+				"number": 123,
+				"url": "https://github.com/OWNER/REPO/issue/123",
+				"body": %s,
+				"repository": { "databaseId": %d, "viewerPermission": %s }
+			} } } }`, strconv.Quote(body), databaseID, strconv.Quote(viewerPermission))),
+	)
 }
 
 func mockIssueNumberGet(_ *testing.T, reg *httpmock.Registry, number int) {
@@ -1419,6 +1940,19 @@ func mockIssueUpdate(t *testing.T, reg *httpmock.Registry) {
 		httpmock.GraphQLMutation(`
 				{ "data": { "updateIssue": { "__typename": "" } } }`,
 			func(inputs map[string]interface{}) {}),
+	)
+}
+
+// mockIssueUpdateWithBody stubs the issue update and asserts the body it
+// carries.
+func mockIssueUpdateWithBody(t *testing.T, reg *httpmock.Registry, wantBody string) {
+	reg.Register(
+		httpmock.GraphQL(`mutation IssueUpdate\b`),
+		httpmock.GraphQLMutation(`
+				{ "data": { "updateIssue": { "__typename": "" } } }`,
+			func(inputs map[string]interface{}) {
+				assert.Equal(t, wantBody, inputs["body"])
+			}),
 	)
 }
 


### PR DESCRIPTION
Part of the pull request stack tracked in #14186.

### Description

This is the top of the stack. It adds `--attach` to `gh issue create` and `gh issue edit`, one commit each.

```
gh issue edit 12 --attach ./repro.png
```

On create the body can come from `--body`, from `--body-file`, from standard input, or from a text editor. A reference written in the editor is rewritten exactly like one passed by flag. `--attach` with `--web` is refused.

On edit, using only `--attach` keeps the existing body and appends the file below it, and a reference already in the body is rewritten in place instead.

Editing more than one issue at once with `--attach` is refused, since one upload would have to be shared across several bodies.

### How did you test this change?

Both commands were exercised by hand against a private test repository. That covered an issue created with an image, one created with a video, one created from a body file, and one created through the editor where the reference in the editor text was rewritten in place.

On edit it covered appending to an existing body, and editing where the reference already in the body was rewritten. Both refused flag combinations were checked.

### Key points

The editor path is worth knowing about. The body a user types into their editor is treated the same as one passed on the command line, so a reference written there is rewritten too.

### Notes for reviewers

With this merged the flag is available on all six commands: `gh issue comment`, `gh pr comment`, `gh issue create`, `gh pr create`, `gh issue edit` and `gh pr edit`.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @BagToad will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
