### PR TITLE
Adapt spinner output for invoking agents

### DIFF
--- a/acceptance/testdata/telemetry/agent-dimensions.txtar
+++ b/acceptance/testdata/telemetry/agent-dimensions.txtar
@@ -1,0 +1,8 @@
+# Telemetry log mode records the invoking agent and adapted spinner state
+env GH_TELEMETRY=log
+env GH_TELEMETRY_SAMPLE_RATE=100
+env AI_AGENT=some-agent
+
+exec gh version
+stderr '"agent": "some-agent"'
+stderr '"spinner_disabled": "true"'

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -53,6 +53,7 @@ func Main() exitCode {
 	buildDate := build.Date
 	buildVersion := build.Version
 	hasDebug, _ := utils.IsDebugEnabled()
+	invokingAgent := agents.Detect()
 
 	cfg, cfgErr := config.NewConfig()
 	if cfgErr != nil {
@@ -62,7 +63,7 @@ func Main() exitCode {
 
 	var ioStreams *iostreams.IOStreams
 	if cfgErr == nil {
-		ioStreams = newIOStreams(cfg)
+		ioStreams = newIOStreams(cfg, invokingAgent)
 	} else {
 		ioStreams = iostreams.System()
 	}
@@ -73,7 +74,7 @@ func Main() exitCode {
 	additionalCommonDimensions := ghtelemetry.Dimensions{
 		"version":             strings.TrimPrefix(buildVersion, "v"),
 		"is_tty":              strconv.FormatBool(ioStreams.IsStdoutTTY()),
-		"agent":               string(agents.Detect()),
+		"agent":               string(invokingAgent),
 		"ci":                  strconv.FormatBool(ci.IsCI()),
 		"github_actions":      strconv.FormatBool(ci.IsGitHubActions()),
 		"accessible_colors":   strconv.FormatBool(ioStreams.AccessibleColorsEnabled()),
@@ -129,7 +130,7 @@ func Main() exitCode {
 	}
 	defer telemetryService.Flush()
 
-	cmdFactory := factory.New(buildVersion, string(agents.Detect()), cfgFunc, ioStreams, ghExecutablePath, telemetryService)
+	cmdFactory := factory.New(buildVersion, string(invokingAgent), cfgFunc, ioStreams, ghExecutablePath, telemetryService)
 
 	if cfgErr == nil {
 		var m migration.MultiAccount
@@ -346,7 +347,7 @@ func isUnderHomebrew(ghBinary string) bool {
 	return strings.HasPrefix(ghBinary, brewBinPrefix)
 }
 
-func newIOStreams(cfg gh.Config) *iostreams.IOStreams {
+func newIOStreams(cfg gh.Config, invokingAgent agents.AgentName) *iostreams.IOStreams {
 	io := iostreams.System()
 
 	if _, ghPromptDisabled := os.LookupEnv("GH_PROMPT_DISABLED"); ghPromptDisabled {
@@ -378,7 +379,9 @@ func newIOStreams(cfg gh.Config) *iostreams.IOStreams {
 		if !slices.Contains(falseyValues, ghSpinnerDisabledValue) {
 			io.SetSpinnerDisabled(true)
 		}
-	} else if spinnerDisabled := cfg.Spinner(""); spinnerDisabled.Value == "disabled" {
+	} else if invokingAgent != "" {
+		io.SetSpinnerDisabled(true)
+	} else if spinner := cfg.Spinner(""); spinner.Value == "disabled" {
 		io.SetSpinnerDisabled(true)
 	}
 

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/agents"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	ghmock "github.com/cli/cli/v2/internal/gh/mock"
@@ -144,7 +145,7 @@ func Test_newIOStreams_pager(t *testing.T) {
 			} else {
 				cfg = config.NewMockConfig()
 			}
-			io := newIOStreams(cfg)
+			io := newIOStreams(cfg, "")
 			assert.Equal(t, tt.wantPager, io.GetPager())
 		})
 	}
@@ -185,7 +186,7 @@ func Test_newIOStreams_prompt(t *testing.T) {
 			} else {
 				cfg = config.NewMockConfig()
 			}
-			io := newIOStreams(cfg)
+			io := newIOStreams(cfg, "")
 			assert.Equal(t, tt.promptDisabled, io.GetNeverPrompt())
 		})
 	}
@@ -195,12 +196,18 @@ func Test_newIOStreams_spinnerDisabled(t *testing.T) {
 	tests := []struct {
 		name            string
 		config          gh.Config
+		invokingAgent   agents.AgentName
 		spinnerDisabled bool
 		env             map[string]string
 	}{
 		{
 			name:            "default config",
 			spinnerDisabled: false,
+		},
+		{
+			name:            "agent detected",
+			invokingAgent:   "some-agent",
+			spinnerDisabled: true,
 		},
 		{
 			name:            "config with spinner disabled",
@@ -213,12 +220,30 @@ func Test_newIOStreams_spinnerDisabled(t *testing.T) {
 			spinnerDisabled: false,
 		},
 		{
+			name:            "agent overrides config enabled",
+			config:          enableSpinnersConfig(),
+			invokingAgent:   "some-agent",
+			spinnerDisabled: true,
+		},
+		{
+			name:            "config disabled with agent",
+			config:          disableSpinnersConfig(),
+			invokingAgent:   "some-agent",
+			spinnerDisabled: true,
+		},
+		{
 			name:            "spinner disabled via GH_SPINNER_DISABLED env var = 0",
 			env:             map[string]string{"GH_SPINNER_DISABLED": "0"},
 			spinnerDisabled: false,
 		},
 		{
 			name:            "spinner disabled via GH_SPINNER_DISABLED env var = false",
+			env:             map[string]string{"GH_SPINNER_DISABLED": "false"},
+			spinnerDisabled: false,
+		},
+		{
+			name:            "GH_SPINNER_DISABLED false overrides agent",
+			invokingAgent:   "some-agent",
 			env:             map[string]string{"GH_SPINNER_DISABLED": "false"},
 			spinnerDisabled: false,
 		},
@@ -261,7 +286,7 @@ func Test_newIOStreams_spinnerDisabled(t *testing.T) {
 			} else {
 				cfg = config.NewMockConfig()
 			}
-			io := newIOStreams(cfg)
+			io := newIOStreams(cfg, tt.invokingAgent)
 			assert.Equal(t, tt.spinnerDisabled, io.GetSpinnerDisabled())
 		})
 	}
@@ -327,7 +352,7 @@ func Test_newIOStreams_accessiblePrompterEnabled(t *testing.T) {
 			} else {
 				cfg = config.NewMockConfig()
 			}
-			io := newIOStreams(cfg)
+			io := newIOStreams(cfg, "")
 			assert.Equal(t, tt.accessiblePrompterEnabled, io.AccessiblePrompterEnabled())
 		})
 	}
@@ -403,7 +428,7 @@ func Test_newIOStreams_colorLabels(t *testing.T) {
 			} else {
 				cfg = config.NewMockConfig()
 			}
-			io := newIOStreams(cfg)
+			io := newIOStreams(cfg, "")
 			assert.Equal(t, tt.colorLabelsEnabled, io.ColorLabels())
 		})
 	}

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -279,6 +279,10 @@ func Test_newIOStreams_spinnerDisabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv registers the cleanup that restores the caller's environment;
+			// os.Unsetenv then clears the variable outright. Both are needed because
+			// newIOStreams branches on os.LookupEnv, so leaving GH_SPINNER_DISABLED
+			// set-but-empty would take the env branch and never reach agent or config.
 			t.Setenv("GH_SPINNER_DISABLED", "")
 			require.NoError(t, os.Unsetenv("GH_SPINNER_DISABLED"))
 			for k, v := range tt.env {

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/cli/cli/v2/api"
@@ -17,6 +18,7 @@ import (
 	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_printError(t *testing.T) {
@@ -277,6 +279,8 @@ func Test_newIOStreams_spinnerDisabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GH_SPINNER_DISABLED", "")
+			require.NoError(t, os.Unsetenv("GH_SPINNER_DISABLED"))
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}


### PR DESCRIPTION
Closes cli/cli#12839
Related to cli/cli#12522

### Description

`gh` already detects when it is invoked by an AI coding agent, but detection happened after IOStreams initialization and was repeated for telemetry and HTTP setup.

This change detects the invoking agent once during startup and shares that result with IOStreams, telemetry, and the command factory. When an agent is detected, animated braille spinners use the existing text-only progress indicator instead.

`GH_SPINNER_DISABLED` remains the highest-precedence override, including falsey values that explicitly restore animated spinners.

### How did you test this change?

Manually exercised a spinner-producing command under a real PTY:

- Without an agent environment variable, the animated braille spinner appeared.
- With `AI_AGENT` or `CLAUDECODE`, `Working...` appeared without braille animation.
- With an agent and `GH_SPINNER_DISABLED=false`, animated braille was restored.
- With piped or non-TTY output, no progress indicator appeared.

### Key points

- Spinner precedence is environment override, detected agent, then configuration.
- The existing agent detector remains the single source of truth.
- The detected value is stored on the existing command factory for downstream output adaptations.
- No-agent and non-TTY behavior remains unchanged.

### Notes for reviewers

Start with `internal/ghcmd/cmd.go`, where detection moves ahead of IOStreams initialization and spinner precedence is applied.

`internal/ghcmd/cmd_test.go` covers precedence and environment isolation. `acceptance/testdata/telemetry/agent-dimensions.txtar` verifies the complete startup path.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @niik will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.