### PR TITLE
Accept pre-release tags in deployment validation

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -16,7 +16,7 @@ on:
       tag_name:
         required: true
         type: string
-        description: "The tag name for the release (e.g. v2.100.0)."
+        description: "The tag name for the release (e.g. v2.100.0, or v2.100.0-rc.1 for a pre-release)."
       environment:
         default: production
         type: environment
@@ -42,8 +42,9 @@ jobs:
         env:
           TAG_NAME: ${{ inputs.tag_name }}
         run: |
-          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid tag name format. Must be in the form v1.2.3"
+          # Build metadata (v1.2.3+001) is rejected: later steps detect a pre-release by its hyphen.
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Invalid tag name format. Must be in the form v1.2.3 or v1.2.3-rc.1"
             exit 1
           fi
   linux:

--- a/docs/release-process-deep-dive.md
+++ b/docs/release-process-deep-dive.md
@@ -38,18 +38,20 @@ Although this workflow is used to do our production releases for Linux, MacOS an
     runs-on: ubuntu-latest
     steps:
       - name: Validate tag name format
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
-          if [[ ! "${{ inputs.tag_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid tag name format. Must be in the form v1.2.3"
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Invalid tag name format. Must be in the form v1.2.3 or v1.2.3-rc.1"
             exit 1
           fi
 ```
 </details>
 
-The purpose of this job is to [prevent incorrectly tagged releases](https://github.com/cli/cli/pull/10121), by ensuring they conform to the `major.minor.patch` form of semantic versioning, preceded by a `v`.
+The purpose of this job is to [prevent incorrectly tagged releases](https://github.com/cli/cli/pull/10121), by ensuring they conform to the `major.minor.patch` form of semantic versioning, preceded by a `v`. An optional pre-release suffix such as `-rc.1` is allowed. Build metadata after a `+` is not, because the rest of the workflow identifies a pre-release by looking for a hyphen.
 
-> [!WARNING]
-> The `release` job can [create the GitHub release as a pre-release based on the existence of a hyphen in the tag name](https://github.com/cli/cli/blob/756f4ec04abdc9fdbab3fef35b182c546ef1dd17/.github/workflows/deployment.yml#L362-L364), but the later addition of `validate-tag-name` disallows this.
+> [!NOTE]
+> A hyphen in the tag name changes three things: the `release` job [creates the GitHub release as a pre-release](https://github.com/cli/cli/blob/756f4ec04abdc9fdbab3fef35b182c546ef1dd17/.github/workflows/deployment.yml#L362-L364), the site is not published, and the Windows MSI drops the suffix so its `ProductVersion` stays numeric.
 
 ## <a id="os-builds">[OS Builds](https://github.com/cli/cli/blob/756f4ec04abdc9fdbab3fef35b182c546ef1dd17/.github/workflows/deployment.yml#L40-L248)</a>
 


### PR DESCRIPTION
<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

The deployment workflow previously rejected any tag with a pre-release suffix. We widened the regular expression to accept an optional one:

```bash
# Before
^v[0-9]+\.[0-9]+\.[0-9]+$

# Now
^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$
```

The validator was stricter than the workflow it guards. Three existing steps already handle hyphenated pre-release tags correctly:
1. The [create the release step](https://github.com/cli/cli/blob/9d1ebccf0f216ac9921e8c3cc13da415755469a4/.github/workflows/deployment.yml#L447-L449) adds the pre-release flag.
2. The [site publish step](https://github.com/cli/cli/blob/9d1ebccf0f216ac9921e8c3cc13da415755469a4/.github/workflows/deployment.yml#L456) skips publishing the documentation site.
3. The [Windows MSI build](https://github.com/cli/cli/blob/9d1ebccf0f216ac9921e8c3cc13da415755469a4/.github/workflows/deployment.yml#L275) strips the suffix to keep the product version numeric.

We updated the release process documentation to replace an obsolete warning. That warning cautioned that the release job's pre-release behavior was unreachable because the validator blocked it.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

I extracted the validation step into a standalone script and tested it manually. I verified 22 test cases in total to exercise the full set of rules. A representative subset is below.

| Tag | Expected | Actual |
| --- | --- | --- |
| `v2.98.0` | accept | accept |
| `v2.98.0-rc.1` | accept | accept |
| `v2.98.0+build.5` | reject | reject |
| `pre-v2.98.0` | reject | reject |
| `v2.98.0-` | reject | reject |
| `v2.98` | reject | reject |
| `v2.98.0 junk` | reject | reject |
| `v2.98.0\nrm -rf /` | reject | reject |
| (empty string) | reject | reject |

The newline test case verifies that Bash anchors the string correctly instead of matching line boundaries.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

Build metadata tags like `v2.98.0+build.5` are deliberately rejected. Because they lack a hyphen, downstream steps would treat them as final releases, and the Windows MSI build would retain non-numeric characters. Rejecting plus signs avoids this conflict.

The validator accepts a leading zero in a numeric pre-release identifier, such as `v2.98.0-01`. Enforcing strict semantic versioning here would pointlessly complicate the pattern.

Both scripts that receive the raw tag were checked and needed no changes. The [release script](https://github.com/cli/cli/blob/9d1ebccf0f216ac9921e8c3cc13da415755469a4/script/release) passes the tag through unchanged. The [macOS packaging script](https://github.com/cli/cli/blob/9d1ebccf0f216ac9921e8c3cc13da415755469a4/script/pkgmacos) keeps the pre-release suffix, which is correct because `pkgbuild --version` accepts an arbitrary string.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with the validation update in the deployment workflow. The documentation change follows directly from this behavior shift.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
