### PR TITLE
pr create: Fix remote resolution with `--fill` and `--base`

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -186,9 +186,10 @@ type CreateContext struct {
 	// of PRRefs, but a huge amount of refactoring was done to introduce that struct,
 	// and this is a small price to pay for the convenience of not having to do a lot
 	// more design.
-	BaseTrackingBranch string
-	Client             *api.Client
-	GitClient          *git.Client
+	BaseTrackingBranch           string
+	fallbackBaseTrackingBranches []string
+	Client                       *api.Client
+	GitClient                    *git.Client
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
@@ -643,9 +644,23 @@ func createRun(opts *CreateOptions) error {
 var regexPattern = regexp.MustCompile(`(?m)^`)
 
 func initDefaultTitleBody(ctx CreateContext, state *shared.IssueMetadataState, useFirstCommit bool, addBody bool) error {
-	commits, err := ctx.GitClient.Commits(context.Background(), ctx.BaseTrackingBranch, ctx.PRRefs.UnqualifiedHeadRef())
-	if err != nil {
-		return err
+	var commits []*git.Commit
+	var firstErr error
+	var succeeded bool
+	baseTrackingBranches := append([]string{ctx.BaseTrackingBranch}, ctx.fallbackBaseTrackingBranches...)
+	for _, baseTrackingBranch := range baseTrackingBranches {
+		var err error
+		commits, err = ctx.GitClient.Commits(context.Background(), baseTrackingBranch, ctx.PRRefs.UnqualifiedHeadRef())
+		if err == nil {
+			succeeded = true
+			break
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if !succeeded {
+		return firstErr
 	}
 
 	if len(commits) == 1 || useFirstCommit {
@@ -743,27 +758,66 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 	// This closure provides an easy way to instantiate a CreateContext with everything other than
 	// the refs. This probably indicates that CreateContext could do with some rework, but the refactor
 	// to introduce PRRefs is already large enough.
-	var newCreateContext = func(refs creationRefs) *CreateContext {
-		baseTrackingBranch := refs.BaseRef()
+	var newCreateContext = func(refs creationRefs, baseTrackingBranches []string) *CreateContext {
+		return &CreateContext{
+			ResolvedRemotes:              resolvedRemotes,
+			Client:                       client,
+			GitClient:                    opts.GitClient,
+			PRRefs:                       refs,
+			BaseTrackingBranch:           baseTrackingBranches[0],
+			fallbackBaseTrackingBranches: baseTrackingBranches[1:],
+		}
+	}
 
-		// The baseTrackingBranch is used later for a command like:
-		// `git commit upstream/main feature` in order to create a PR message showing the commits
-		// between these two refs. I'm not really sure what is expected to happen if we don't have a remote,
-		// which seems like it would be possible with a command `gh pr create --repo owner/repo-that-is-not-a-remote`.
-		// In that case, we might just have a mess? In any case, this is what the old code did, so I don't want to change
-		// it as part of an already large refactor.
+	resolveBase := func(base string) (*api.Repository, string, []string, error) {
+		owner, branch, qualified := strings.Cut(base, ":")
+		if qualified {
+			if owner == "" || branch == "" || strings.Contains(branch, ":") {
+				return nil, "", nil, fmt.Errorf("invalid qualified base ref format %q", base)
+			}
+
+			var trackingBranches []string
+			var baseRemote *ghContext.Remote
+			for _, remote := range remotes {
+				if strings.EqualFold(remote.RepoOwner(), owner) &&
+					strings.EqualFold(remote.RepoHost(), baseRepo.RepoHost()) {
+					if baseRemote == nil {
+						baseRemote = remote
+					}
+					trackingBranches = append(trackingBranches, fmt.Sprintf("%s/%s", remote.Name, branch))
+				}
+			}
+			if len(trackingBranches) == 0 {
+				return nil, "", nil, fmt.Errorf("no git remote for base repository owner %q", owner)
+			}
+			resolvedBaseRepo := baseRepo
+			if !ghrepo.IsSame(baseRemote, baseRepo) {
+				resolvedBaseRepo, err = api.GitHubRepo(client, baseRemote)
+				if err != nil {
+					return nil, "", nil, err
+				}
+			}
+			return resolvedBaseRepo, branch, trackingBranches, nil
+		}
+		branch = base
+
+		trackingBranches := make([]string, 0, len(remotes))
 		baseRemote, _ := resolvedRemotes.RemoteForRepo(baseRepo)
 		if baseRemote != nil {
-			baseTrackingBranch = fmt.Sprintf("%s/%s", baseRemote.Name, baseTrackingBranch)
+			trackingBranches = append(trackingBranches, fmt.Sprintf("%s/%s", baseRemote.Name, branch))
 		}
-
-		return &CreateContext{
-			ResolvedRemotes:    resolvedRemotes,
-			Client:             client,
-			GitClient:          opts.GitClient,
-			PRRefs:             refs,
-			BaseTrackingBranch: baseTrackingBranch,
+		for _, remote := range remotes {
+			if remote == baseRemote ||
+				!strings.EqualFold(remote.RepoName(), baseRepo.RepoName()) ||
+				!strings.EqualFold(remote.RepoHost(), baseRepo.RepoHost()) {
+				continue
+			}
+			trackingBranches = append(trackingBranches, fmt.Sprintf("%s/%s", remote.Name, branch))
 		}
+		if len(trackingBranches) == 0 {
+			trackingBranches = append(trackingBranches, branch)
+		}
+		return baseRepo, branch, trackingBranches, nil
 	}
 
 	// If the user provided a head branch we're going to use that without any interrogation
@@ -793,6 +847,10 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 		if baseBranch == "" {
 			baseBranch = baseRepo.DefaultBranchRef.Name
 		}
+		baseRepo, baseBranch, baseTrackingBranches, err := resolveBase(baseBranch)
+		if err != nil {
+			return nil, err
+		}
 
 		return newCreateContext(skipPushRefs{
 			qualifiedHeadRef: qualifiedHeadRef,
@@ -800,7 +858,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 				baseRepo:       baseRepo,
 				baseBranchName: baseBranch,
 			},
-		}), nil
+		}, baseTrackingBranches), nil
 	}
 
 	if ucc, err := opts.GitClient.UncommittedChangeCount(context.Background()); err == nil && ucc > 0 {
@@ -825,6 +883,10 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 	}
 	if baseBranch == "" {
 		baseBranch = baseRepo.DefaultBranchRef.Name
+	}
+	baseRepo, baseBranch, baseTrackingBranches, err := resolveBase(baseBranch)
+	if err != nil {
+		return nil, err
 	}
 
 	// First we check with the git information we have to see if we can figure out the default
@@ -876,7 +938,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 				return newCreateContext(skipPushRefs{
 					qualifiedHeadRef: qualifiedHeadRef,
 					baseRefs:         baseRefs,
-				}), nil
+				}, baseTrackingBranches), nil
 			}
 		}
 	}
@@ -942,7 +1004,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 			return newCreateContext(skipPushRefs{
 				qualifiedHeadRef: qualifiedHeadRef,
 				baseRefs:         baseRefs,
-			}), nil
+			}, baseTrackingBranches), nil
 		}
 	}
 
@@ -999,7 +1061,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 			headRepo:       pushableRepos[selectedOption],
 			headBranchName: currentBranch,
 			baseRefs:       baseRefs,
-		}), nil
+		}, baseTrackingBranches), nil
 	} else if pushOptions[selectedOption] == "Skip pushing the branch" {
 		// We're going to skip pushing the branch altogether, meaning, use whatever SHA is already pushed.
 		// It's not exactly clear what repo the user expects to use here for the HEAD, and maybe we should
@@ -1008,7 +1070,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 		return newCreateContext(skipPushRefs{
 			qualifiedHeadRef: shared.NewQualifiedHeadRefWithoutOwner(currentBranch),
 			baseRefs:         baseRefs,
-		}), nil
+		}, baseTrackingBranches), nil
 	} else if pushOptions[selectedOption] == "Cancel" {
 		return nil, cmdutil.CancelError
 	} else {
@@ -1016,7 +1078,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 		return newCreateContext(forkableRefs{
 			qualifiedHeadRef: shared.NewQualifiedHeadRef(currentLogin, currentBranch),
 			baseRefs:         baseRefs,
-		}), nil
+		}, baseTrackingBranches), nil
 	}
 }
 

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1304,6 +1304,104 @@ func Test_createRun(t *testing.T) {
 			expectedErrOut: "\nCreating pull request for feature into master in OWNER/REPO\n\n",
 		},
 		{
+			name: "fill falls back to a base branch on another remote",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.Autofill = true
+				opts.HeadBranch = "feature"
+				opts.BaseBranch = "some-branch"
+				opts.Remotes = func() (context.Remotes, error) {
+					return context.Remotes{
+						{
+							Remote: &git.Remote{Name: "upstream", Resolved: "base"},
+							Repo:   ghrepo.New("OWNER", "REPO"),
+						},
+						{
+							Remote: &git.Remote{Name: "origin"},
+							Repo:   ghrepo.New("MyOrg", "REPO"),
+						},
+					}, nil
+				}
+				return func() {}
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry upstream/some-branch...feature",
+					1,
+					"fatal: ambiguous argument 'upstream/some-branch...feature': unknown revision",
+				)
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry origin/some-branch...feature",
+					0,
+					"3a9b48085046d156c5acce8f3b3a0532cd706a4a\u0000first commit of pr\u0000first commit description\u0000\n",
+				)
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createPullRequest": { "pullRequest": {
+							"URL": "https://github.com/OWNER/REPO/pull/12"
+						} } } }`,
+						func(input map[string]interface{}) {
+							assert.Equal(t, "some-branch", input["baseRefName"])
+							assert.Equal(t, "first commit of pr", input["title"])
+						}),
+				)
+			},
+			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
+			expectedErrOut: "\nCreating pull request for feature into some-branch in OWNER/REPO\n\n",
+		},
+		{
+			name: "web fill resolves a qualified base branch to its repository",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.Autofill = true
+				opts.WebMode = true
+				opts.HeadBranch = "MyOrg:wiggles/xuzt"
+				opts.BaseBranch = "MyOrg:some-branch"
+				opts.Remotes = func() (context.Remotes, error) {
+					return context.Remotes{
+						{
+							Remote: &git.Remote{Name: "upstream", Resolved: "base"},
+							Repo:   ghrepo.New("OWNER", "REPO"),
+						},
+						{
+							Remote: &git.Remote{Name: "origin"},
+							Repo:   ghrepo.New("MyOrg", "FORK"),
+						},
+					}, nil
+				}
+				return func() {}
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry origin/some-branch...wiggles/xuzt",
+					0,
+					"3a9b48085046d156c5acce8f3b3a0532cd706a4a\u0000first commit of pr\u0000first commit description\u0000\n",
+				)
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryInfo\b`),
+					httpmock.GraphQLQuery(`
+						{ "data": { "repository": {
+							"id": "MYORG_REPOID",
+							"name": "FORK",
+							"owner": {"login": "MyOrg"},
+							"defaultBranchRef": {"name": "master"},
+							"viewerPermission": "WRITE"
+						} } }`,
+						func(_ string, variables map[string]interface{}) {
+							assert.Equal(t, "MyOrg", variables["owner"])
+							assert.Equal(t, "FORK", variables["name"])
+						}),
+				)
+			},
+			expectedErrOut: "Opening https://github.com/MyOrg/FORK/compare/some-branch...MyOrg:wiggles/xuzt in your browser.\n",
+			expectedBrowse: "https://github.com/MyOrg/FORK/compare/some-branch...MyOrg:wiggles%2Fxuzt?body=first+commit+description&expand=1&title=first+commit+of+pr",
+		},
+		{
 			name: "fill-first flag provided",
 			tty:  true,
 			setup: func(opts *CreateOptions, t *testing.T) func() {


### PR DESCRIPTION
NB: This is AI generated and although I've tested it manually, I haven't read the code; it's not ready for review or submission yet.

`pr create --fill` assumed that the selected PR repository remote also contained the local tracking ref for `--base`. When that ref existed only on another remote, the generated Git log range referenced a nonexistent ref and failed before the PR could be created.

Owner-qualified bases had two related problems. The owner leaked into the Git revision, producing refs such as `upstream/MyOrg:branch`, and the owner was discarded when constructing the PR target. As a result, `--web` still opened the compare page for the default repository instead of the repository selected by `OWNER:branch`.

Build an ordered list of base tracking refs, starting with the default PR remote and falling back to other matching remotes when the Git log fails. For `OWNER:branch`, resolve the remote by owner and host, use its repository as the PR base for both API and web flows, and use the unqualified branch name for the Git comparison and GitHub request. This also supports forks whose repository name differs from the upstream repository. Preserve the original Git error when no candidate succeeds.

Add regression coverage for unqualified remote fallback and an exact owner-qualified `--web --fill` flow.
