### PR TITLE
ci: add temporary step to verify Linux repo signing keys

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -427,6 +427,34 @@ jobs:
           cp -a dists/ pool/ upload/
           mkdir -p site/packages
           cp -a upload/* site/packages/
+      # TEMPORARY: this step verifies the APT and RPM repositories are signed with the
+      # expected keys. It is intended for a one-off dry-run confirmation and will be
+      # dropped once the signing has been confirmed.
+      - name: Verify repository signatures
+        if: ${{ inputs.environment == 'production' }}
+        run: |
+          set -euo pipefail
+
+          # Start from a clean gpg database so the signing keys loaded earlier (including
+          # private key material) are gone, then import only the published public keyring
+          # and verify against that. Nothing sensitive is left in the environment afterwards.
+          rm -rf ~/.gnupg
+          gpg --batch --import site/packages/githubcli-archive-keyring.gpg >/dev/null 2>&1
+
+          # Fingerprints published in docs/install_linux.md.
+          # gpg's human-readable output goes to stderr and is discarded; only the
+          # machine-readable VALIDSIG lines (which contain public fingerprints) are grepped.
+
+          # APT repository: signed with both the old and new keys.
+          apt_status="$(gpg --batch --status-fd 1 --verify site/packages/dists/stable/Release.gpg site/packages/dists/stable/Release 2>/dev/null)"
+          echo "$apt_status" | grep -q "VALIDSIG.*2C6106201985B60E6C7AC87323F3D4EA75716059"
+          echo "$apt_status" | grep -q "VALIDSIG.*7F38BBB59D064DBCB3D84D725612B36462313325"
+
+          # RPM repository: signed with the old key.
+          rpm_status="$(gpg --batch --status-fd 1 --verify site/packages/rpm/repodata/repomd.xml.asc site/packages/rpm/repodata/repomd.xml 2>/dev/null)"
+          echo "$rpm_status" | grep -q "VALIDSIG.*2C6106201985B60E6C7AC87323F3D4EA75716059"
+
+          echo "Repository signatures verified."
       - name: Create the release
         env:
           # In non-production environments, the assets will not have been signed


### PR DESCRIPTION
### Description

Our Linux packages and repository metadata are signed with two PGP keys (fingerprints published in `docs/install_linux.md`). This adds a temporary step to the `release` job, just before "Create the release", that confirms the signing actually happened as expected: the APT repository is signed with both keys, and the RPM repository is signed with the old key.

The step wipes the local gpg database and re-imports only the published public keyring before verifying, so it never touches private key material, and it suppresses all command output so nothing sensitive can be printed. It is guarded on the production environment and meant to be run once via a dry run, then removed after confirmation.

### How did you test this change?

Triggered the `deployment.yml` workflow manually with the production environment and `dry_run: true`. The new "Verify repository signatures" step ran after reprepro/createrepo and passed, printing only "Repository signatures verified." A local check confirmed a mismatched fingerprint causes the step to fail (via `grep -q` under `set -e`).

### Key points

- Verification uses gpg's machine-readable `--status-fd 1` output grepped against literal fingerprints, rather than reusable shell helpers, to keep it easy to read.
- The step is intentionally temporary and marked as such in a comment.

### Notes for reviewers

Start at the "Verify repository signatures" step in `.github/workflows/deployment.yml`. Confirm the paths (`site/packages/dists/stable/*` and `site/packages/rpm/repodata/*`) and the expected fingerprints match our signing setup.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @babakks will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
