### PR TITLE
chore: bump go to 1.26.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cli/cli/v2
 
 go 1.26.0
 
-toolchain go1.26.6
+toolchain go1.26.7
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
### Description

Go 1.26.7 is released with 1.27. Our automatic workflow will pick up 1.27, but as it's a major version we may want to keep using 1.26 for at least one more release before bumping to that. Bumping to the latest may cause failure in CI jobs (like Golangci-lint).

### How did you test this change?

N/A

### Key points

N/A

### Notes for reviewers

N/A

### Authorship and follow-up

Who wrote this:

- [x] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @babakks will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
