### PR TITLE
fix(issue list): update limit variable on subsequent search pages

### DIFF
--- a/pkg/cmd/issue/list/http.go
+++ b/pkg/cmd/issue/list/http.go
@@ -212,7 +212,7 @@ loop:
 			break
 		}
 		variables["after"] = resp.Search.PageInfo.EndCursor
-		variables["perPage"] = min(perPage, limit-len(ic.Issues))
+		variables["limit"] = min(perPage, limit-len(ic.Issues))
 	}
 
 	return &ic, nil

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -2,8 +2,10 @@ package list
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/api"
@@ -266,4 +268,59 @@ func TestSearchIssues_rejectsPullRequestQualifiers(t *testing.T) {
 			assert.Len(t, reg.Requests, 0)
 		})
 	}
+}
+
+func TestSearchIssues_pagination(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	firstPageNodes := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		firstPageNodes[i] = fmt.Sprintf(`{"number": %d}`, i+1)
+	}
+
+	reg.Register(
+		httpmock.GraphQL(`query IssueSearch\b`),
+		httpmock.GraphQLQuery(fmt.Sprintf(`{
+			"data": {
+				"repository": { "hasIssuesEnabled": true },
+				"search": {
+					"issueCount": 150,
+					"nodes": [%s],
+					"pageInfo": { "hasNextPage": true, "endCursor": "ENDCURSOR" }
+				}
+			}
+		}`, strings.Join(firstPageNodes, ",")), func(query string, vars map[string]interface{}) {
+			assert.Equal(t, float64(100), vars["limit"])
+			assert.Nil(t, vars["after"])
+		}))
+
+	reg.Register(
+		httpmock.GraphQL(`query IssueSearch\b`),
+		httpmock.GraphQLQuery(`{
+			"data": {
+				"repository": { "hasIssuesEnabled": true },
+				"search": {
+					"issueCount": 150,
+					"nodes": [ { "number": 101 } ],
+					"pageInfo": { "hasNextPage": false, "endCursor": "ENDCURSOR2" }
+				}
+			}
+		}`, func(query string, vars map[string]interface{}) {
+			assert.Equal(t, float64(50), vars["limit"])
+			assert.Equal(t, "ENDCURSOR", vars["after"])
+		}))
+
+	httpClient := &http.Client{Transport: reg}
+	client := api.NewClientFromHTTP(httpClient)
+
+	res, err := searchIssues(
+		client,
+		fd.AdvancedIssueSearchSupportedAsOnlyBackend(),
+		ghrepo.New("OWNER", "REPO"),
+		prShared.FilterOptions{Search: "is:open"},
+		150,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, 101, len(res.Issues))
 }


### PR DESCRIPTION
Fixes #13906

### Summary
When paginating through issue search results (e.g. `gh issue list --search "..." --limit 150`), `searchIssues` in `pkg/cmd/issue/list/http.go` calculated the remaining page size reduction into `variables["perPage"]`.

Because the GraphQL operation `IssueSearch` declares `$limit`, `variables["limit"]` remained unchanged at `100`, causing every subsequent page to request 100 items instead of the remaining needed items.

### Changes
- Updated `pkg/cmd/issue/list/http.go` to assign the reduced page limit directly to `variables["limit"]`, matching `listIssues` and `pr list`.
- Added `TestSearchIssues_pagination` in `pkg/cmd/issue/list/http_test.go` asserting that a 2-page search with limit 150 sends `$limit: 50` on the second request.

### Verification
Ran `go test -v ./pkg/cmd/issue/list/...`:
```text
=== RUN   TestSearchIssues_pagination
--- PASS: TestSearchIssues_pagination (0.00s)
PASS
ok      github.com/cli/cli/v2/pkg/cmd/issue/list    0.066s
```