### PR TITLE
Fix issue triage action compatibility [skip changelog]

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -58,7 +58,7 @@
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
 #   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - github/gh-aw-actions/setup@6aab9e5b5c91c615506061f09bedd81a23babe3c # v0.86.2
+#   - github/gh-aw-actions/setup@2709137ea6c5b0e19aa621454dc643ea8dc526b1 # v0.85.4
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.27.44@sha256:0d727725c737b58c7bdf51f640cffb928385ec46517e0917c7f1a02f1bada8b4
@@ -126,7 +126,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@6aab9e5b5c91c615506061f09bedd81a23babe3c # v0.86.2
+        uses: github/gh-aw-actions/setup@2709137ea6c5b0e19aa621454dc643ea8dc526b1 # v0.85.4
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -466,7 +466,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@6aab9e5b5c91c615506061f09bedd81a23babe3c # v0.86.2
+        uses: github/gh-aw-actions/setup@2709137ea6c5b0e19aa621454dc643ea8dc526b1 # v0.85.4
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1070,7 +1070,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@6aab9e5b5c91c615506061f09bedd81a23babe3c # v0.86.2
+        uses: github/gh-aw-actions/setup@2709137ea6c5b0e19aa621454dc643ea8dc526b1 # v0.85.4
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1314,7 +1314,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@6aab9e5b5c91c615506061f09bedd81a23babe3c # v0.86.2
+        uses: github/gh-aw-actions/setup@2709137ea6c5b0e19aa621454dc643ea8dc526b1 # v0.85.4
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1591,7 +1591,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@6aab9e5b5c91c615506061f09bedd81a23babe3c # v0.86.2
+        uses: github/gh-aw-actions/setup@2709137ea6c5b0e19aa621454dc643ea8dc526b1 # v0.85.4
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

Issue triage has failed on every invocation since the `gh-aw-actions/setup` dependency bump in #14147. The generated lock file was compiled by gh-aw v0.85.4 and invokes `create_prompt_first.sh`, but Dependabot changed only the setup action to v0.86.2, where that helper no longer exists. Activation therefore exits with code 127 before the agent starts.

Recompile `issue-triage` with the repository's gh-aw v0.85.4 compiler, restoring the matching v0.85.4 setup action pin.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

Given the issue-triage lock file generated by gh-aw v0.85.4,
when it uses setup action v0.86.2,
then activation fails because `create_prompt_first.sh` is absent.

Given the recompiled lock file,
when setup action v0.85.4 populates the activation scripts,
then the referenced helper is present and prompt creation can proceed.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

This intentionally rolls back only the setup action pin. A full upgrade to gh-aw v0.86.x would regenerate the entire lock file and is better handled separately.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with the setup action pins in `.github/workflows/issue-triage.lock.yml`. The first sustained failing run is https://github.com/cli/cli/actions/runs/31859145481; all 23 subsequent runs through August 19 failed before agent execution with the same missing-helper error.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @tidy-dev will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.