### PR TITLE
Reject --comments with --json

### DIFF
--- a/pkg/cmd/discussion/view/view.go
+++ b/pkg/cmd/discussion/view/view.go
@@ -152,6 +152,11 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.BaseRepo = f.BaseRepo
 
+			if err := cmdutil.MutuallyExclusive("specify only one of --comments or --json",
+				opts.Comments, opts.Exporter != nil); err != nil {
+				return err
+			}
+
 			if err := cmdutil.MutuallyExclusive("specify only one of --comments or --web",
 				opts.Comments, opts.WebMode); err != nil {
 				return err

--- a/pkg/cmd/discussion/view/view_test.go
+++ b/pkg/cmd/discussion/view/view_test.go
@@ -205,6 +205,11 @@ func TestNewCmdView(t *testing.T) {
 			wantErr: "specify only one of --comments or --web",
 		},
 		{
+			name:    "comments and JSON are mutually exclusive",
+			args:    "123 --comments --json number",
+			wantErr: "specify only one of --comments or --json",
+		},
+		{
 			name:    "order requires comments or comment arg",
 			args:    "123 --order newest",
 			wantErr: "--order requires --comments or a comment argument",

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -57,6 +57,11 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 		`, "`"),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.MutuallyExclusive("specify only one of --comments or --json",
+				opts.Comments, opts.Exporter != nil); err != nil {
+				return err
+			}
+
 			issueNumber, baseRepo, err := issueShared.ParseIssueFromArg(args[0])
 			if err != nil {
 				return err

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -60,6 +60,18 @@ func TestJSONFields(t *testing.T) {
 func TestNewCmdView(t *testing.T) {
 	// Test shared parsing of issue number / URL.
 	argparsetest.TestArgParsing(t, NewCmdView)
+
+	t.Run("comments and JSON are mutually exclusive", func(t *testing.T) {
+		cmd := NewCmdView(&cmdutil.Factory{}, func(*ViewOptions) error {
+			return nil
+		})
+		cmd.SetArgs([]string{"123", "--comments", "--json", "number"})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+
+		_, err := cmd.ExecuteC()
+		require.EqualError(t, err, "specify only one of --comments or --json")
+	})
 }
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -57,6 +57,11 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 		`, "`"),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.MutuallyExclusive("specify only one of --comments or --json",
+				opts.Comments, opts.Exporter != nil); err != nil {
+				return err
+			}
+
 			opts.Finder = shared.NewFinder(f)
 
 			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && len(args) == 0 {

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -127,6 +127,11 @@ func Test_NewCmdView(t *testing.T) {
 				Comments:    true,
 			},
 		},
+		{
+			name:    "comments and JSON are mutually exclusive",
+			args:    "123 --comments --json number",
+			wantErr: "specify only one of --comments or --json",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Fixes https://github.com/cli/cli/issues/14214

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

Passing `--comments` with `--json` currently succeeds, but JSON field selection takes precedence and silently ignores `--comments`.

Reject this combination in the issue, pull request, and discussion view commands. Each command now returns "specify only one of --comments or --json" instead.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

Given a built `bin/gh` and an issue
When I run `./bin/gh issue view 14214 --repo cli/cli --comments --json number`
Then the command exits with "specify only one of --comments or --json" before making an API request.

Given the string-valued search qualifier
When I run `./bin/gh search issues --repo cli/cli --comments 5 --json number --limit 1` and the equivalent `search prs` command
Then both commands return JSON results.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

Each view command validates the modes it owns. Shared JSON flag handling remains unaware of `--comments`, leaving string-valued search qualifiers compatible with JSON output.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with the three `NewCmdView` checks and their constructor tests. The expected behavior was confirmed in https://github.com/cli/cli/issues/14214#issuecomment-5363003928.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
