### PR TITLE
Treat gist contents as binary only when they are not valid UTF-8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea
 	github.com/distribution/reference v0.6.0
-	github.com/gabriel-vasile/mimetype v1.4.15
 	github.com/gdamore/tcell/v2 v2.13.10
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.9

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,6 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/gabriel-vasile/mimetype v1.4.15 h1:05iP/CYtZ/w455R/KZM6rZ5ieAdh99UPtd+d3YzLmaI=
-github.com/gabriel-vasile/mimetype v1.4.15/go.mod h1:azpTcoLcDZRNgFou5j+APrqQx9HqVPWa6ijYQIIVswQ=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/gdamore/tcell/v2 v2.13.10 h1:Afs3JKt83HnhuUKdZ3MnxUgOqQRWftj5JyDqv1LLynA=

--- a/pkg/cmd/gist/shared/shared.go
+++ b/pkg/cmd/gist/shared/shared.go
@@ -6,17 +6,18 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/gabriel-vasile/mimetype"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -199,30 +200,29 @@ pagination:
 }
 
 func IsBinaryFile(file string) (bool, error) {
-	detectedMime, err := mimetype.DetectFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return false, err
 	}
-
-	isBinary := true
-	for mime := detectedMime; mime != nil; mime = mime.Parent() {
-		if mime.Is("text/plain") {
-			isBinary = false
-			break
-		}
-	}
-	return isBinary, nil
+	return IsBinaryContents(contents), nil
 }
 
+// IsBinaryContents reports whether contents cannot be sent to the Gists API.
+//
+// Gist contents travel as a JSON string. encoding/json does not reject invalid
+// UTF-8, it rewrites every offending byte to U+FFFD, so contents that are not
+// valid UTF-8 are mangled by gh itself before they are ever sent, and the
+// original bytes cannot be recovered from the gist afterwards.
+//
+// Valid UTF-8 is encoded losslessly, control characters included. The API
+// accepts those and normalises them the same way the web UI does.
+//
+// Detecting binary by MIME type answered a different question, and was wrong in
+// both directions: most ASCII control characters sniff as binary, so plain text
+// files containing one were rejected, while latin-1 and UTF-16 text sniff as
+// text/plain and were uploaded and corrupted.
 func IsBinaryContents(contents []byte) bool {
-	isBinary := true
-	for mime := mimetype.Detect(contents); mime != nil; mime = mime.Parent() {
-		if mime.Is("text/plain") {
-			isBinary = false
-			break
-		}
-	}
-	return isBinary
+	return !utf8.Valid(contents)
 }
 
 func PromptGists(prompter prompter.Prompter, client *http.Client, host string, cs *iostreams.ColorScheme) (gist *Gist, err error) {

--- a/pkg/cmd/gist/shared/shared_test.go
+++ b/pkg/cmd/gist/shared/shared_test.go
@@ -1,8 +1,11 @@
 package shared
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,6 +14,7 @@ import (
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_GetGistIDFromURL(t *testing.T) {
@@ -60,37 +64,160 @@ func Test_GetGistIDFromURL(t *testing.T) {
 
 func TestIsBinaryContents(t *testing.T) {
 	tests := []struct {
+		name        string
 		fileContent []byte
 		want        bool
 	}{
 		{
-			want:        false,
+			name:        "ASCII text",
 			fileContent: []byte("package main"),
+			want:        false,
 		},
 		{
-			want:        false,
+			name:        "empty",
 			fileContent: []byte(""),
-		},
-		{
 			want:        false,
-			fileContent: []byte(nil),
 		},
 		{
-			want: true,
-			fileContent: []byte{239, 191, 189, 239, 191, 189, 239, 191, 189, 239,
-				191, 189, 239, 191, 189, 16, 74, 70, 73, 70, 239, 191, 189, 1, 1, 1,
-				1, 44, 1, 44, 239, 191, 189, 239, 191, 189, 239, 191, 189, 239, 191,
-				189, 239, 191, 189, 67, 239, 191, 189, 8, 6, 6, 7, 6, 5, 8, 7, 7, 7,
-				9, 9, 8, 10, 12, 20, 10, 12, 11, 11, 12, 25, 18, 19, 15, 20, 29, 26,
-				31, 30, 29, 26, 28, 28, 32, 36, 46, 39, 32, 34, 44, 35, 28, 28, 40,
-				55, 41, 44, 48, 49, 52, 52, 52, 31, 39, 57, 61, 56, 50, 60, 46, 51,
-				52, 50, 239, 191, 189, 239, 191, 189, 239, 191, 189, 67, 1, 9, 9, 9, 12},
+			name:        "nil",
+			fileContent: []byte(nil),
+			want:        false,
+		},
+		{
+			name:        "multi-byte UTF-8",
+			fileContent: []byte("café 👋 日本語"),
+			want:        false,
+		},
+		{
+			// https://github.com/cli/cli/issues/9761
+			name:        "control character in the middle",
+			fileContent: []byte("hello\x01world"),
+			want:        false,
+		},
+		{
+			name:        "control character at the start",
+			fileContent: []byte("\x01hello"),
+			want:        false,
+		},
+		{
+			name:        "control character at the end",
+			fileContent: []byte("hello\x01"),
+			want:        false,
+		},
+		{
+			name:        "every ASCII control character",
+			fileContent: allASCIIControlChars(),
+			want:        false,
+		},
+		{
+			// Invalid UTF-8 is silently rewritten to U+FFFD when encoded as
+			// JSON, so it must not be uploaded.
+			name:        "latin-1 text",
+			fileContent: []byte{'c', 'a', 'f', 0xe9},
+			want:        true,
+		},
+		{
+			name:        "UTF-16 text",
+			fileContent: []byte{0xff, 0xfe, 'h', 0x00, 'i', 0x00},
+			want:        true,
+		},
+		{
+			name:        "JPEG",
+			fileContent: []byte{0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F'},
+			want:        true,
+		},
+		{
+			name:        "PNG",
+			fileContent: []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a},
+			want:        true,
 		},
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.want, IsBinaryContents(tt.fileContent))
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsBinaryContents(tt.fileContent))
+		})
 	}
+}
+
+// Contents that IsBinaryContents reports as text must survive a JSON round
+// trip unchanged, since that is how they reach the Gists API.
+func TestIsBinaryContentsMatchesJSONRoundTrip(t *testing.T) {
+	contents := [][]byte{
+		[]byte("package main"),
+		[]byte("café 👋 日本語"),
+		[]byte("hello\x01world"),
+		allASCIIControlChars(),
+		{'c', 'a', 'f', 0xe9},
+		{0xff, 0xfe, 'h', 0x00, 'i', 0x00},
+		{0xff, 0xd8, 0xff, 0xe0},
+		{0x89, 'P', 'N', 'G'},
+	}
+
+	for _, c := range contents {
+		encoded, err := json.Marshal(string(c))
+		require.NoError(t, err)
+
+		var decoded string
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+
+		lossless := decoded == string(c)
+		assert.Equal(t, lossless, !IsBinaryContents(c),
+			"contents %q: survives JSON round trip = %v, treated as text = %v",
+			c, lossless, !IsBinaryContents(c))
+	}
+}
+
+func TestIsBinaryFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileContent []byte
+		want        bool
+	}{
+		{
+			name:        "text file",
+			fileContent: []byte("package main"),
+			want:        false,
+		},
+		{
+			// https://github.com/cli/cli/issues/9761
+			name:        "text file containing control characters",
+			fileContent: []byte("hello\x01world\n"),
+			want:        false,
+		},
+		{
+			name:        "JPEG file",
+			fileContent: []byte{0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F'},
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "gistfile.txt")
+			require.NoError(t, os.WriteFile(file, tt.fileContent, 0600))
+
+			got, err := IsBinaryFile(file)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsBinaryFileMissing(t *testing.T) {
+	_, err := IsBinaryFile(filepath.Join(t.TempDir(), "does-not-exist"))
+	assert.Error(t, err)
+}
+
+// allASCIIControlChars returns the 33 ASCII control characters, surrounded by
+// ordinary text.
+func allASCIIControlChars() []byte {
+	contents := []byte("start")
+	for i := 0x00; i <= 0x1f; i++ {
+		contents = append(contents, byte(i))
+	}
+	contents = append(contents, 0x7f)
+	return append(contents, []byte("end")...)
 }
 
 func TestPromptGists(t *testing.T) {


### PR DESCRIPTION
Fixes #9761
Fixes #14216

### Description

`gh gist create` and `gh gist edit` refuse to upload contents they consider binary. Gist contents are sent to the API inside a JSON string, so the question that actually matters is "can these bytes be represented in a JSON string without being changed?". The check asked a different question — it classified the contents by MIME type — and the two answers disagree in both directions.

Most ASCII control characters sniff as binary. So a plain text file that happens to contain one is rejected with `binary file not supported`, even though the API accepts it and the same gist can be created in the browser. That is #9761, reported two years ago.

The other direction is worse and had not been reported until now. Contents that are text but not UTF-8 — latin-1, UTF-16 — sniff as `text/plain` and sail through the check. `encoding/json` does not reject invalid UTF-8; it rewrites every offending byte to U+FFFD. So `gh` mangles the file itself, before it is ever sent, then reports success. The original bytes cannot be recovered from the gist afterwards. That is #14216.

This replaces the MIME check with `utf8.Valid`. Control characters are valid UTF-8 and are encoded losslessly, so they are now accepted; the API normalises them the same way the web UI does. Contents that are not valid UTF-8 are now refused up front instead of being silently rewritten.

`IsBinaryFile` also stops sniffing and reads the file. `mimetype.DetectFile` only inspects the first 3072 bytes, so a large file that turns invalid later slipped through; and the caller read the whole file immediately afterwards anyway, so this is one read rather than two.

### How did you test this change?

By hand, against the real API, with a `gh` built from `trunk` and one built from this branch. Two files:

```sh
printf 'caf\xe9 r\xe9sum\xe9\n' > latin1.txt        # text, but latin-1, not UTF-8
printf 'hello\x01world\n'      > controlchars.txt   # text with a SOH control char
```

**Given** a text file containing a control character
**When** I run `gh gist create controlchars.txt`

on `trunk` it is refused:

```
failed to collect files for posting: failed to upload controlchars.txt: binary file not supported
```

and on this branch the gist is created, and `gh gist view` renders it:

```
hello^Aworld
```

**Given** a latin-1 text file
**When** I run `gh gist create latin1.txt`

on `trunk` it succeeds and exits 0, and the gist does not contain my file. Reading the stored contents straight back off the API:

```
on disk : 63 61 66 e9 20 72 e9 73 75 6d e9 0a                             (12 bytes)
in gist : 63 61 66 ef bf bd 20 72 ef bf bd 73 75 6d ef bf bd 0a           (18 bytes)
```

Every `e9` has become `ef bf bd`, U+FFFD. On this branch it is refused before anything is sent:

```
failed to collect files for posting: failed to upload latin1.txt: binary file not supported
```

I also checked that ordinary files are unaffected — ASCII, multi-byte UTF-8 (`café 👋 日本語`), and empty files all still upload — and that real binaries are still refused, using actual JPEG and PNG headers.

The gists created during this walkthrough have been deleted.

### Key points

**Control characters reach the API, they are not stored byte-for-byte.** Creating the gist above and reading it back off the API gives `hello^Aworld` — the server normalises `0x01` to caret notation, exactly as it does for a gist created in the browser. #9761 asks for the gist to be created successfully and be viewable, which it now is; I did not try to make the stored bytes identical, since that is the API's behaviour and not something the client decides.

**NUL is now accepted.** It is a valid UTF-8 encoding and one of the 33 ASCII control characters covered by #9761, so the rule admits it. I have not found a case where the API rejects it, but I have not exercised it either — happy to special-case NUL if you would rather be conservative there.

**This is a behaviour change for non-UTF-8 files.** Anyone currently uploading latin-1 or UTF-16 files gets an error where they previously got a gist. That gist did not contain their file, so I think refusing is the right outcome, but it is a visible change rather than a pure bug fix.

**The error message still says `binary file not supported`.** It is now reachable for contents that are text but not UTF-8, where that wording is not quite accurate. I left it alone to keep the diff focused, but I am glad to reword it if you want.

`go mod tidy` drops `github.com/gabriel-vasile/mimetype`, which was only used here.

### Notes for reviewers

Start at `IsBinaryContents` in `pkg/cmd/gist/shared/shared.go`; everything else follows from it. It gates four call sites — `gist create` (file and stdin), `gist edit` (twice), and `gist view` — and the `view` one matters for #9761, since @williammartin's original acceptance note asked that the file also be viewable afterwards.

One thing worth a glance: the old `TestIsBinaryContents` fixture for "binary" contents was a run of `239, 191, 189` bytes. That is U+FFFD repeated, so the JPEG it was captured from had already been through this same lossy conversion before it became test data. I replaced it with real JPEG and PNG headers.

Prior discussion is on #9761, where @steiza and @williammartin weighed up whether the upstream mimetype behaviour could be fixed instead. This takes the other route and stops using mimetype for this decision at all.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @MaramHarsha will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
