### PR TITLE
Fix Copilot declined-install warning newline

### DIFF
--- a/pkg/cmd/copilot/copilot.go
+++ b/pkg/cmd/copilot/copilot.go
@@ -156,7 +156,7 @@ func runCopilot(opts *CopilotOptions) error {
 				return cmdutil.SilentError
 			}
 		} else if !ci.IsCI() {
-			fmt.Fprintf(opts.IO.ErrOut, "%s Copilot CLI not installed\n", opts.IO.ColorScheme().WarningIcon())
+			fmt.Fprintf(opts.IO.ErrOut, "%s Copilot CLI not installed", opts.IO.ColorScheme().WarningIcon())
 			return cmdutil.SilentError
 		}
 

--- a/pkg/cmd/copilot/copilot.go
+++ b/pkg/cmd/copilot/copilot.go
@@ -152,11 +152,11 @@ func runCopilot(opts *CopilotOptions) error {
 				return err
 			}
 			if !confirmed {
-				fmt.Fprintf(opts.IO.ErrOut, "%s Copilot CLI was not installed", opts.IO.ColorScheme().WarningIcon())
+				fmt.Fprintf(opts.IO.ErrOut, "%s Copilot CLI was not installed\n", opts.IO.ColorScheme().WarningIcon())
 				return cmdutil.SilentError
 			}
 		} else if !ci.IsCI() {
-			fmt.Fprintf(opts.IO.ErrOut, "%s Copilot CLI not installed", opts.IO.ColorScheme().WarningIcon())
+			fmt.Fprintf(opts.IO.ErrOut, "%s Copilot CLI not installed\n", opts.IO.ColorScheme().WarningIcon())
 			return cmdutil.SilentError
 		}
 

--- a/pkg/cmd/copilot/copilot_test.go
+++ b/pkg/cmd/copilot/copilot_test.go
@@ -115,7 +115,8 @@ func TestNewCmdCopilot(t *testing.T) {
 			assert.NoError(t, err)
 
 			var gotOpts *CopilotOptions
-			cmd := NewCmdCopilot(f, &telemetry.CommandRecorderSpy{}, func(opts *CopilotOptions) error {
+			spy := &telemetry.CommandRecorderSpy{}
+			cmd := NewCmdCopilot(f, spy, func(opts *CopilotOptions) error {
 				gotOpts = opts
 				return nil
 			})
@@ -126,6 +127,7 @@ func TestNewCmdCopilot(t *testing.T) {
 			cmd.SetErr(&bytes.Buffer{})
 
 			_, err = cmd.ExecuteC()
+			assert.Equal(t, ghtelemetry.SAMPLE_ALL, spy.LastSampleRate)
 			if tt.wantErrString != "" {
 				require.EqualError(t, err, tt.wantErrString)
 				return
@@ -675,20 +677,4 @@ func TestRunCopilot(t *testing.T) {
 			assert.Equal(t, tt.wantStderr, stderr.String())
 		})
 	}
-}
-
-func TestCopilotCommandIsSampledAt100(t *testing.T) {
-	spy := &telemetry.CommandRecorderSpy{}
-	factory := &cmdutil.Factory{}
-	cmd := NewCmdCopilot(factory, spy, func(opts *CopilotOptions) error {
-		return nil
-	})
-	cmd.SetArgs([]string{})
-	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
-
-	_, err := cmd.ExecuteC()
-	require.NoError(t, err)
-	require.Equal(t, ghtelemetry.SAMPLE_ALL, spy.LastSampleRate)
 }

--- a/pkg/cmd/copilot/copilot_test.go
+++ b/pkg/cmd/copilot/copilot_test.go
@@ -621,14 +621,6 @@ func TestRunCopilot(t *testing.T) {
 			wantStderr: "! Copilot CLI was not installed\n",
 		},
 		{
-			name: "non-interactive missing install prints trailing newline",
-			findCopilot: func() string {
-				return ""
-			},
-			wantErr:    cmdutil.SilentError,
-			wantStderr: "! Copilot CLI not installed\n",
-		},
-		{
 			name: "execution failure includes direct command hint",
 			findCopilot: func() string {
 				return "/usr/bin/copilot"

--- a/pkg/cmd/copilot/copilot_test.go
+++ b/pkg/cmd/copilot/copilot_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/internal/safeurl"
 	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -591,30 +592,89 @@ func TestDownloadCopilot(t *testing.T) {
 	})
 }
 
-func TestRunCopilot_execFailureHint(t *testing.T) {
-	ios, _, _, _ := iostreams.Test()
-	opts := &CopilotOptions{
-		IO:          ios,
-		CopilotArgs: []string{},
-	}
-
-	origFind := findCopilotBinaryFunc
-	findCopilotBinaryFunc = func() string {
-		return "/usr/bin/copilot"
-	}
-	t.Cleanup(func() { findCopilotBinaryFunc = origFind })
-
+func TestRunCopilot(t *testing.T) {
 	execErr := fmt.Errorf("exec failed: something went wrong")
-	origRun := runExternalCmdFunc
-	runExternalCmdFunc = func(_ *exec.Cmd) error {
-		return execErr
+	tests := []struct {
+		name             string
+		isTTY            bool
+		prompter         prompter.Prompter
+		findCopilot      func() string
+		runExternal      func(*exec.Cmd) error
+		wantErr          error
+		wantErrSubstring string
+		wantStderr       string
+	}{
+		{
+			name:  "declining install prints trailing newline",
+			isTTY: true,
+			prompter: &prompter.PrompterMock{
+				ConfirmFunc: func(_ string, _ bool) (bool, error) {
+					return false, nil
+				},
+			},
+			findCopilot: func() string {
+				return ""
+			},
+			wantErr:    cmdutil.SilentError,
+			wantStderr: "! Copilot CLI was not installed\n",
+		},
+		{
+			name: "non-interactive missing install prints trailing newline",
+			findCopilot: func() string {
+				return ""
+			},
+			wantErr:    cmdutil.SilentError,
+			wantStderr: "! Copilot CLI not installed\n",
+		},
+		{
+			name: "execution failure includes direct command hint",
+			findCopilot: func() string {
+				return "/usr/bin/copilot"
+			},
+			runExternal: func(_ *exec.Cmd) error {
+				return execErr
+			},
+			wantErr:          execErr,
+			wantErrSubstring: "try running `copilot` directly without `gh`.",
+		},
 	}
-	t.Cleanup(func() { runExternalCmdFunc = origRun })
 
-	err := runCopilot(opts)
-	require.Error(t, err)
-	require.ErrorIs(t, err, execErr)
-	require.Contains(t, err.Error(), "try running `copilot` directly without `gh`.")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CI", "")
+			t.Setenv("BUILD_NUMBER", "")
+			t.Setenv("RUN_ID", "")
+
+			ios, _, _, stderr := iostreams.Test()
+			if tt.isTTY {
+				ios.SetStdinTTY(true)
+				ios.SetStdoutTTY(true)
+			}
+
+			opts := &CopilotOptions{
+				IO:          ios,
+				Prompter:    tt.prompter,
+				CopilotArgs: []string{},
+			}
+
+			origFind := findCopilotBinaryFunc
+			findCopilotBinaryFunc = tt.findCopilot
+			t.Cleanup(func() { findCopilotBinaryFunc = origFind })
+
+			if tt.runExternal != nil {
+				origRun := runExternalCmdFunc
+				runExternalCmdFunc = tt.runExternal
+				t.Cleanup(func() { runExternalCmdFunc = origRun })
+			}
+
+			err := runCopilot(opts)
+			require.ErrorIs(t, err, tt.wantErr)
+			if tt.wantErrSubstring != "" {
+				require.ErrorContains(t, err, tt.wantErrSubstring)
+			}
+			assert.Equal(t, tt.wantStderr, stderr.String())
+		})
+	}
 }
 
 func TestCopilotCommandIsSampledAt100(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Fixes #14189

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

When `gh copilot` cannot find Copilot CLI and installation is declined, its warning does not end with a newline. This leaves the next shell prompt on the same line.

Add a trailing newline to the warning and cover its exact output in the primary run-function table test.

While adding that coverage, consolidate the existing execution-failure test into the run-function table and move the telemetry sampling assertion into the constructor table. This keeps command-level behavior in the two primary table tests.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

Given Copilot CLI was excluded from `PATH`, when I ran a locally built `gh copilot` in a terminal and declined installation, then the warning and following shell marker appeared on separate lines:

```console
? GitHub Copilot CLI is not installed. Would you like to install it? No
! Copilot CLI was not installed
SHELL_PROMPT_MARKER
```

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- The declined-install warning now terminates its output before returning.
- The existing execution-failure coverage is consolidated into the run-function table.
- The existing telemetry sampling assertion is consolidated into the constructor table.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with the declined-install branch, then review its output case in the run-function table. [Issue #14189](https://github.com/cli/cli/issues/14189) contains the original terminal reproduction.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.