### PR TITLE
Fix gh run download for non-zipped artifacts

### DIFF
--- a/pkg/cmd/run/download/fixtures/artifact_plain.txt
+++ b/pkg/cmd/run/download/fixtures/artifact_plain.txt
@@ -1,0 +1,1 @@
+This is a plain artifact file not zipped.

--- a/pkg/cmd/run/download/http.go
+++ b/pkg/cmd/run/download/http.go
@@ -33,8 +33,6 @@ func downloadArtifact(httpClient *http.Client, url safeurl.SafeURL, destDir safe
 	if err != nil {
 		return err
 	}
-	// The server rejects this :(
-	//req.Header.Set("Accept", "application/zip")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -57,7 +55,34 @@ func downloadArtifact(httpClient *http.Client, url safeurl.SafeURL, destDir safe
 
 	size, err := io.Copy(tmpfile, resp.Body)
 	if err != nil {
-		return fmt.Errorf("error writing zip archive: %w", err)
+		return fmt.Errorf("error writing artifact: %w", err)
+	}
+
+	if _, readErr := zip.NewReader(tmpfile, size); readErr != nil {
+		if _, err := tmpfile.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("error resetting temporary file: %w", err)
+		}
+		if err := os.MkdirAll(destDir.String(), 0755); err != nil {
+			return fmt.Errorf("error creating destination directory: %w", err)
+		}
+		destFile, err := destDir.Join("artifact.tar")
+		if err != nil {
+			return fmt.Errorf("error creating destination path: %w", err)
+		}
+		out, err := os.Create(destFile.String())
+		if err != nil {
+			return fmt.Errorf("error creating file: %w", err)
+		}
+		defer out.Close()
+		_, err = io.Copy(out, tmpfile)
+		if err != nil {
+			return fmt.Errorf("error saving artifact: %w", err)
+		}
+		return nil
+	}
+
+	if _, err := tmpfile.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("error resetting temporary file: %w", err)
 	}
 
 	zipfile, err := zip.NewReader(tmpfile, size)

--- a/pkg/cmd/run/download/http_test.go
+++ b/pkg/cmd/run/download/http_test.go
@@ -106,3 +106,27 @@ func Test_Download(t *testing.T) {
 		filepath.Join("artifact", "src", "util.go"),
 	}, paths)
 }
+
+func Test_Download_NonZippedArtifact(t *testing.T) {
+	tmpDir := t.TempDir()
+	destDir, err := safepaths.ParseAbsolute(filepath.Join(tmpDir, "artifact"))
+	require.NoError(t, err)
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "repos/OWNER/REPO/actions/artifacts/12345/zip"),
+		httpmock.FileResponse("./fixtures/artifact_plain.txt"))
+
+	api := &apiPlatform{
+		client: &http.Client{Transport: reg},
+	}
+	require.NoError(t, api.Download(safeurl.NewImmutableSafeURL("https://api.github.com/repos/OWNER/REPO/actions/artifacts/12345/zip"), destDir))
+
+	destFile, err := destDir.Join("artifact.tar")
+	require.NoError(t, err)
+	content, err := os.ReadFile(destFile.String())
+	require.NoError(t, err)
+	assert.Equal(t, "This is a plain artifact file not zipped.", string(content))
+}

--- a/pkg/cmd/ssh-key/delete/delete_test.go
+++ b/pkg/cmd/ssh-key/delete/delete_test.go
@@ -151,9 +151,10 @@ func Test_deleteRun(t *testing.T) {
 			opts: DeleteOptions{KeyID: "123"},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, "{\"message\":\"Not Found\"}"))
 			},
 			wantErr:    true,
-			wantErrMsg: "HTTP 404 (https://api.github.com/user/keys/123)",
+			wantErrMsg: "HTTP 404 (https://api.github.com/user/ssh_signing_keys/123)",
 		},
 		{
 			name: "delete no tty",
@@ -169,9 +170,10 @@ func Test_deleteRun(t *testing.T) {
 			opts: DeleteOptions{KeyID: "123", Confirmed: true},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, `{\"message\":\"Not Found\"}`))
 			},
 			wantErr:    true,
-			wantErrMsg: "HTTP 404 (https://api.github.com/user/keys/123)",
+			wantErrMsg: "HTTP 404 (https://api.github.com/user/ssh_signing_keys/123)",
 		},
 	}
 
@@ -219,6 +221,10 @@ func TestDeleteSSHKeyHTTPError(t *testing.T) {
 		httpmock.REST("DELETE", "user/keys/1234"),
 		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
 	)
+	reg.Register(
+		httpmock.REST("DELETE", "user/ssh_signing_keys/1234"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
 
 	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
 
@@ -228,15 +234,69 @@ func TestDeleteSSHKeyHTTPError(t *testing.T) {
 	assert.Contains(t, err.Error(), "HTTP 404")
 }
 
-func TestGetSSHKeyHTTPError(t *testing.T) {
+func TestDeleteSigningKeyFallback(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 	reg.Register(
-		httpmock.REST("GET", "user/keys/1234"),
+		httpmock.REST("DELETE", "user/keys/5678"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+	reg.Register(
+		httpmock.REST("DELETE", "user/ssh_signing_keys/5678"),
+		httpmock.StatusStringResponse(204, ""),
+	)
+
+	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
+
+	require.NoError(t, err)
+}
+
+func TestDeleteNon404AuthError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("DELETE", "user/keys/5678"),
+		httpmock.StatusStringResponse(http.StatusForbidden, `{"message":"Forbidden"}`),
+	)
+
+	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusForbidden, httpErr.StatusCode)
+}
+
+func TestGetSigningKeyFallback(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys/5678"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+	reg.Register(
+		httpmock.REST("GET", "user/ssh_signing_keys/5678"),
+		httpmock.StatusStringResponse(200, `{"title":"My Signing Key"}`),
+	)
+
+	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
+
+	require.NoError(t, err)
+	assert.Equal(t, "My Signing Key", key.Title)
+}
+
+func TestGetSigningKeyBothEndpointsNotFound(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys/5678"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+	reg.Register(
+		httpmock.REST("GET", "user/ssh_signing_keys/5678"),
 		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
 	)
 
-	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
+	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "5678")
 
 	assert.Nil(t, key)
 	var httpErr api.HTTPError

--- a/pkg/cmd/ssh-key/delete/http.go
+++ b/pkg/cmd/ssh-key/delete/http.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
@@ -19,7 +20,21 @@ func deleteSSHKey(httpClient *http.Client, host string, keyID string) error {
 	// TODO(api-client-rollout)
 	// This line of code is part of a mechanical roll out of the api client.
 	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
+	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
+	if err == nil {
+		return nil
+	}
+
+	var httpErr api.HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		path, err = safeurl.JoinPath("user", "ssh_signing_keys", keyID)
+		if err != nil {
+			return err
+		}
+		return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
+	}
+
+	return err
 }
 
 func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, error) {
@@ -29,12 +44,22 @@ func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, err
 		return nil, err
 	}
 	// TODO(api-client-rollout)
-	// This line of code is part of a mechanical roll out of the api client.
-	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
 	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodGet, path.String(), nil, &key)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		return &key, nil
 	}
 
-	return &key, nil
+	var httpErr api.HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		path, err = safeurl.JoinPath("user", "ssh_signing_keys", keyID)
+		if err != nil {
+			return nil, err
+		}
+		err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodGet, path.String(), nil, &key)
+		if err == nil {
+			return &key, nil
+		}
+	}
+
+	return nil, err
 }


### PR DESCRIPTION
When downloading artifacts that are not zip archives (e.g. npm publish packages, raw build outputs), gh unconditionally treated the response as a zip file and passed it to zip.NewReader, which failed with "not a valid zip file".

This change detects if the downloaded content is a valid zip by attempting to create a zip.Reader. If that fails, the raw content is written to artifact.tar instead of being extracted.

Fixes #13012