### PR TITLE
fix(ssh-key/delete): route signing keys to the correct endpoint

### DIFF
--- a/pkg/cmd/ssh-key/delete/delete_test.go
+++ b/pkg/cmd/ssh-key/delete/delete_test.go
@@ -173,6 +173,34 @@ func Test_deleteRun(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "HTTP 404 (https://api.github.com/user/keys/123)",
 		},
+		{
+			// Regression for https://github.com/cli/cli/issues/14064 — signing
+			// keys live at /user/ssh_signing_keys/{id}, not /user/keys/{id}.
+			name: "delete signing key tty",
+			tty:  true,
+			opts: DeleteOptions{KeyID: "456"},
+			prompterStubs: func(pm *prompter.PrompterMock) {
+				pm.ConfirmDeletionFunc = func(_ string) error {
+					return nil
+				}
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/keys/456"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/456"), httpmock.StatusStringResponse(200, keyResp))
+				reg.Register(httpmock.REST("DELETE", "user/ssh_signing_keys/456"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "✓ SSH key \"My Key\" (456) deleted from your account\n",
+		},
+		{
+			name: "delete signing key no tty",
+			opts: DeleteOptions{KeyID: "456", Confirmed: true},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/keys/456"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/456"), httpmock.StatusStringResponse(200, keyResp))
+				reg.Register(httpmock.REST("DELETE", "user/ssh_signing_keys/456"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -243,4 +271,42 @@ func TestGetSSHKeyHTTPError(t *testing.T) {
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
 	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+// TestDeleteSSHKeySigningKeyFallback covers the 404-on-auth-then-204-on-signing
+// path that fixes https://github.com/cli/cli/issues/14064.
+func TestDeleteSSHKeySigningKeyFallback(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("DELETE", "user/keys/456"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+	reg.Register(
+		httpmock.REST("DELETE", "user/ssh_signing_keys/456"),
+		httpmock.StatusStringResponse(http.StatusNoContent, ""),
+	)
+
+	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "456")
+	require.NoError(t, err)
+}
+
+// TestGetSSHKeySigningKeyFallback covers the 404-on-auth-then-200-on-signing
+// path that fixes https://github.com/cli/cli/issues/14064.
+func TestGetSSHKeySigningKeyFallback(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("GET", "user/keys/456"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+	reg.Register(
+		httpmock.REST("GET", "user/ssh_signing_keys/456"),
+		httpmock.StatusStringResponse(http.StatusOK, `{"title":"My Signing Key"}`),
+	)
+
+	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "456")
+	require.NoError(t, err)
+	assert.Equal(t, "My Signing Key", key.Title)
+	assert.Equal(t, "signing", key.Type)
 }

--- a/pkg/cmd/ssh-key/delete/http.go
+++ b/pkg/cmd/ssh-key/delete/http.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
@@ -9,32 +10,65 @@ import (
 
 type sshKey struct {
 	Title string
+	Type  string // "authentication" or "signing"
 }
 
 func deleteSSHKey(httpClient *http.Client, host string, keyID string) error {
-	path, err := safeurl.JoinPath("user", "keys", keyID)
+	// Try the authentication-keys endpoint first; if the key is a signing key,
+	// GitHub returns 404 from /user/keys/{id} and we fall through to the
+	// signing-keys endpoint. See https://github.com/cli/cli/issues/14064.
+	authPath, err := safeurl.JoinPath("user", "keys", keyID)
 	if err != nil {
 		return err
 	}
 	// TODO(api-client-rollout)
 	// This line of code is part of a mechanical roll out of the api client.
 	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
+	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, authPath.String(), nil, nil)
+	if err == nil {
+		return nil
+	}
+	var httpErr api.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusNotFound {
+		return err
+	}
+
+	signingPath, err := safeurl.JoinPath("user", "ssh_signing_keys", keyID)
+	if err != nil {
+		return err
+	}
+	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, signingPath.String(), nil, nil)
 }
 
 func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, error) {
 	var key sshKey
-	path, err := safeurl.JoinPath("user", "keys", keyID)
+	authPath, err := safeurl.JoinPath("user", "keys", keyID)
 	if err != nil {
 		return nil, err
 	}
 	// TODO(api-client-rollout)
 	// This line of code is part of a mechanical roll out of the api client.
 	// As a follow up, consider whether the api client can be injected to this call site, rather than constructed
-	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodGet, path.String(), nil, &key)
-	if err != nil {
+	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodGet, authPath.String(), nil, &key)
+	if err == nil {
+		key.Type = "authentication"
+		return &key, nil
+	}
+	var httpErr api.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusNotFound {
 		return nil, err
 	}
 
+	// Fall through to the signing-keys endpoint.
+	key = sshKey{}
+	signingPath, err := safeurl.JoinPath("user", "ssh_signing_keys", keyID)
+	if err != nil {
+		return nil, err
+	}
+	err = api.NewClientFromHTTP(httpClient).REST(host, http.MethodGet, signingPath.String(), nil, &key)
+	if err != nil {
+		return nil, err
+	}
+	key.Type = "signing"
 	return &key, nil
 }


### PR DESCRIPTION
## Summary

Closes #14064.

`gh ssh-key delete` only called `/user/keys/{id}` (the authentication-keys endpoint), so passing a signing-key ID returned HTTP 404 and left the key unchanged. `gh ssh-key add --type signing` and `gh ssh-key list` already handle signing keys via `/user/ssh_signing_keys/{id}` — this brings `gh ssh-key delete` in line with the rest of the ssh-key commands.

## Approach

In `deleteSSHKey` and `getSSHKey` (pkg/cmd/ssh-key/delete/http.go), try the authentication-keys endpoint first and fall through to the signing-keys endpoint on HTTP 404. Any other error from the first attempt is returned unchanged — so a network error or 500 still surfaces immediately rather than getting masked by a second request.

The `sshKey` struct gains a `Type` field (`"authentication"` / `"signing"\`) so callers can distinguish the two if they need to. `Test_deleteRun` (the existing table-driven test) gets two new entries for the signing-key paths, plus two new helper-level tests (`TestDeleteSSHKeySigningKeyFallback`, `TestGetSSHKeySigningKeyFallback\`) cover the 404-then-success flow directly.

## Why fallback vs upfront type detection

`gh ssh-key list` does upfront detection (calls both `UserKeys` and `UserSigningKeys`, merges the results). Delete doesn't have that luxury — `gh ssh-key delete <id>` gets just an ID, no list context. Fallback on 404 keeps the surface simple: one extra round-trip *only* when the key isn't an auth key, zero extra requests in the common case.

## Test plan

``\`
go test ./pkg/cmd/ssh-key/delete/...
``\`

Five test cases now cover the delete flow:
- delete tty (auth key, existing)
- delete with confirm flag tty (auth key, existing)
- delete no tty (auth key, existing)
- delete signing key tty (NEW — auth returns 404, signing returns 200, delete on signing returns 204)
- delete signing key no tty (NEW — same flow, --yes flag)

Plus two helper tests for the signing-key fallback path.

## Diff scope

``\`
 pkg/cmd/ssh-key/delete/delete_test.go | 66 +++++++++++++++++++++++++++++++++++
 pkg/cmd/ssh-key/delete/http.go        | 44 ++++++++++++++++++++---
 2 files changed, 105 insertions(+), 5 deletions(-)
``\`

## Note on local testing

I could not run `go test` locally — the dev environment I'm working in does not have Go installed and `apt-get install` is unavailable. The test cases follow the exact pattern of the existing tests in the file (same httpmock setup, same tty/non-tty fixtures, same assertion style). If anything breaks on CI I'll iterate.