### PR TITLE
Reject non-empty worktree targets before branch creation

### DIFF
--- a/acceptance/testdata/issue/issue-develop-worktree.txtar
+++ b/acceptance/testdata/issue/issue-develop-worktree.txtar
@@ -21,6 +21,15 @@ cd ${REPO}
 exec gh issue create --title 'Feature Request' --body 'Request Body'
 stdout2env ISSUE_URL
 
+# Targeting an existing, non-empty directory that is not a linked worktree is
+# rejected before any branch is created, so the issue is left without an orphan
+# linked branch on the remote.
+exists ../occupied/keep.txt
+! exec gh issue develop ${ISSUE_URL} --name feature-branch --checkout --worktree ../occupied
+stderr '--worktree path must be empty'
+exec gh issue develop --list ${ISSUE_URL}
+! stdout .
+
 # Develop the issue in a fresh worktree
 exec gh issue develop ${ISSUE_URL} --name feature-branch --checkout --worktree ../wt
 exists ../wt
@@ -50,3 +59,6 @@ stdout '(?m)^feature-branch$'
 # The main working copy remains untouched
 exec git rev-parse --abbrev-ref HEAD
 stdout '(?m)^main$'
+
+-- occupied/keep.txt --
+placeholder

--- a/acceptance/testdata/pr/pr-checkout-worktree.txtar
+++ b/acceptance/testdata/pr/pr-checkout-worktree.txtar
@@ -31,6 +31,12 @@ exec git checkout main
 exec git branch -D feature-branch
 stdout 'Deleted branch feature-branch'
 
+# Targeting an existing, non-empty directory that is not a linked worktree is
+# rejected up front with a clear error instead of deferring to git worktree add.
+exists ../occupied/keep.txt
+! exec gh pr checkout ${PR_URL} --worktree ../occupied
+stderr '--worktree path must be empty'
+
 # Checkout the PR into a fresh worktree
 exec gh pr checkout ${PR_URL} --worktree ../wt
 exists ../wt
@@ -133,3 +139,6 @@ stdout ${WT2_HEAD}
 # The main working copy is left untouched
 exec git rev-parse --abbrev-ref HEAD
 stdout '(?m)^main$'
+
+-- occupied/keep.txt --
+placeholder

--- a/pkg/cmd/issue/develop/develop_test.go
+++ b/pkg/cmd/issue/develop/develop_test.go
@@ -192,6 +192,8 @@ func TestDevelopRun(t *testing.T) {
 	unsafeTargetDir := t.TempDir()
 	unsafeTarget := filepath.Join(unsafeTargetDir, "worktree-link")
 	require.NoError(t, os.Symlink(unsafeTargetDir, unsafeTarget))
+	nonEmptyTarget := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(nonEmptyTarget, "file"), []byte("x"), 0o644))
 
 	tests := []struct {
 		name            string
@@ -859,6 +861,32 @@ func TestDevelopRun(t *testing.T) {
 				)
 			},
 			wantErrContains: "--worktree path must not be a symlink",
+		},
+		{
+			name: "non-empty worktree target is rejected before creating a linked branch",
+			opts: &DevelopOptions{
+				IssueNumber: 123,
+				Checkout:    true,
+				Worktree:    nonEmptyTarget,
+			},
+			remotes: map[string]string{
+				"origin": "OWNER/REPO",
+			},
+			httpStubs: func(reg *httpmock.Registry, _ *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`query LinkedBranchFeature\b`),
+					httpmock.StringResponse(featureEnabledPayload),
+				)
+				reg.Register(
+					httpmock.GraphQL(`query IssueByNumber\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"hasIssuesEnabled":true,"issue":{"id":"SOMEID","number":123,"title":"my issue"}}}}`),
+				)
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git rev-parse --path-format=absolute --show-toplevel --git-common-dir`, 0, "/repo/main\n/repo/.git\n")
+				cs.Register(`git -C .+ rev-parse --path-format=absolute --show-toplevel --show-prefix --git-common-dir`, 128, "")
+			},
+			wantErrContains: "--worktree path must be empty",
 		},
 		{
 			name: "develop with base branch which does not exist",

--- a/pkg/cmd/pr/shared/worktree.go
+++ b/pkg/cmd/pr/shared/worktree.go
@@ -2,7 +2,9 @@ package shared
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,6 +30,11 @@ func ResolveWorktreeTarget(client *git.Client, path string) (WorktreeTarget, err
 	reuse, err := resolveWorktreeTarget(client, path)
 	if err != nil {
 		return target, err
+	}
+	if !reuse {
+		if err := ensureWorktreePathEmpty(path); err != nil {
+			return target, err
+		}
 	}
 	target.Reuse = reuse
 	return target, nil
@@ -119,4 +126,25 @@ func ensureWorktreePathSafe(path string) error {
 		return fmt.Errorf("--worktree path must be a directory: %s", path)
 	}
 	return nil
+}
+
+func ensureWorktreePathEmpty(path string) error {
+	dir, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+
+	_, err = dir.Readdirnames(1)
+	switch {
+	case errors.Is(err, io.EOF):
+		return nil
+	case err != nil:
+		return err
+	default:
+		return fmt.Errorf("--worktree path must be empty: %s", path)
+	}
 }

--- a/pkg/cmd/pr/shared/worktree_test.go
+++ b/pkg/cmd/pr/shared/worktree_test.go
@@ -103,6 +103,10 @@ func TestResolveWorktreeTargetPathSafety(t *testing.T) {
 	existingDir := filepath.Join(base, "dir")
 	require.NoError(t, os.Mkdir(existingDir, 0o755))
 
+	nonEmptyDir := filepath.Join(base, "non-empty-dir")
+	require.NoError(t, os.Mkdir(nonEmptyDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nonEmptyDir, "file"), []byte("x"), 0o644))
+
 	regularFile := filepath.Join(base, "file")
 	require.NoError(t, os.WriteFile(regularFile, []byte("x"), 0o644))
 
@@ -123,6 +127,11 @@ func TestResolveWorktreeTargetPathSafety(t *testing.T) {
 			path: existingDir,
 		},
 		{
+			name:    "existing non-empty directory is rejected",
+			path:    nonEmptyDir,
+			wantErr: "--worktree path must be empty",
+		},
+		{
 			name:    "leaf symlink is rejected",
 			path:    symlink,
 			wantErr: "--worktree path must not be a symlink",
@@ -138,7 +147,7 @@ func TestResolveWorktreeTargetPathSafety(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cs, teardown := run.Stub()
 			defer teardown(t)
-			if tt.wantErr == "" {
+			if tt.wantErr == "" || tt.path == nonEmptyDir {
 				cs.Register(`git rev-parse --path-format=absolute --show-toplevel --git-common-dir`, 128, "")
 			}
 

--- a/pkg/cmd/pr/shared/worktree_test.go
+++ b/pkg/cmd/pr/shared/worktree_test.go
@@ -13,9 +13,12 @@ import (
 
 func TestResolveWorktreeTarget(t *testing.T) {
 	dir := t.TempDir()
+	nonEmptyLinkedWorktree := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(nonEmptyLinkedWorktree, "file"), []byte("x"), 0o644))
 
 	tests := []struct {
 		name      string
+		path      string
 		stubs     func(*run.CommandStubber)
 		wantReuse bool
 		wantErr   string
@@ -38,6 +41,7 @@ func TestResolveWorktreeTarget(t *testing.T) {
 		},
 		{
 			name: "path is a different worktree of this repo",
+			path: nonEmptyLinkedWorktree,
 			stubs: func(cs *run.CommandStubber) {
 				cs.Register(`git rev-parse --path-format=absolute --show-toplevel --git-common-dir`, 0, "/repo/main\n/repo/.git\n")
 				cs.Register(`git -C .+ rev-parse --path-format=absolute --show-toplevel --show-prefix --git-common-dir`, 0, "/path/to/wt\n\n/repo/.git\n")
@@ -85,14 +89,18 @@ func TestResolveWorktreeTarget(t *testing.T) {
 				GhPath:  "/some/path/gh",
 				GitPath: "/some/path/git",
 			}
-			target, err := ResolveWorktreeTarget(client, dir)
+			path := tt.path
+			if path == "" {
+				path = dir
+			}
+			target, err := ResolveWorktreeTarget(client, path)
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantReuse, target.Reuse)
-			assert.Equal(t, dir, target.Path)
+			assert.Equal(t, path, target.Path)
 		})
 	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/cli/cli/pull/14136#issuecomment-5371707995

### Description

`gh issue develop --checkout --worktree` created its linked branch before Git rejected an existing non-empty target directory. This could leave an orphaned linked branch without a local worktree.

Reject existing non-empty directories while resolving a fresh worktree target, before `gh issue develop` creates or reuses any linked branch. Existing linked worktrees remain reusable.

### How did you test this change?

Given an existing directory containing a file
When I target it with `gh issue develop --checkout --worktree`
Then the command reports that the worktree path must be empty before creating a linked branch.

Given an empty or non-existent target directory
When I resolve it as a new worktree target
Then checkout proceeds as before.

Given an existing linked worktree
When I target its root
Then the worktree remains eligible for reuse even though it contains files.

### Key points

The validation lives in the shared worktree resolver so `gh issue develop` and `gh pr checkout` retain consistent target semantics. The non-empty check runs only after determining that the target is not an existing linked worktree.

### Notes for reviewers

Start with `pkg/cmd/pr/shared/worktree.go`. The regression test in `pkg/cmd/issue/develop/develop_test.go` deliberately registers no linked-branch mutation, proving validation happens before branch creation.

This follows up on the deferred edge case identified during review of #14136.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @tidy-dev will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.