### PR TITLE
Fix typos in docs and test comments

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -26,7 +26,7 @@ What this does is:
 ## Bumping Homebrew
 
 Homebrew bumps are handled by [autobump](https://docs.brew.sh/Autobump), which runs periodically every 3 hours. In cases where a quicker rollout is required, a pull request can be opened manually with the following steps:
- 1. Replace the version number in the url to point ot the updated version.
+ 1. Replace the version number in the url to point to the updated version.
  2. Calculate and replace the sha256 value.
  3. Open the PR.
 

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -326,7 +326,7 @@ func TestApp_Create(t *testing.T) {
 			wantStderr: "  ✓ Codespaces usage for this repository is paid for by monalisa\n",
 		},
 		{
-			name: "create codespace with default branch does not show idle timeout notice if not conntected to terminal",
+			name: "create codespace with default branch does not show idle timeout notice if not connected to terminal",
 			fields: fields{
 				apiClient: apiCreateDefaults(&apiClientMock{
 					CreateCodespaceFunc: func(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error) {

--- a/pkg/cmd/gist/edit/edit_test.go
+++ b/pkg/cmd/gist/edit/edit_test.go
@@ -701,7 +701,7 @@ func Test_editRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("POST", "gists/1234"), httpmock.StatusStringResponse(201, "{}"))
-				// Explicity exclude also-truncated.txt raw URL to ensure it is not fetched since we did not select it.
+				// Explicitly exclude also-truncated.txt raw URL to ensure it is not fetched since we did not select it.
 				reg.Exclude(t, httpmock.REST("GET", "user/1234/raw/also-truncated.txt"))
 			},
 			wantLastRequestParameters: map[string]interface{}{

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -2447,7 +2447,7 @@ func Test_generateCompareURL(t *testing.T) {
 				},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				// Ensure no v1 projects are requestd
+				// Ensure no v1 projects are requested
 				// ( is required to avoid matching projectsV2
 				reg.Exclude(t, httpmock.GraphQL(`projects\(`))
 				reg.Register(


### PR DESCRIPTION
Four misspellings I ran into while reading the code:

- `docs/releasing.md` — "point ot the updated version" → "to"
- `pkg/cmd/codespace/create_test.go` — "conntected" in a test case name
- `pkg/cmd/pr/create/create_test.go` — "requestd" in a comment
- `pkg/cmd/gist/edit/edit_test.go` — "Explicity" in a comment

No behaviour change; the only Go edits are a comment and a test-case name. `go test` passes for the three affected packages.

I left `nwo`, `commitish`, `dne`, and `intoto` alone — those are intentional terms, not typos.