### PR TITLE
fix(issue develop): reject leading-dash branch names

### DIFF
--- a/pkg/cmd/issue/develop/develop.go
+++ b/pkg/cmd/issue/develop/develop.go
@@ -268,6 +268,9 @@ func developRunCreate(opts *DevelopOptions, apiClient *api.Client, issueRepo ghr
 	if branchName == "" {
 		return fmt.Errorf("failed to create linked branch: API returned empty branch name")
 	}
+	if err := validateBranchName(branchName); err != nil {
+		return err
+	}
 
 	opts.IO.StopProgressIndicator()
 
@@ -351,6 +354,10 @@ func printLinkedBranches(io *iostreams.IOStreams, branches []api.LinkedBranch) {
 }
 
 func checkoutBranch(opts *DevelopOptions, branchRepo ghrepo.Interface, checkoutBranch string, worktreeTarget prShared.WorktreeTarget) (err error) {
+	if err := validateBranchName(checkoutBranch); err != nil {
+		return err
+	}
+
 	remotes, err := opts.Remotes()
 	if err != nil {
 		// If the user specified the branch to be checked out and no remotes are found
@@ -428,6 +435,13 @@ func runGitCommands(client *git.Client, commands [][]string) error {
 		if _, err := cmd.Output(); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func validateBranchName(branchName string) error {
+	if strings.HasPrefix(branchName, "-") {
+		return fmt.Errorf("invalid branch name: %q", branchName)
 	}
 	return nil
 }

--- a/pkg/cmd/issue/develop/develop_test.go
+++ b/pkg/cmd/issue/develop/develop_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/run"
 	"github.com/cli/cli/v2/pkg/cmd/issue/argparsetest"
+	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -974,4 +975,95 @@ func registerWorktreeDevelopHTTPStubs(reg *httpmock.Registry, _ *testing.T) {
 		httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
 		httpmock.StringResponse(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"2","ref":{"name":"my-branch"}}}}}`),
 	)
+}
+
+func TestDevelopRunCreate_invalidBranchNameBeforeSetBranchConfig(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	featureEnabledPayload := `{"data":{"LinkedBranch":{"fields":[{"name":"id"},{"name":"ref"}]}}}`
+	reg.Register(
+		httpmock.GraphQL(`query LinkedBranchFeature\b`),
+		httpmock.StringResponse(featureEnabledPayload),
+	)
+	reg.Register(
+		httpmock.GraphQL(`query IssueByNumber\b`),
+		httpmock.StringResponse(`{"data":{"repository":{"hasIssuesEnabled":true,"issue":{"id":"SOMEID","number":123,"title":"my issue"}}}}`),
+	)
+	reg.Register(
+		httpmock.GraphQL(`query ListLinkedBranches\b`),
+		httpmock.GraphQLQuery(`
+                        {"data":{"repository":{"issue":{"linkedBranches":{"nodes":[]}}}}}
+                `, func(query string, inputs map[string]interface{}) {
+			assert.Equal(t, float64(123), inputs["number"])
+			assert.Equal(t, "OWNER", inputs["owner"])
+			assert.Equal(t, "REPO", inputs["name"])
+		}),
+	)
+	reg.Register(
+		httpmock.GraphQL(`query FindRepoBranchID\b`),
+		httpmock.StringResponse(`{"data":{"repository":{"id":"REPOID","ref":{"target":{"oid":"OID"}}}}}`),
+	)
+	reg.Register(
+		httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
+		httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"2","ref":{"name":"-foo"}}}}}`,
+			func(inputs map[string]interface{}) {
+				assert.Equal(t, "REPOID", inputs["repositoryId"])
+				assert.Equal(t, "SOMEID", inputs["issueId"])
+				assert.Equal(t, "OID", inputs["oid"])
+				assert.Equal(t, "my-branch", inputs["name"])
+			}),
+	)
+
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &DevelopOptions{
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		GitClient: &git.Client{
+			GhPath:  "some/path/gh",
+			GitPath: "some/path/git",
+		},
+		IO: ios,
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.New("OWNER", "REPO"), nil
+		},
+		Remotes: func() (context.Remotes, error) {
+			return context.Remotes{
+				&context.Remote{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   ghrepo.New("OWNER", "REPO"),
+				},
+			}, nil
+		},
+		Name:        "my-branch",
+		BaseBranch:  "main",
+		IssueNumber: 123,
+	}
+
+	err := developRun(opts)
+	require.EqualError(t, err, `invalid branch name: "-foo"`)
+}
+
+func TestCheckoutBranch_invalidBranchName(t *testing.T) {
+	ios, _, stdout, stderr := iostreams.Test()
+
+	err := checkoutBranch(&DevelopOptions{
+		IO:        ios,
+		GitClient: &git.Client{GitPath: "some/path/git"},
+		Remotes: func() (context.Remotes, error) {
+			return context.Remotes{
+				&context.Remote{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   ghrepo.New("OWNER", "REPO"),
+				},
+			}, nil
+		},
+		Checkout: true,
+	}, ghrepo.New("OWNER", "REPO"), "-foo", prShared.WorktreeTarget{})
+
+	require.EqualError(t, err, `invalid branch name: "-foo"`)
+	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "", stderr.String())
 }


### PR DESCRIPTION
Closes #14238

### Description

`gh pr checkout` already rejects head branch names that begin with `-` before passing them to Git, but `gh issue develop` did not apply the same guard. This change adds a shared `validateBranchName` helper in `issue develop` and uses it both after linked-branch creation/reuse and again at the top of `checkoutBranch`, so `SetBranchConfig`, fetch, checkout, and pull never receive a leading-dash branch name.

### How did you test this change?

Given `issue develop` receives a linked branch name of `-foo`
When the branch name comes back from linked-branch creation or is passed directly into `checkoutBranch`
Then the command now returns `invalid branch name: -foo` before trying to run `git config`, `git fetch`, `git checkout`, or `git pull`

I exercised both paths with focused regression coverage and verified that removing the guard makes those new tests fail.

### Key points

This keeps `issue develop` aligned with the existing `pr checkout` defense-in-depth behavior instead of inventing a separate policy. The validation happens in both entry points so the error is raised before branch config is written and before any later caller can reach Git through `checkoutBranch` directly.

### Notes for reviewers

Review can start in `pkg/cmd/issue/develop/develop.go`, then `pkg/cmd/issue/develop/develop_test.go` for the two added regression tests.

I only ran focused tests locally on Windows. I did not run `go test ./...` because this package currently includes a symlink-based worktree test that requires Windows symlink privileges outside this session's environment.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @nishantmulchandani will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.