### PR TITLE
Fix namespaced skill install file tree output

### DIFF
--- a/internal/skills/discovery/discovery.go
+++ b/internal/skills/discovery/discovery.go
@@ -74,10 +74,7 @@ func (s Skill) DisplayName() string {
 	}
 }
 
-// InstallName returns the relative path used for the install directory.
-// For namespaced skills it returns "namespace/name" (creating a nested directory),
-// otherwise it returns the plain name. Callers should use filepath.FromSlash
-// when building OS-specific paths from this value.
+// InstallName returns "namespace/name" when a namespace is present, or the skill name otherwise.
 func (s Skill) InstallName() string {
 	if s.Namespace != "" {
 		return s.Namespace + "/" + s.Name

--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -1154,8 +1154,9 @@ func printFileTree(w io.Writer, cs *iostreams.ColorScheme, dir string, skillName
 	}
 	fmt.Fprintln(w)
 	for _, name := range skillNames {
-		skillDir := filepath.Join(dir, filepath.FromSlash(name))
-		fmt.Fprintf(w, "  %s\n", cs.Bold(name+"/"))
+		skillDirName := filepath.Base(filepath.FromSlash(name))
+		skillDir := filepath.Join(dir, skillDirName)
+		fmt.Fprintf(w, "  %s\n", cs.Bold(skillDirName+"/"))
 		printTreeDir(w, cs, skillDir, "  ")
 	}
 }

--- a/pkg/cmd/skills/install/install_test.go
+++ b/pkg/cmd/skills/install/install_test.go
@@ -1880,6 +1880,7 @@ func TestRunLocalInstall(t *testing.T) {
 				assert.Contains(t, string(content), "alice xlsx-pro")
 			},
 			wantStdout: "Installed",
+			wantStderr: "xlsx-pro/\n  └── SKILL.md",
 		},
 		{
 			name:  "local install existing skill without force non-interactive errors",


### PR DESCRIPTION
Fixes #14190

### Description

Namespaced skills install into flat directories, but the post-install file tree still resolves their qualified names as nested paths. Successful installs therefore display `(could not read directory)`.

Resolve each file-tree entry from its flat on-disk name while preserving the qualified name in the success message. The `InstallName` comment now describes the returned name instead of the obsolete nested install layout.

### How did you test this change?

Given a local skill at `src/skills/alice/deploy/SKILL.md`, I ran:

```sh
bin/gh skill install ./src --from-local --all --force --dir target
```

Before, the install succeeded but displayed:

```text
Installed alice/deploy (from ./src) in target

  alice/deploy/
  (could not read directory)
```

After, it displayed the installed directory and file:

```text
Installed alice/deploy (from ./src) in target

  deploy/
  └── SKILL.md
```

The installed file remained at `target/deploy/SKILL.md`.

### Key points

- Only the post-install file tree on stderr changes; the install itself and its file layout are untouched.
- Success messages and the lockfile continue to use the qualified name (`alice/deploy`). Only the tree label and the directory it reads use the flat name.
- `printFileTree` derives the flat name from the qualified name it already receives, so the installer's `Result` shape stays unchanged.

### Notes for reviewers

The behavior change is in `printFileTree`, which both the repository and `--from-local` install paths call. The regression assertion extends the existing namespaced local-install table case.

#13266 introduced the flat install layout that this output now follows.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @Hiro5409 will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
