### PR TITLE
Clarify skill publish error for nested skill directories

### DIFF
--- a/pkg/cmd/skills/publish/publish.go
+++ b/pkg/cmd/skills/publish/publish.go
@@ -104,9 +104,6 @@ func NewCmdPublish(f *cmdutil.Factory, runF func(*PublishOptions) error) *cobra.
 			Validate a local repository's skills against the Agent Skills specification
 			and publish them by creating a GitHub release.
 
-			The directory must be the root of a Git repository so that all skills are
-			validated before the repository is tagged and released.
-
 			Skills are discovered using the same conventions as install:
 
 			  - %[1]sskills/*/SKILL.md%[1]s
@@ -183,14 +180,6 @@ func publishRun(opts *PublishOptions) error {
 		return fmt.Errorf("could not resolve path: %w", err)
 	}
 
-	if opts.GitClient != nil {
-		dirGitClient := opts.GitClient.Copy()
-		dirGitClient.RepoDir = dir
-		if dirGitClient.PathFromRoot(context.Background()) != "" {
-			return fmt.Errorf("%s is not a repository root; gh skill publish must target the repository root", dir)
-		}
-	}
-
 	canPrompt := opts.IO.CanPrompt()
 
 	// Client initialization is deferred until after local validation so that
@@ -204,6 +193,15 @@ func publishRun(opts *PublishOptions) error {
 	skills, err := discovery.DiscoverLocalSkills(dir)
 	if err != nil {
 		return err
+	}
+
+	// Discovery uses "." when the supplied directory is itself a skill.
+	if len(skills) == 1 && skills[0].Path == "." && opts.GitClient != nil {
+		dirGitClient := opts.GitClient.Copy()
+		dirGitClient.RepoDir = dir
+		if dirGitClient.PathFromRoot(context.Background()) != "" {
+			return fmt.Errorf("%s is a skill directory within a repository; gh skill publish must target the repository root", dir)
+		}
 	}
 
 	for _, skill := range skills {

--- a/pkg/cmd/skills/publish/publish.go
+++ b/pkg/cmd/skills/publish/publish.go
@@ -104,6 +104,9 @@ func NewCmdPublish(f *cmdutil.Factory, runF func(*PublishOptions) error) *cobra.
 			Validate a local repository's skills against the Agent Skills specification
 			and publish them by creating a GitHub release.
 
+			The directory must be the root of a Git repository so that all skills are
+			validated before the repository is tagged and released.
+
 			Skills are discovered using the same conventions as install:
 
 			  - %[1]sskills/*/SKILL.md%[1]s
@@ -178,6 +181,14 @@ func publishRun(opts *PublishOptions) error {
 	dir, err := filepath.Abs(dir)
 	if err != nil {
 		return fmt.Errorf("could not resolve path: %w", err)
+	}
+
+	if opts.GitClient != nil {
+		dirGitClient := opts.GitClient.Copy()
+		dirGitClient.RepoDir = dir
+		if dirGitClient.PathFromRoot(context.Background()) != "" {
+			return fmt.Errorf("%s is not a repository root; gh skill publish must target the repository root", dir)
+		}
 	}
 
 	canPrompt := opts.IO.CanPrompt()

--- a/pkg/cmd/skills/publish/publish_test.go
+++ b/pkg/cmd/skills/publish/publish_test.go
@@ -26,10 +26,6 @@ func newTestGitClient() *git.Client {
 	return &git.Client{GitPath: "some/path/git"}
 }
 
-func stubGitRepositoryRoot(cs *run.CommandStubber) {
-	cs.Register(`git( .+)? rev-parse --show-prefix`, 0, "\n")
-}
-
 // stubGitRemote registers CommandStubber stubs for git remote detection.
 func stubGitRemote(cs *run.CommandStubber, remoteURLs map[string]string) {
 	var remoteLines string
@@ -165,7 +161,6 @@ func TestPublishRun_UnsupportedHost(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	stubGitRepositoryRoot(cs)
 	stubGitRemote(cs, map[string]string{"origin": "https://github.com/monalisa/skills-repo.git"})
 
 	ios, _, _, _ := iostreams.Test()
@@ -179,7 +174,7 @@ func TestPublishRun_UnsupportedHost(t *testing.T) {
 	require.ErrorContains(t, err, "does not currently support GitHub Enterprise Server")
 }
 
-func TestPublishRun_RejectsDirectoryWithinRepository(t *testing.T) {
+func TestPublishRun_ExplainsSkillDirectoryWithinRepository(t *testing.T) {
 	repoDir := t.TempDir()
 	writeSkill(t, repoDir, "reskill", heredoc.Doc(`
 		---
@@ -202,7 +197,7 @@ func TestPublishRun_RejectsDirectoryWithinRepository(t *testing.T) {
 		GitClient: newTestGitClient(),
 	})
 
-	require.ErrorContains(t, err, "is not a repository root; gh skill publish must target the repository root")
+	require.ErrorContains(t, err, "is a skill directory within a repository; gh skill publish must target the repository root")
 	assert.NotContains(t, err.Error(), `does not match directory name "."`)
 }
 
@@ -1538,7 +1533,6 @@ func TestPublishRun(t *testing.T) {
 			if tt.cmdStubs != nil {
 				cs, cmdTeardown := run.Stub()
 				defer cmdTeardown(t)
-				stubGitRepositoryRoot(cs)
 				tt.cmdStubs(cs)
 			}
 
@@ -1586,7 +1580,6 @@ func TestDetectGitHubRemote_UsesDir(t *testing.T) {
 func TestPublishRun_DirArgUsesTargetRemote(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	stubGitRepositoryRoot(cs)
 	stubGitRemote(cs, map[string]string{
 		"origin": "https://github.com/monalisa/target-repo.git",
 	})

--- a/pkg/cmd/skills/publish/publish_test.go
+++ b/pkg/cmd/skills/publish/publish_test.go
@@ -26,6 +26,10 @@ func newTestGitClient() *git.Client {
 	return &git.Client{GitPath: "some/path/git"}
 }
 
+func stubGitRepositoryRoot(cs *run.CommandStubber) {
+	cs.Register(`git( .+)? rev-parse --show-prefix`, 0, "\n")
+}
+
 // stubGitRemote registers CommandStubber stubs for git remote detection.
 func stubGitRemote(cs *run.CommandStubber, remoteURLs map[string]string) {
 	var remoteLines string
@@ -161,6 +165,7 @@ func TestPublishRun_UnsupportedHost(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
+	stubGitRepositoryRoot(cs)
 	stubGitRemote(cs, map[string]string{"origin": "https://github.com/monalisa/skills-repo.git"})
 
 	ios, _, _, _ := iostreams.Test()
@@ -172,6 +177,33 @@ func TestPublishRun_UnsupportedHost(t *testing.T) {
 		host:       "acme.ghes.com",
 	})
 	require.ErrorContains(t, err, "does not currently support GitHub Enterprise Server")
+}
+
+func TestPublishRun_RejectsDirectoryWithinRepository(t *testing.T) {
+	repoDir := t.TempDir()
+	writeSkill(t, repoDir, "reskill", heredoc.Doc(`
+		---
+		name: reskill
+		description: A test skill
+		license: MIT
+		---
+		Body.
+	`))
+	skillDir := filepath.Join(repoDir, "skills", "reskill")
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+	cs.Register(`git( .+)? rev-parse --show-prefix`, 0, "skills/reskill/\n")
+
+	ios, _, _, _ := iostreams.Test()
+	err := publishRun(&PublishOptions{
+		IO:        ios,
+		Dir:       skillDir,
+		GitClient: newTestGitClient(),
+	})
+
+	require.ErrorContains(t, err, "is not a repository root; gh skill publish must target the repository root")
+	assert.NotContains(t, err.Error(), `does not match directory name "."`)
 }
 
 func TestPublishRun(t *testing.T) {
@@ -1506,6 +1538,7 @@ func TestPublishRun(t *testing.T) {
 			if tt.cmdStubs != nil {
 				cs, cmdTeardown := run.Stub()
 				defer cmdTeardown(t)
+				stubGitRepositoryRoot(cs)
 				tt.cmdStubs(cs)
 			}
 
@@ -1553,6 +1586,7 @@ func TestDetectGitHubRemote_UsesDir(t *testing.T) {
 func TestPublishRun_DirArgUsesTargetRemote(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
+	stubGitRepositoryRoot(cs)
 	stubGitRemote(cs, map[string]string{
 		"origin": "https://github.com/monalisa/target-repo.git",
 	})


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

Closes #14134

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

When `gh skill publish` is given a skill directory containing `SKILL.md` directly, shared discovery represents that skill's path as `.`. Publish then compares the skill name with `.` and reports the misleading error `name "reskill" does not match directory name "."`.

This change recognizes only that already-failing case when the selected skill directory is inside a Git repository and replaces the name-mismatch error with an explanation that `gh skill publish` must target the repository root. It does not add general repository-root enforcement or change successful publishing behavior.

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

### How did you test this change?

Given this checkout contains `skills/gh-skill`, when I ran `go run ./cmd/gh skill publish skills/gh-skill --dry-run`, then the command still exited unsuccessfully but explained that the selected path is a skill directory within a repository and that publishing must target the repository root.

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

### Key points

- Checks only a single directly supplied skill represented by discovery as `.`.
- Preserves the existing failure and changes only its explanation.
- Leaves all other directory targeting and publishing behavior unchanged.

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

### Notes for reviewers

Start with the targeted check in `publishRun`, followed by `TestPublishRun_ExplainsSkillDirectoryWithinRepository`. #14134 contains the original misleading diagnostic.

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @tommaso-moro will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.