### PR TITLE
Support PI_CODING_AGENT_DIR for skills

### DIFF
--- a/internal/skills/registry/registry.go
+++ b/internal/skills/registry/registry.go
@@ -31,7 +31,8 @@ const (
 
 	DefaultAgentID = "github-copilot"
 
-	claudeConfigDirEnv = "CLAUDE_CONFIG_DIR"
+	claudeConfigDirEnv  = "CLAUDE_CONFIG_DIR"
+	piCodingAgentDirEnv = "PI_CODING_AGENT_DIR"
 
 	sharedProjectSkillsDir = ".agents/skills"
 )
@@ -415,8 +416,15 @@ func (h *AgentHost) InstallDir(scope Scope, gitRoot, homeDir string) (string, er
 		}
 		return filepath.Join(gitRoot, h.ProjectDir), nil
 	case ScopeUser:
-		if h.ID == "claude-code" {
-			if configDir := os.Getenv(claudeConfigDirEnv); configDir != "" {
+		var configDirEnv string
+		switch h.ID {
+		case "claude-code":
+			configDirEnv = claudeConfigDirEnv
+		case "pi":
+			configDirEnv = piCodingAgentDirEnv
+		}
+		if configDirEnv != "" {
+			if configDir := os.Getenv(configDirEnv); configDir != "" {
 				return filepath.Join(configDir, "skills"), nil
 			}
 		}

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -44,6 +44,7 @@ func TestFindByID(t *testing.T) {
 
 func TestInstallDir(t *testing.T) {
 	t.Setenv(claudeConfigDirEnv, "")
+	t.Setenv(piCodingAgentDirEnv, "")
 
 	tests := []struct {
 		name    string
@@ -90,13 +91,32 @@ func TestInstallDir(t *testing.T) {
 		{
 			name: "claude code user scope, respect env var",
 			setup: func(t *testing.T) {
-				t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join("/home", "monalisa", ".config", "claude"))
+				t.Setenv(claudeConfigDirEnv, filepath.Join("/home", "monalisa", ".config", "claude"))
 			},
 			hostID:  "claude-code",
 			scope:   ScopeUser,
 			gitRoot: "/tmp/monalisa-repo",
 			homeDir: "/home/monalisa",
 			wantDir: filepath.Join("/home", "monalisa", ".config", "claude", "skills"),
+		},
+		{
+			name:    "pi user scope",
+			hostID:  "pi",
+			scope:   ScopeUser,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/home/monalisa", ".pi", "agent", "skills"),
+		},
+		{
+			name: "pi user scope, respect env var",
+			setup: func(t *testing.T) {
+				t.Setenv(piCodingAgentDirEnv, filepath.Join("/home", "monalisa", ".config", "pi", "agent"))
+			},
+			hostID:  "pi",
+			scope:   ScopeUser,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/home", "monalisa", ".config", "pi", "agent", "skills"),
 		},
 		{
 			name:    "cursor project scope",

--- a/pkg/cmd/skills/install/install_test.go
+++ b/pkg/cmd/skills/install/install_test.go
@@ -1589,6 +1589,37 @@ func TestInstallRun(t *testing.T) {
 			},
 			wantStdout: "Installed git-commit",
 		},
+		{
+			name: "respect pi coding agent dir env var for user scope",
+			setup: func(t *testing.T) {
+				t.Setenv("PI_CODING_AGENT_DIR", t.TempDir())
+			},
+			stubs: func(reg *httpmock.Registry) {
+				stubResolveVersion(reg, "monalisa", "skills-repo", "v1.0.0", "abc123")
+				stubDiscoverTree(reg, "monalisa", "skills-repo", "abc123",
+					singleSkillTreeJSON("git-commit", "treeSHA", "blobSHA"))
+				stubInstallFiles(reg, "monalisa", "skills-repo", "treeSHA", "blobSHA", gitCommitContent)
+			},
+			opts: func(ios *iostreams.IOStreams, reg *httpmock.Registry) *InstallOptions {
+				t.Helper()
+				return &InstallOptions{
+					IO:           ios,
+					HttpClient:   func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+					GitClient:    &git.Client{RepoDir: t.TempDir()},
+					SkillSource:  "monalisa/skills-repo",
+					SkillName:    "git-commit",
+					Agent:        "pi",
+					Scope:        "user",
+					ScopeChanged: true,
+					Telemetry:    &telemetry.NoOpService{},
+				}
+			},
+			assert: func(t *testing.T) {
+				assert.FileExists(t, filepath.Join(os.Getenv("PI_CODING_AGENT_DIR"), "skills", "git-commit", "SKILL.md"))
+				assert.NoFileExists(t, filepath.Join(os.Getenv("HOME"), ".pi", "agent", "skills", "git-commit", "SKILL.md"))
+			},
+			wantStdout: "Installed git-commit",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Fixes #14118

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

Pi supports relocating its global agent configuration with `PI_CODING_AGENT_DIR` and discovers global skills under that directory's `skills/` subdirectory. `gh skill` ignored the override and always used `~/.pi/agent/skills` for Pi user-scope operations.

This updates the shared agent registry resolver to use `$PI_CODING_AGENT_DIR/skills` when the variable is set. Because install, list, and update all use this resolver, they now agree on the custom Pi location. When the variable is unset, the existing `~/.pi/agent/skills` fallback remains unchanged.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

Given `PI_CODING_AGENT_DIR` pointed to this checkout's `.github` directory, whose `skills/` directory contains the `code-review` skill, when I ran `go run ./cmd/gh skill list --agent pi --scope user --json skillName,path`, the command reported `code-review` at `.github/skills/code-review` instead of looking under `~/.pi/agent/skills`.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

The change stays in `AgentHost.InstallDir`, matching the existing `CLAUDE_CONFIG_DIR` handling. Project-scope resolution and every other agent remain unchanged.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `internal/skills/registry/registry.go`, then review the registry and install regression tests. Pi's current [environment variable documentation](https://pi.dev/docs/latest/environment-variables) defines `PI_CODING_AGENT_DIR` as the config-directory override, and its [skills documentation](https://pi.dev/docs/latest/skills#locations) places global skills beneath the agent directory. This follows the same approach merged for Claude Code in #13523.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @tommaso-moro will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.