### PR TITLE
Document attachment support in `gh` skill

### DIFF
--- a/skills/gh/SKILL.md
+++ b/skills/gh/SKILL.md
@@ -93,6 +93,40 @@ blocked-by/blocking relationships.
 - GHES: issue types and sub-issues need 3.17+; blocked-by/blocking
   relationships need 3.19+.
 
+## Attaching images and videos
+
+`--attach <path>` is available on `gh issue create`, `gh issue edit`,
+`gh issue comment`, `gh pr create`, `gh pr edit`, and `gh pr comment`.
+
+- Repeat `--attach` to upload multiple files:
+  `gh issue comment 12 --attach ./before.png --attach ./after.png`.
+- Supported files are `png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`, `mp4`,
+  `mov`, and `webm`.
+- For an image, append alt text to the path after `#`. Quote the value so the
+  shell does not treat `#` as a comment:
+  `gh pr create --attach './login.png#The login error state'`. Without alt
+  text, the filename is used.
+- If the body references an attached path, `gh` rewrites that Markdown
+  reference to the uploaded URL. The reference keeps its existing alt text.
+  Otherwise, `gh` appends the attachment to the body. For example:
+  `gh pr edit 23 --body '![error](./login.png)' --attach ./login.png`.
+- Videos cannot take alt text. A standalone `![recording](./repro.mp4)` becomes
+  a bare player URL, while an inline video image becomes a link. A
+  reference-style video image such as `![recording][clip]` with
+  `[clip]: ./repro.mp4` is rejected; use a reference-style link instead.
+- `gh issue create` and `gh pr create`: `--attach` cannot be used with
+  `--web`. `gh pr create --attach` also cannot be used with `--dry-run`.
+- `gh issue edit`: `--attach` can edit only one issue at a time.
+- `gh issue comment` and `gh pr comment`: `--attach` cannot be used with
+  `--web` or `--delete-last`. It works alone, with `--edit-last`, or with one
+  of `--body`, `--body-file`, or `--editor`.
+- Uploads require GitHub.com or a GHE.com tenant, an OAuth token, classic PAT,
+  or fine-grained PAT, and `WRITE`, `MAINTAIN`, or `ADMIN` repository
+  permission. GitHub Enterprise Server and GitHub App tokens are unsupported.
+- Uploads stop at the first failure. If earlier files uploaded, `gh` still
+  writes those attachments and exits non-zero. Create and edit commands also
+  print the issue or pull request URL.
+
 ## Discussions (`gh discussion`)
 
 Preview command set, subject to change. Subcommands:


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

Related implementation: https://github.com/cli/cli/pull/14255

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the background they need before the problem makes sense, and avoid jargon.
-->

The installable `gh` agent skill does not describe the new repeatable `--attach` flag. Agents using the skill would miss the supported commands, argument format, Markdown rewriting, video behavior, incompatible modes, authentication requirements, and partial-failure contract.

This adds one concise attachment section to `skills/gh/SKILL.md`, following the skill's existing bullet-oriented style and inline command examples.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

I previewed the installable skill package with `gh skill publish --dry-run .` and read the rendered source alongside the command help and attachment tests on the parent branch.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- Covers all six issue, pull request, and comment commands that support attachments.
- Keeps invocation guidance in the `gh` skill rather than documenting implementation details.
- Distinguishes image alt text, standalone video players, inline video links, and unsupported reference-style video images.
- Records the host, token, permission, conflict, and partial-failure constraints agents need before invoking the flag.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Review the new **Attaching images and videos** section in `skills/gh/SKILL.md`. The file path is the tracked skill source installed by `gh skill install cli/cli gh --scope user`.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
