### PR TITLE
Address final attachment review feedback

### DIFF
--- a/internal/attachments/client.go
+++ b/internal/attachments/client.go
@@ -213,7 +213,11 @@ func (e *uploadError) Error() string {
 		if e.RetryAfter == "" {
 			return fmt.Sprintf("could not upload %s: rate limited; wait and try again", e.Path)
 		}
-		return fmt.Sprintf("could not upload %s: rate limited; retry after %s", e.Path, e.RetryAfter)
+		retryAfter := e.RetryAfter
+		if seconds, err := strconv.Atoi(e.RetryAfter); err == nil {
+			retryAfter = fmt.Sprintf("%d seconds", seconds)
+		}
+		return fmt.Sprintf("could not upload %s: rate limited; retry after %s", e.Path, retryAfter)
 	}
 	return fmt.Sprintf("failed to upload %s: %v", e.Path, e.err)
 }

--- a/internal/attachments/client_test.go
+++ b/internal/attachments/client_test.go
@@ -258,7 +258,17 @@ func TestUploadErrors(t *testing.T) {
 			status:         429,
 			response:       `{"message":"Too Many Requests"}`,
 			retryAfter:     "120",
-			wantErr:        "could not upload ./shot.png: rate limited; retry after 120",
+			wantErr:        "could not upload ./shot.png: rate limited; retry after 120 seconds",
+			wantStatusCode: 429,
+		},
+		{
+			name:           "rate limited until a date",
+			file:           "shot.png",
+			contentType:    "image/png",
+			status:         429,
+			response:       `{"message":"Too Many Requests"}`,
+			retryAfter:     "Wed, 21 Oct 2015 07:28:00 GMT",
+			wantErr:        "could not upload ./shot.png: rate limited; retry after Wed, 21 Oct 2015 07:28:00 GMT",
 			wantStatusCode: 429,
 		},
 		{

--- a/skills/gh/SKILL.md
+++ b/skills/gh/SKILL.md
@@ -106,6 +106,8 @@ blocked-by/blocking relationships.
   shell does not treat `#` as a comment:
   `gh pr create --attach './login.png#The login error state'`. Without alt
   text, the filename is used.
+- `--attach` paths and local Markdown destinations may be absolute or relative
+  to the directory where `gh` runs.
 - If the body references an attached path, `gh` rewrites that Markdown
   reference to the uploaded URL. The reference keeps its existing alt text.
   Otherwise, `gh` appends the attachment to the body. For example:


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

Related review feedback:

- https://github.com/cli/cli/pull/14200#discussion_r3857188576
- https://github.com/cli/cli/pull/14261#discussion_r3857313592

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the background they need before the problem makes sense, and avoid jargon.
-->

Two non-blocking review comments arrived after the final attachment stack layers were approved. Numeric `Retry-After` values did not name their unit, and the installable `gh` skill did not explain how attachment paths are resolved.

This adds a `seconds` suffix only when `Retry-After` is numeric, preserving valid HTTP-date values unchanged. It also documents that `--attach` paths and local Markdown destinations may be absolute or relative to the directory where `gh` runs.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

Given an upload response with `Retry-After: 120`
When `gh` renders the rate-limit error
Then it says `retry after 120 seconds`

Given the header contains an HTTP date
When `gh` renders the rate-limit error
Then it preserves the date without adding a unit

I also previewed the installable skill package with `gh skill publish --dry-run .`.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- Numeric retry windows gain an explicit unit without changing the empty-header or HTTP-date cases.
- The path guidance matches the existing absolute-path normalization used for attachment arguments and Markdown destinations.
- Each review thread has its own commit.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Review the commits in order:

1. `Clarify rate limit retry units` updates the error and its existing table coverage.
2. `Document attachment path resolution` updates the installable skill.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
