### PR TITLE
Add dataType to gh project field-list JSON and table output

### DIFF
--- a/pkg/cmd/project/field-create/field_create_test.go
+++ b/pkg/cmd/project/field-create/field_create_test.go
@@ -697,6 +697,7 @@ func TestRunCreateField_JSON(t *testing.T) {
 						"__typename": "ProjectV2Field",
 						"id":         "Field ID",
 						"name":       "a name",
+						"dataType":   "TEXT",
 					},
 				},
 			},
@@ -721,6 +722,6 @@ func TestRunCreateField_JSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(
 		t,
-		`{"id":"Field ID","name":"a name","type":"ProjectV2Field"}`,
+		`{"id":"Field ID","name":"a name","type":"ProjectV2Field","dataType":"TEXT"}`,
 		stdout.String())
 }

--- a/pkg/cmd/project/field-delete/field_delete_test.go
+++ b/pkg/cmd/project/field-delete/field_delete_test.go
@@ -131,6 +131,7 @@ func TestRunDeleteField_JSON(t *testing.T) {
 						"__typename": "ProjectV2Field",
 						"id":         "Field ID",
 						"name":       "a name",
+						"dataType":   "TEXT",
 					},
 				},
 			},
@@ -152,6 +153,6 @@ func TestRunDeleteField_JSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(
 		t,
-		`{"id":"Field ID","name":"a name","type":"ProjectV2Field"}`,
+		`{"id":"Field ID","name":"a name","type":"ProjectV2Field","dataType":"TEXT"}`,
 		stdout.String())
 }

--- a/pkg/cmd/project/field-list/field_list.go
+++ b/pkg/cmd/project/field-list/field_list.go
@@ -109,7 +109,7 @@ func printResults(config listConfig, fields []queries.ProjectField, login string
 
 	for _, f := range fields {
 		tp.AddField(f.Name())
-		tp.AddField(f.Type())
+		tp.AddField(f.DataType())
 		tp.AddField(f.ID(), tableprinter.WithTruncate(nil))
 		tp.EndRow()
 	}

--- a/pkg/cmd/project/field-list/field_list_test.go
+++ b/pkg/cmd/project/field-list/field_list_test.go
@@ -142,16 +142,19 @@ func TestRunList_User_tty(t *testing.T) {
 									"__typename": "ProjectV2Field",
 									"name":       "FieldTitle",
 									"id":         "field ID",
+									"dataType":   "TEXT",
 								},
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"name":       "Status",
 									"id":         "status ID",
+									"dataType":   "SINGLE_SELECT",
 								},
 								{
 									"__typename": "ProjectV2IterationField",
 									"name":       "Iterations",
 									"id":         "iteration ID",
+									"dataType":   "ITERATION",
 								},
 							},
 						},
@@ -176,10 +179,10 @@ func TestRunList_User_tty(t *testing.T) {
 	err := runList(config)
 	assert.NoError(t, err)
 	assert.Equal(t, heredoc.Doc(`
-		NAME        DATA TYPE                   ID
-		FieldTitle  ProjectV2Field              field ID
-		Status      ProjectV2SingleSelectField  status ID
-		Iterations  ProjectV2IterationField     iteration ID
+		NAME        DATA TYPE      ID
+		FieldTitle  TEXT           field ID
+		Status      SINGLE_SELECT  status ID
+		Iterations  ITERATION      iteration ID
   `), stdout.String())
 }
 
@@ -237,16 +240,19 @@ func TestRunList_User(t *testing.T) {
 									"__typename": "ProjectV2Field",
 									"name":       "FieldTitle",
 									"id":         "field ID",
+									"dataType":   "TEXT",
 								},
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"name":       "Status",
 									"id":         "status ID",
+									"dataType":   "SINGLE_SELECT",
 								},
 								{
 									"__typename": "ProjectV2IterationField",
 									"name":       "Iterations",
 									"id":         "iteration ID",
+									"dataType":   "ITERATION",
 								},
 							},
 						},
@@ -271,7 +277,7 @@ func TestRunList_User(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(
 		t,
-		"FieldTitle\tProjectV2Field\tfield ID\nStatus\tProjectV2SingleSelectField\tstatus ID\nIterations\tProjectV2IterationField\titeration ID\n",
+		"FieldTitle\tTEXT\tfield ID\nStatus\tSINGLE_SELECT\tstatus ID\nIterations\tITERATION\titeration ID\n",
 		stdout.String())
 }
 
@@ -329,16 +335,19 @@ func TestRunList_Org(t *testing.T) {
 									"__typename": "ProjectV2Field",
 									"name":       "FieldTitle",
 									"id":         "field ID",
+									"dataType":   "TEXT",
 								},
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"name":       "Status",
 									"id":         "status ID",
+									"dataType":   "SINGLE_SELECT",
 								},
 								{
 									"__typename": "ProjectV2IterationField",
 									"name":       "Iterations",
 									"id":         "iteration ID",
+									"dataType":   "ITERATION",
 								},
 							},
 						},
@@ -363,7 +372,7 @@ func TestRunList_Org(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(
 		t,
-		"FieldTitle\tProjectV2Field\tfield ID\nStatus\tProjectV2SingleSelectField\tstatus ID\nIterations\tProjectV2IterationField\titeration ID\n",
+		"FieldTitle\tTEXT\tfield ID\nStatus\tSINGLE_SELECT\tstatus ID\nIterations\tITERATION\titeration ID\n",
 		stdout.String())
 }
 
@@ -411,16 +420,19 @@ func TestRunList_Me(t *testing.T) {
 									"__typename": "ProjectV2Field",
 									"name":       "FieldTitle",
 									"id":         "field ID",
+									"dataType":   "TEXT",
 								},
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"name":       "Status",
 									"id":         "status ID",
+									"dataType":   "SINGLE_SELECT",
 								},
 								{
 									"__typename": "ProjectV2IterationField",
 									"name":       "Iterations",
 									"id":         "iteration ID",
+									"dataType":   "ITERATION",
 								},
 							},
 						},
@@ -445,7 +457,7 @@ func TestRunList_Me(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(
 		t,
-		"FieldTitle\tProjectV2Field\tfield ID\nStatus\tProjectV2SingleSelectField\tstatus ID\nIterations\tProjectV2IterationField\titeration ID\n",
+		"FieldTitle\tTEXT\tfield ID\nStatus\tSINGLE_SELECT\tstatus ID\nIterations\tITERATION\titeration ID\n",
 		stdout.String())
 }
 
@@ -568,16 +580,19 @@ func TestRunList_JSON(t *testing.T) {
 									"__typename": "ProjectV2Field",
 									"name":       "FieldTitle",
 									"id":         "field ID",
+									"dataType":   "TEXT",
 								},
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"name":       "Status",
 									"id":         "status ID",
+									"dataType":   "SINGLE_SELECT",
 								},
 								{
 									"__typename": "ProjectV2IterationField",
 									"name":       "Iterations",
 									"id":         "iteration ID",
+									"dataType":   "ITERATION",
 								},
 							},
 							"totalCount": 3,
@@ -604,6 +619,6 @@ func TestRunList_JSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(
 		t,
-		`{"fields":[{"id":"field ID","name":"FieldTitle","type":"ProjectV2Field"},{"id":"status ID","name":"Status","type":"ProjectV2SingleSelectField"},{"id":"iteration ID","name":"Iterations","type":"ProjectV2IterationField"}],"totalCount":3}`,
+		`{"fields":[{"id":"field ID","name":"FieldTitle","type":"ProjectV2Field","dataType":"TEXT"},{"id":"status ID","name":"Status","type":"ProjectV2SingleSelectField","dataType":"SINGLE_SELECT"},{"id":"iteration ID","name":"Iterations","type":"ProjectV2IterationField","dataType":"ITERATION"}],"totalCount":3}`,
 		stdout.String())
 }

--- a/pkg/cmd/project/shared/queries/export_data_test.go
+++ b/pkg/cmd/project/shared/queries/export_data_test.go
@@ -97,11 +97,12 @@ func TestJSONProjectField_FieldType(t *testing.T) {
 	field.TypeName = "ProjectV2Field"
 	field.Field.ID = "123"
 	field.Field.Name = "name"
+	field.Field.DataType = "TEXT"
 
 	b, err := json.Marshal(field.ExportData(nil))
 	assert.NoError(t, err)
 
-	assert.Equal(t, `{"id":"123","name":"name","type":"ProjectV2Field"}`, string(b))
+	assert.Equal(t, `{"dataType":"TEXT","id":"123","name":"name","type":"ProjectV2Field"}`, string(b))
 }
 
 func TestJSONProjectField_SingleSelectType(t *testing.T) {
@@ -109,6 +110,7 @@ func TestJSONProjectField_SingleSelectType(t *testing.T) {
 	field.TypeName = "ProjectV2SingleSelectField"
 	field.SingleSelectField.ID = "123"
 	field.SingleSelectField.Name = "name"
+	field.SingleSelectField.DataType = "SINGLE_SELECT"
 	field.SingleSelectField.Options = []SingleSelectFieldOptions{
 		{
 			ID:   "123",
@@ -123,7 +125,7 @@ func TestJSONProjectField_SingleSelectType(t *testing.T) {
 	b, err := json.Marshal(field.ExportData(nil))
 	assert.NoError(t, err)
 
-	assert.JSONEq(t, `{"id":"123","name":"name","type":"ProjectV2SingleSelectField","options":[{"id":"123","name":"name"},{"id":"456","name":"name2"}]}`, string(b))
+	assert.JSONEq(t, `{"id":"123","name":"name","type":"ProjectV2SingleSelectField","dataType":"SINGLE_SELECT","options":[{"id":"123","name":"name"},{"id":"456","name":"name2"}]}`, string(b))
 }
 
 func TestJSONProjectField_ProjectV2IterationField(t *testing.T) {
@@ -131,11 +133,12 @@ func TestJSONProjectField_ProjectV2IterationField(t *testing.T) {
 	field.TypeName = "ProjectV2IterationField"
 	field.IterationField.ID = "123"
 	field.IterationField.Name = "name"
+	field.IterationField.DataType = "ITERATION"
 
 	b, err := json.Marshal(field.ExportData(nil))
 	assert.NoError(t, err)
 
-	assert.Equal(t, `{"id":"123","name":"name","type":"ProjectV2IterationField"}`, string(b))
+	assert.Equal(t, `{"dataType":"ITERATION","id":"123","name":"name","type":"ProjectV2IterationField"}`, string(b))
 }
 
 func TestJSONProjectFields(t *testing.T) {
@@ -143,11 +146,13 @@ func TestJSONProjectFields(t *testing.T) {
 	field.TypeName = "ProjectV2Field"
 	field.Field.ID = "123"
 	field.Field.Name = "name"
+	field.Field.DataType = "TEXT"
 
 	field2 := ProjectField{}
 	field2.TypeName = "ProjectV2SingleSelectField"
 	field2.SingleSelectField.ID = "123"
 	field2.SingleSelectField.Name = "name"
+	field2.SingleSelectField.DataType = "SINGLE_SELECT"
 	field2.SingleSelectField.Options = []SingleSelectFieldOptions{
 		{
 			ID:   "123",
@@ -172,7 +177,7 @@ func TestJSONProjectFields(t *testing.T) {
 	b, err := json.Marshal(p.Fields.ExportData(nil))
 	assert.NoError(t, err)
 
-	assert.JSONEq(t, `{"fields":[{"id":"123","name":"name","type":"ProjectV2Field"},{"id":"123","name":"name","type":"ProjectV2SingleSelectField","options":[{"id":"123","name":"name"},{"id":"456","name":"name2"}]}],"totalCount":5}`, string(b))
+	assert.JSONEq(t, `{"fields":[{"id":"123","name":"name","type":"ProjectV2Field","dataType":"TEXT"},{"id":"123","name":"name","type":"ProjectV2SingleSelectField","dataType":"SINGLE_SELECT","options":[{"id":"123","name":"name"},{"id":"456","name":"name2"}]}],"totalCount":5}`, string(b))
 }
 
 func TestJSONProjectItem_DraftIssue(t *testing.T) {

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -1046,9 +1046,10 @@ func (p ProjectField) Options() []SingleSelectFieldOptions {
 
 func (p ProjectField) ExportData(_ []string) map[string]interface{} {
 	v := map[string]interface{}{
-		"id":   p.ID(),
-		"name": p.Name(),
-		"type": p.Type(),
+		"id":       p.ID(),
+		"name":     p.Name(),
+		"type":     p.Type(),
+		"dataType": p.DataType(),
 	}
 	// Emulate omitempty
 	if opts := p.Options(); len(opts) != 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

Fixes #7917

### Description

`gh project field-list --format json` currently exports `id`, `name`, and `type`. `type` is the GraphQL typename (`ProjectV2Field`, `ProjectV2SingleSelectField`, `ProjectV2IterationField`), which is not enough to choose the matching `gh project item-edit` flag (`--date`, `--number`, and so on).

The GraphQL field `dataType` (`TEXT`, `NUMBER`, `DATE`, `SINGLE_SELECT`, `ITERATION`) is already fetched and exposed as `ProjectField.DataType()`. This change:

- adds `dataType` to JSON export
- leaves `type` unchanged so existing scripts keep working
- prints `dataType` in the table column already labeled "Data type" (it previously printed the GraphQL typename)

### How did you test this change?

Given a project with a text field, a single-select field, and an iteration field
When I run `gh project field-list N --format json`
Then each field object includes `dataType` (`TEXT`, `SINGLE_SELECT`, `ITERATION`) and still includes `id`, `name`, and `type`

Given the same project
When I run `gh project field-list N` in a TTY
Then the "Data type" column shows `TEXT` / `SINGLE_SELECT` / `ITERATION` instead of `ProjectV2Field` / `ProjectV2SingleSelectField` / `ProjectV2IterationField`

Covered with unit tests in `pkg/cmd/project/field-list`, `pkg/cmd/project/shared/queries`, plus the JSON exporters used by `field-create` and `field-delete`.

### Key points

`dataType` was already on the GraphQL structs. This is export and table output only; no extra API requests.

I asked for Acceptance Criteria and `help wanted` on #7917. Opening this now so the change is reviewable; happy to adjust if the team wants a different shape.

### Notes for reviewers

Start at `ProjectField.ExportData` in `pkg/cmd/project/shared/queries/queries.go`, then `printResults` in `pkg/cmd/project/field-list/field_list.go`.

Related: https://github.com/cli/cli/issues/7917#issuecomment-1701072199 asked for `dataType` on both JSON and the standard list column.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [x] Nobody has explicitly committed to replying.