### PR TITLE
Handle attestation detail write errors

### DIFF
--- a/.experiments/tech-debt-burndown/memory.md
+++ b/.experiments/tech-debt-burndown/memory.md
@@ -71,3 +71,8 @@ None yet.
 ## Failed attempts
 
 None yet.
+
+## Landed targets
+
+- 2026-08-26: `pkg/cmd/attestation/verify` now returns terminal write errors from
+  `PrintBulletPoints`; the package-scoped errcheck count dropped from 17 to 16.

--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -340,8 +340,9 @@ func runVerify(opts *Options) error {
 			{"  - Signer repo", signerRepoAndOrg},
 			{"  - Signer workflow", signerWorkflow},
 		}
-		//nolint:errcheck
-		opts.Logger.PrintBulletPoints(rows)
+		if _, err := opts.Logger.PrintBulletPoints(rows); err != nil {
+			return err
+		}
 	}
 
 	// All attestations passed verification and policy evaluation

--- a/pkg/cmd/attestation/verify/verify_test.go
+++ b/pkg/cmd/attestation/verify/verify_test.go
@@ -33,6 +33,21 @@ var (
 	bundlePath   = test.NormalizeRelativePath("../test/data/sigstore-js-2.1.0-bundle.json")
 )
 
+type failOnSubstringWriter struct {
+	substring string
+}
+
+func (w failOnSubstringWriter) Write(p []byte) (int, error) {
+	if strings.Contains(string(p), w.substring) {
+		return 0, fmt.Errorf("write failed")
+	}
+	return len(p), nil
+}
+
+func (failOnSubstringWriter) Fd() uintptr {
+	return 0
+}
+
 func TestNewVerifyCmd(t *testing.T) {
 	testIO, _, _, _ := iostreams.Test()
 	var testReg httpmock.Registry
@@ -389,6 +404,17 @@ func TestRunVerify(t *testing.T) {
 
 	t.Run("with valid artifact and bundle", func(t *testing.T) {
 		require.NoError(t, runVerify(&publicGoodOpts))
+	})
+
+	t.Run("with error writing attestation details", func(t *testing.T) {
+		testIO, _, _, _ := iostreams.Test()
+		testIO.SetStdoutTTY(true)
+		testIO.ErrOut = failOnSubstringWriter{substring: "Build repo"}
+
+		opts := publicGoodOpts
+		opts.Logger = io.NewHandler(testIO)
+
+		require.ErrorContains(t, runVerify(&opts), "write failed")
 	})
 
 	t.Run("with failing OCI artifact fetch", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

I found that the TTY detail-rendering path ignored an error from `PrintBulletPoints`, so verification could report success even when those details could not be written. I chose this target because the behavior is localized and testable: I now return the write error and cover it with a focused regression test.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

Given a successful public attestation verification on a TTY, when I make the terminal writer fail while rendering the attestation details, then `runVerify` now returns that write error instead of continuing to a successful result.

The package-scoped `errcheck` sensor reported 17 findings with the suppression removed before the change and 16 after the change; the `PrintBulletPoints` finding is gone. The focused attestation verification package test passes, and `make lint` reports 0 issues.

For the baseline comparison, `go test ./...` reproduced the same local-environment failures before and after the change: pager-selection assertions in `internal/ghcmd`, interactive prompt timeouts in `internal/prompter`, and ANSI-color assertions in `pkg/surveyext`. No new failure category appeared, and `pkg/cmd/attestation/verify` passed.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

N/A — the first target passed its focused regression test and validation, so I did not abandon any alternative implementation.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

I suggest starting with the error handling in `verify.go`, then reading the writer-failure subtest in `verify_test.go`. I intentionally left the other 16 package-scoped `errcheck` findings unchanged because each needs its own output-behavior decision.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
