### PR TITLE
docs(gh-skill): document gh issue develop --checkout --worktree

### DIFF
--- a/skills/gh/SKILL.md
+++ b/skills/gh/SKILL.md
@@ -202,6 +202,11 @@ Sometimes useful data isn't on the typed commands. Examples:
   `gh pr view <n>` if you only need to read.
 - `gh pr checkout <n> --worktree <path>` checks the PR out into a git worktree
   at `<path>` instead of switching the current branch.
+- `gh issue develop <n> --checkout` creates a linked branch for the issue and
+  checks it out. Add `--worktree <path>` to check that branch out into a git
+  worktree at `<path>` instead of switching the current branch;
+  `--worktree` requires `--checkout`, cannot be blank, and cannot be combined
+  with `--list`.
 - `NO_COLOR`, `CLICOLOR_FORCE`, and `GH_FORCE_TTY` are honored. Set
   `GH_FORCE_TTY=1` if you want TTY-style output (colors, tables, the
   pager, interactivity) inside an agent harness; leave it unset unless needed.


### PR DESCRIPTION
### Description

The `gh` agent skill (`skills/gh/SKILL.md`) documents useful `gh` invocation patterns for agents, including checking a PR out into a git worktree with `gh pr checkout <n> --worktree <path>`. The equivalent capability for issues, `gh issue develop <n> --checkout --worktree <path>`, was not documented.

This adds a note covering `gh issue develop --checkout` and the `--worktree` flag, including its constraints, so agents know they can create a linked branch for an issue and check it out into a worktree instead of switching the current branch.

### How did you test this change?

This is a documentation-only change to a skill Markdown file, so there is no runtime behavior to exercise. I verified the documented flags and constraints against the command source in `pkg/cmd/issue/develop/develop.go`:

- `--checkout` creates and checks out the linked branch.
- `--worktree <path>` checks the branch out into a worktree.
- `--worktree` requires `--checkout`, cannot be blank, and is mutually exclusive with `--list`.

### Key points

Placed the new note directly below the existing `gh pr checkout --worktree` entry in the "Other notes" section to keep the two worktree patterns together.

### Notes for reviewers

Start in `skills/gh/SKILL.md`, "Other notes" section. The wording mirrors the adjacent `pr checkout --worktree` note for consistency.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @babakks will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
