### PR TITLE
repo create: drop the GraphQL: prefix from API errors

### DIFF
--- a/pkg/cmd/repo/create/http.go
+++ b/pkg/cmd/repo/create/http.go
@@ -244,7 +244,7 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput) (*a
 	}
 	`, variables, &response)
 	if err != nil {
-		return nil, err
+		return nil, userFacingGraphQLError(err)
 	}
 
 	return api.InitRepoHostname(&response.CreateRepository.Repository, hostname), nil
@@ -257,6 +257,17 @@ type ownerResponse struct {
 
 func (r *ownerResponse) IsOrganization() bool {
 	return r.Type == "Organization"
+}
+
+// userFacingGraphQLError strips the "GraphQL: " prefix go-gh puts on
+// GraphQLError.Error() so CLI users see the server message (#14257).
+func userFacingGraphQLError(err error) error {
+	const prefix = "GraphQL: "
+	msg := err.Error()
+	if strings.HasPrefix(msg, prefix) {
+		return fmt.Errorf("%s", strings.TrimPrefix(msg, prefix))
+	}
+	return err
 }
 
 func resolveOwner(client *api.Client, hostname, orgName string) (*ownerResponse, error) {

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -747,4 +748,11 @@ func Test_repoCreate(t *testing.T) {
 			assert.Equal(t, tt.wantRepo, ghrepo.GenerateRepoURL(r, ""))
 		})
 	}
+}
+
+func TestUserFacingGraphQLError(t *testing.T) {
+	err := userFacingGraphQLError(errors.New("GraphQL: Name already exists on this account (createRepository)"))
+	assert.EqualError(t, err, "Name already exists on this account (createRepository)")
+	plain := errors.New("not graphql")
+	assert.Equal(t, plain, userFacingGraphQLError(plain))
 }


### PR DESCRIPTION
`gh repo create` surfaces go-gh's GraphQL error as:

```
GraphQL: Name already exists on this account (createRepository)
```

The `GraphQL:` prefix is an implementation detail of the client, not part of the server message. Strip it so the user-facing error is:

```
Name already exists on this account (createRepository)
```

Fixes #14257