### PR TITLE
Reject non-UTF-8 gist contents instead of silently corrupting them

### DIFF
--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -217,17 +217,12 @@ func processFiles(stdin io.ReadCloser, filenameOverride string, filenames []stri
 				return nil, fmt.Errorf("binary file contents not supported")
 			}
 		} else {
-			isBinary, err := shared.IsBinaryFile(f)
-			if err != nil {
-				return fs, fmt.Errorf("failed to read file %s: %w", f, err)
-			}
-			if isBinary {
-				return nil, fmt.Errorf("failed to upload %s: binary file not supported", f)
-			}
-
 			content, err = os.ReadFile(f)
 			if err != nil {
 				return fs, fmt.Errorf("failed to read file %s: %w", f, err)
+			}
+			if shared.IsBinaryContents(content) {
+				return nil, fmt.Errorf("failed to upload %s: binary file not supported", f)
 			}
 
 			filename = filepath.Base(f)

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_processFiles(t *testing.T) {
@@ -32,6 +33,34 @@ func Test_processFiles(t *testing.T) {
 
 	assert.Equal(t, 1, len(files))
 	assert.Equal(t, "hey cool how is it going", files["gistfile0.txt"].Content)
+}
+
+func Test_processFiles_nonUTF8(t *testing.T) {
+	latin1 := []byte("caf\xe9 r\xe9sum\xe9\n")
+
+	t.Run("rejects latin-1 stdin", func(t *testing.T) {
+		_, err := processFiles(io.NopCloser(bytes.NewReader(latin1)), "", []string{"-"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "binary file contents not supported")
+	})
+
+	t.Run("rejects latin-1 file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "latin1.txt")
+		require.NoError(t, os.WriteFile(path, latin1, 0o644))
+
+		_, err := processFiles(io.NopCloser(strings.NewReader("")), "", []string{path})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "binary file not supported")
+	})
+
+	t.Run("accepts valid utf-8 file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "utf8.txt")
+		require.NoError(t, os.WriteFile(path, []byte("café résumé\n"), 0o644))
+
+		files, err := processFiles(io.NopCloser(strings.NewReader("")), "", []string{path})
+		require.NoError(t, err)
+		assert.Equal(t, "café résumé\n", files["utf8.txt"].Content)
+	})
 }
 
 func Test_guessGistName_stdin(t *testing.T) {

--- a/pkg/cmd/gist/edit/edit_test.go
+++ b/pkg/cmd/gist/edit/edit_test.go
@@ -37,6 +37,12 @@ func Test_getFilesToAdd(t *testing.T) {
 	}, gf)
 }
 
+func Test_getFilesToAdd_rejectsNonUTF8(t *testing.T) {
+	_, err := getFilesToAdd("latin1.txt", []byte("caf\xe9 r\xe9sum\xe9\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "binary file not supported")
+}
+
 func TestNewCmdEdit(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/cmd/gist/shared/shared.go
+++ b/pkg/cmd/gist/shared/shared.go
@@ -6,10 +6,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/prompter"
@@ -198,23 +200,30 @@ pagination:
 	return gists, nil
 }
 
+// IsBinaryFile reports whether the named file cannot be stored in a gist
+// without changing its bytes. See IsBinaryContents.
 func IsBinaryFile(file string) (bool, error) {
-	detectedMime, err := mimetype.DetectFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return false, err
 	}
-
-	isBinary := true
-	for mime := detectedMime; mime != nil; mime = mime.Parent() {
-		if mime.Is("text/plain") {
-			isBinary = false
-			break
-		}
-	}
-	return isBinary, nil
+	return IsBinaryContents(contents), nil
 }
 
+// IsBinaryContents reports whether contents cannot be stored in a gist without
+// changing their bytes.
+//
+// Gist file bodies are sent as JSON strings. encoding/json does not reject
+// invalid UTF-8; it rewrites every offending byte to U+FFFD. MIME sniffing
+// classifies encodings such as ISO-8859-1 and UTF-16 as text/plain, so those
+// files would otherwise be uploaded as replacement characters with a
+// successful exit. Rejecting invalid UTF-8 here matches what a JSON round
+// trip can actually carry.
 func IsBinaryContents(contents []byte) bool {
+	if !utf8.Valid(contents) {
+		return true
+	}
+
 	isBinary := true
 	for mime := mimetype.Detect(contents); mime != nil; mime = mime.Parent() {
 		if mime.Is("text/plain") {

--- a/pkg/cmd/gist/shared/shared_test.go
+++ b/pkg/cmd/gist/shared/shared_test.go
@@ -3,6 +3,8 @@ package shared
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_GetGistIDFromURL(t *testing.T) {
@@ -60,23 +63,54 @@ func Test_GetGistIDFromURL(t *testing.T) {
 
 func TestIsBinaryContents(t *testing.T) {
 	tests := []struct {
+		name        string
 		fileContent []byte
 		want        bool
 	}{
 		{
-			want:        false,
+			name:        "ascii text",
 			fileContent: []byte("package main"),
+			want:        false,
 		},
 		{
-			want:        false,
+			name:        "empty",
 			fileContent: []byte(""),
-		},
-		{
 			want:        false,
-			fileContent: []byte(nil),
 		},
 		{
-			want: true,
+			name:        "nil",
+			fileContent: []byte(nil),
+			want:        false,
+		},
+		{
+			name:        "valid utf-8",
+			fileContent: []byte("café 👋 日本語\n"),
+			want:        false,
+		},
+		{
+			// MIME sniffing classifies this as text/plain, but encoding/json
+			// would rewrite each 0xe9 to U+FFFD.
+			name:        "latin-1 text",
+			fileContent: []byte("caf\xe9 r\xe9sum\xe9\n"),
+			want:        true,
+		},
+		{
+			name:        "utf-16 le with bom",
+			fileContent: []byte{0xff, 0xfe, 'h', 0x00, 'i', 0x00},
+			want:        true,
+		},
+		{
+			name:        "jpeg soi",
+			fileContent: []byte{0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F'},
+			want:        true,
+		},
+		{
+			name:        "png signature",
+			fileContent: []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a},
+			want:        true,
+		},
+		{
+			name: "legacy jpeg-like fixture",
 			fileContent: []byte{239, 191, 189, 239, 191, 189, 239, 191, 189, 239,
 				191, 189, 239, 191, 189, 16, 74, 70, 73, 70, 239, 191, 189, 1, 1, 1,
 				1, 44, 1, 44, 239, 191, 189, 239, 191, 189, 239, 191, 189, 239, 191,
@@ -85,12 +119,50 @@ func TestIsBinaryContents(t *testing.T) {
 				31, 30, 29, 26, 28, 28, 32, 36, 46, 39, 32, 34, 44, 35, 28, 28, 40,
 				55, 41, 44, 48, 49, 52, 52, 52, 31, 39, 57, 61, 56, 50, 60, 46, 51,
 				52, 50, 239, 191, 189, 239, 191, 189, 239, 191, 189, 67, 1, 9, 9, 9, 12},
+			want: true,
 		},
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.want, IsBinaryContents(tt.fileContent))
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsBinaryContents(tt.fileContent))
+		})
 	}
+}
+
+func TestIsBinaryFile(t *testing.T) {
+	dir := t.TempDir()
+
+	utf8Path := filepath.Join(dir, "utf8.txt")
+	require.NoError(t, os.WriteFile(utf8Path, []byte("café résumé\n"), 0o644))
+
+	latin1Path := filepath.Join(dir, "latin1.txt")
+	require.NoError(t, os.WriteFile(latin1Path, []byte("caf\xe9 r\xe9sum\xe9\n"), 0o644))
+
+	// MIME detection only inspects the first 3072 bytes. Invalid UTF-8 later
+	// in the file must still be refused.
+	lateInvalid := make([]byte, 4000)
+	for i := range lateInvalid {
+		lateInvalid[i] = 'a'
+	}
+	lateInvalid[3999] = 0xe9
+	latePath := filepath.Join(dir, "late.txt")
+	require.NoError(t, os.WriteFile(latePath, lateInvalid, 0o644))
+
+	got, err := IsBinaryFile(utf8Path)
+	require.NoError(t, err)
+	assert.False(t, got)
+
+	got, err = IsBinaryFile(latin1Path)
+	require.NoError(t, err)
+	assert.True(t, got)
+
+	got, err = IsBinaryFile(latePath)
+	require.NoError(t, err)
+	assert.True(t, got)
+
+	_, err = IsBinaryFile(filepath.Join(dir, "missing.txt"))
+	require.Error(t, err)
 }
 
 func TestPromptGists(t *testing.T) {


### PR DESCRIPTION
## Summary

`gh gist create` and `gh gist edit` send file contents as JSON strings. `encoding/json` does not reject invalid UTF-8; it rewrites every offending byte to U+FFFD. MIME sniffing treats ISO-8859-1 and UTF-16 as `text/plain`, so those files were uploaded as replacement characters and the command exited 0.

This rejects contents that are not valid UTF-8 before they are encoded, so the original bytes are not silently changed.

## Related Issue

Fixes #14216

## Changes Made

- `IsBinaryContents` now treats invalid UTF-8 as unsupported, then still uses MIME sniffing for contents that are valid UTF-8
- `IsBinaryFile` reads the whole file and uses that check (MIME detection only inspects the first 3072 bytes)
- `gist create` checks the bytes it actually read, so a latin-1 file cannot slip past a pre-read sniff
- Tests cover latin-1, UTF-16, JPEG/PNG headers, valid multi-byte UTF-8, and invalid UTF-8 after the 3072-byte window

The MIME check is kept so this does not change how ASCII control characters are classified (#9761).

## Testing

Given a latin-1 file `printf 'caf\xe9 r\xe9sum\xe9\n' > latin1.txt`
When `processFiles` / `IsBinaryContents` inspect it
Then the file is refused with `binary file not supported` and no gist JSON is built

Given a valid UTF-8 file containing `café résumé`
When the same path runs
Then the file is accepted with its original contents

Given a 4000-byte ASCII file whose last byte is `0xe9`
When `IsBinaryFile` inspects it
Then it is refused (the old MIME sniff only looked at the first 3072 bytes)

`go test ./pkg/cmd/gist/shared/ ./pkg/cmd/gist/create/ ./pkg/cmd/gist/edit/`

## Notes

The error text is still `binary file not supported`. That wording is slightly off for latin-1, but it is the existing create/edit failure and this change is only about stopping silent corruption.

A previous PR (#14217) was closed automatically because the linked issues do not have `help wanted`. This issue's expected behavior is explicit: upload unchanged, or refuse and say why. This PR only implements the refuse path for #14216.

<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

### Description

Gist contents travel inside a JSON string. Invalid UTF-8 therefore cannot be stored as-is: `encoding/json` replaces those bytes with U+FFFD. The pre-upload "binary" check asked a MIME question instead, so ISO-8859-1 and UTF-16 files were accepted and then mangled.

This makes "is this valid UTF-8?" part of that check.

### How did you test this change?

Given the latin-1 bytes `caf\xe9 r\xe9sum\xe9\n`
When `gh gist create` collects files (`processFiles`)
Then it returns `binary file not supported` and does not POST a gist

Given UTF-8 `café résumé`
When the same collection path runs
Then the gist file content is unchanged

Given JPEG/PNG signatures
When `IsBinaryContents` runs
Then they remain unsupported

### Key points

MIME sniffing is still used after the UTF-8 check. Replacing it with `utf8.Valid` alone would start accepting ASCII control characters, which is #9761 and outside this issue.

Anyone currently uploading latin-1 or UTF-16 files will now get an error instead of a gist that does not contain their file.

### Notes for reviewers

Start at `IsBinaryContents` in `pkg/cmd/gist/shared/shared.go`. Call sites in `gist create` (stdin and files) and `gist edit` (`getFilesToAdd`) already go through it.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [x] Nobody has explicitly committed to replying.
