### PR TITLE
Support pinning an account per repository via the github.account git config key

### DIFF
--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -209,3 +209,36 @@ flows, this feature has not yet made it into GHES.
 
 For the moment, if you have multiple accounts on GHES that you wish to log in as, you will need to ensure that you
 are authenticated as the correct user in the browser before running `auth login`.
+
+## Pinning an account to a repository
+
+> This section describes behaviour added after the v2.40.0 release notes above.
+
+`gh` resolves one active account per host, which can be surprising when you work on
+repositories belonging to different accounts: `auth switch` changes the active account
+globally, for every terminal and directory at once.
+
+To pin a repository to a specific account, set the `github.account` git configuration
+key to the username of an account you have logged in with `auth login`:
+
+```
+➜ git config github.account williammartin
+```
+
+When this key resolves for the current directory, `gh` uses the pinned account's stored
+token instead of the active account's. Because the value lives in the repository's git
+configuration, it follows the repository rather than the process: two terminals working
+in two different repositories each resolve their own account, with no global active
+state to race over.
+
+A few details worth knowing:
+
+* `GH_TOKEN` and the other token environment variables still take precedence over the
+  pin, since they are an explicit per-process choice.
+* If the pinned account is not logged in (for example after `auth logout`), `gh` falls
+  back to the active account.
+* The pin affects token resolution only. `auth switch`, `auth logout`, and `auth status`
+  continue to operate on the stored active account.
+* You can pin many repositories at once with git's
+  [conditional includes](https://git-scm.com/docs/git-config#_conditional_includes),
+  for example pinning everything under `~/work/` to your work account.

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -976,3 +976,86 @@ func TestActiveTokenType(t *testing.T) {
 		})
 	}
 }
+
+func TestActiveTokenUsesPinnedAccountFromKeyring(t *testing.T) {
+	// Given two users are logged in securely and the non-active one is pinned
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "pinned-user", "pinned-token", "", true)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "active-user", "active-token", "", true)
+	require.NoError(t, err)
+	authCfg.SetPinnedAccount("pinned-user")
+
+	// When we get the token
+	token, source := authCfg.ActiveToken("github.com")
+
+	// Then the pinned user's token is fetched from the keyring
+	require.Equal(t, "pinned-token", token)
+	require.Equal(t, "keyring", source)
+}
+
+func TestActiveTokenUsesPinnedAccountFromConfig(t *testing.T) {
+	// Given two users are logged in insecurely and the non-active one is pinned
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "pinned-user", "pinned-token", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "active-user", "active-token", "", false)
+	require.NoError(t, err)
+	authCfg.SetPinnedAccount("pinned-user")
+
+	// When we get the token
+	token, source := authCfg.ActiveToken("github.com")
+
+	// Then the pinned user's token is fetched from the config
+	require.Equal(t, "pinned-token", token)
+	require.Equal(t, oauthTokenKey, source)
+}
+
+func TestActiveTokenFallsBackWhenPinnedAccountUnauthenticated(t *testing.T) {
+	// Given a logged in user and a pin naming an account with no credentials
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "active-user", "active-token", "", true)
+	require.NoError(t, err)
+	authCfg.SetPinnedAccount("ghost-user")
+
+	// When we get the token
+	token, source := authCfg.ActiveToken("github.com")
+
+	// Then the active user's token is fetched as if no pin were set
+	require.Equal(t, "active-token", token)
+	require.Equal(t, "keyring", source)
+}
+
+func TestActiveTokenEnvVarWinsOverPinnedAccount(t *testing.T) {
+	// Given a pinned authenticated account and a token environment variable
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "pinned-user", "pinned-token", "", true)
+	require.NoError(t, err)
+	authCfg.SetPinnedAccount("pinned-user")
+	t.Setenv("GH_TOKEN", "env-token")
+
+	// When we get the token
+	token, source := authCfg.ActiveToken("github.com")
+
+	// Then the environment token wins over the pin
+	require.Equal(t, "env-token", token)
+	require.Equal(t, "GH_TOKEN", source)
+}
+
+func TestStoredActiveTokenIgnoresPinnedAccount(t *testing.T) {
+	// Given two users are logged in securely and the non-active one is pinned
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "pinned-user", "pinned-token", "", true)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "active-user", "active-token", "", true)
+	require.NoError(t, err)
+	authCfg.SetPinnedAccount("pinned-user")
+
+	// When we get the stored active token
+	token, source := authCfg.storedActiveToken("github.com")
+
+	// Then the active user's token is fetched, not the pinned user's, so
+	// callers like SwitchUser's rollback reason about the stored active user
+	require.Equal(t, "active-token", token)
+	require.Equal(t, "keyring", source)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,15 +4,18 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/keyring"
 	o "github.com/cli/cli/v2/pkg/option"
 	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 	ghConfig "github.com/cli/go-gh/v2/pkg/config"
+	"github.com/cli/safeexec"
 )
 
 // Important: some of the following configuration settings are used outside of `cli/cli`,
@@ -226,10 +229,11 @@ func defaultFor(key string) o.Option[string] {
 // with knowledge on how to access encrypted storage when neccesarry.
 // Behavior is scoped to authentication specific tasks.
 type AuthConfig struct {
-	cfg                 *ghConfig.Config
-	defaultHostOverride func() (string, string)
-	hostsOverride       func() []string
-	tokenOverride       func(string) (string, string)
+	cfg                   *ghConfig.Config
+	defaultHostOverride   func() (string, string)
+	hostsOverride         func() []string
+	tokenOverride         func(string) (string, string)
+	pinnedAccountOverride func() string
 }
 
 // ActiveTokenType reports what kind of credential the active token is, so a
@@ -245,9 +249,29 @@ func (c *AuthConfig) ActiveTokenType(hostname string) gh.TokenType {
 }
 
 // ActiveToken will retrieve the active auth token for the given hostname,
-// searching environment variables, plain text config, and
-// lastly encrypted storage.
+// searching environment variables, an account pinned in git configuration,
+// plain text config, and lastly encrypted storage.
 func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
+	if c.tokenOverride != nil {
+		return c.tokenOverride(hostname)
+	}
+	// Tokens sourced from environment variables are an explicit per-process
+	// choice, so they take precedence over an account pinned in git
+	// configuration.
+	if token, source := ghauth.TokenFromEnvOrConfig(hostname); token != "" && envTokenSources[source] {
+		return token, source
+	}
+	if token, source, ok := c.pinnedActiveToken(hostname); ok {
+		return token, source
+	}
+	return c.storedActiveToken(hostname)
+}
+
+// storedActiveToken retrieves the auth token for the stored active user,
+// ignoring any account pinned in git configuration. Callers that reason about
+// the stored active user, such as SwitchUser's rollback, must use this rather
+// than ActiveToken so a pin cannot substitute another account's token.
+func (c *AuthConfig) storedActiveToken(hostname string) (string, string) {
 	if c.tokenOverride != nil {
 		return c.tokenOverride(hostname)
 	}
@@ -270,6 +294,71 @@ func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 		}
 	}
 	return token, source
+}
+
+// envTokenSources are the source values TokenFromEnvOrConfig reports when the
+// token came from an environment variable rather than from configuration.
+var envTokenSources = map[string]bool{
+	"GH_TOKEN":                true,
+	"GITHUB_TOKEN":            true,
+	"GH_ENTERPRISE_TOKEN":     true,
+	"GITHUB_ENTERPRISE_TOKEN": true,
+}
+
+// gitAccountKey is the git configuration key used to pin gh to one of the
+// authenticated accounts for the repository containing the working directory.
+// See https://github.com/cli/cli/issues/12459.
+const gitAccountKey = "github.account"
+
+// gitPinnedAccount resolves the gitAccountKey git configuration value for the
+// current working directory. The result is cached for the lifetime of the
+// process because gh does not change its working directory, so the resolved
+// value cannot change between calls.
+var gitPinnedAccount = sync.OnceValue(func() string {
+	gitExe, err := safeexec.LookPath("git")
+	if err != nil {
+		return ""
+	}
+	out, err := exec.Command(gitExe, "config", "--get", gitAccountKey).Output()
+	if err != nil {
+		// The key being unset and git being unusable both mean no pin.
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+})
+
+func (c *AuthConfig) pinnedAccount() string {
+	if c.pinnedAccountOverride != nil {
+		return c.pinnedAccountOverride()
+	}
+	return gitPinnedAccount()
+}
+
+// pinnedActiveToken retrieves the auth token for the account pinned in git
+// configuration, reporting ok as false when no pin is set or the pinned
+// account has no stored credentials for the hostname (for example, after
+// logging that account out), so resolution falls back to the active user.
+func (c *AuthConfig) pinnedActiveToken(hostname string) (token, source string, ok bool) {
+	account := c.pinnedAccount()
+	if account == "" {
+		return "", "", false
+	}
+	if token, err := c.TokenFromKeyringForUser(hostname, account); err == nil {
+		return token, "keyring", true
+	}
+	if token, err := c.cfg.Get([]string{hostsKey, hostname, usersKey, account, oauthTokenKey}); err == nil && token != "" {
+		return token, oauthTokenKey, true
+	}
+	return "", "", false
+}
+
+// SetPinnedAccount will override git configuration resolution and use the
+// given account for all calls that resolve the pinned account. Use for
+// testing purposes only.
+func (c *AuthConfig) SetPinnedAccount(account string) {
+	c.pinnedAccountOverride = func() string {
+		return account
+	}
 }
 
 // HasActiveToken returns true when a token for the hostname is present.
@@ -408,7 +497,7 @@ func (c *AuthConfig) SwitchUser(hostname, user string) error {
 		return fmt.Errorf("failed to get active user: %s", err)
 	}
 
-	previouslyActiveToken, previousSource := c.ActiveToken(hostname)
+	previouslyActiveToken, previousSource := c.storedActiveToken(hostname)
 	if previousSource != "keyring" && previousSource != "oauth_token" {
 		return fmt.Errorf("currently active token for %s is from %s", hostname, previousSource)
 	}


### PR DESCRIPTION
Relates to #12459.

### Description

When multiple accounts are logged in for a host, `gh` resolves a single global active account, changed with `gh auth switch`. That state is shared by every terminal and directory on the machine. Working across repositories belonging to different accounts means switching back and forth, and concurrent shells race each other: a switch in one terminal silently changes the identity every other terminal acts as, so a `gh pr create` aimed at a work account can land under a personal one (or vice versa) depending on timing.

This PR adds the opt-in, per-repository pin proposed in #12459: setting the `github.account` git configuration key to the username of a logged-in account makes token resolution for commands run inside that repository use that account's stored credentials. Because the pin lives in git config it follows the repository rather than the process, and git's conditional includes extend it to whole directory trees (e.g. everything under `~/work/`).

Resolution order in `ActiveToken`:

1. `GH_TOKEN` / `GITHUB_TOKEN` (and the enterprise variants) still win — an environment token is an explicit per-process choice.
2. A `github.account` pin, when set and that account has stored credentials (keyring or insecure config) for the hostname.
3. Otherwise the stored active account, exactly as today.

An unauthenticated pin (for example after `gh auth logout`) falls back silently to the active account rather than erroring, so a stale pin never breaks a repository.

One correctness detail: `SwitchUser` captured its rollback token via `ActiveToken`, which would have let a pin substitute another account's token into the rollback path. The stored-active resolution is extracted into a pin-immune `storedActiveToken` helper and `SwitchUser` uses it, so `auth switch` / `auth logout` / `auth status` semantics are unchanged by a pin.

### How did you test this change?

Built `gh` from this branch on macOS with two accounts logged in (`bwt615` active, a work account secondary, both keyring-stored), in a fresh `git init` directory, without ever running `auth switch`:

Given no `github.account` key is set
When I run `gh api user`
Then I see `bwt615` (the active account — behavior unchanged)

Given `git config github.account <work-account>`
When I run `gh api user`
Then I see the work account (the pin overrides the active account)

Given `git config github.account no-such-account-zzz`
When I run `gh api user`
Then I see `bwt615` (an unauthenticated pin falls back to the active account)

Given `git config github.account <work-account>` and `GH_TOKEN` set to the `bwt615` token
When I run `gh api user`
Then I see `bwt615` (the environment token wins over the pin)

Also verified that `gh auth token` inside the pinned repository returns the pinned account's token, and that `gh auth status` still reports the stored active account throughout.

### Key points

- The pin is resolved with `git config --get github.account` (via `safeexec`), cached once per process; `gh` never changes its working directory, so the value cannot change between calls. When git is unavailable or the key is unset this costs one failed lookup and behaves exactly as today.
- The pin affects token resolution only. `ActiveUser`, `auth switch`, `auth logout`, and `auth status` intentionally keep operating on the stored active account in this PR — surfacing the pin in `auth status` output is a natural follow-up, left out to keep this reviewable.
- Also deliberately out of scope, as possible follow-ups: honoring the pin in the git credential helper path, and a `GH_ACCOUNT` environment variable as a process-scoped equivalent.
- I'm aware PRs are normally expected to be linked to a `help wanted` issue, and #12459 does not carry that label yet (#12628 was closed on that basis). I've asked on the issue for triage, and I'm opening this anyway in case a concrete, tested implementation is useful for evaluating the proposal — happy to adjust or split it however the team prefers, and no hard feelings if it's closed pending triage.

### Notes for reviewers

Start with `ActiveToken` in `internal/config/config.go` (the resolution-order change), then `pinnedActiveToken`, then the `SwitchUser` rollback change together with `TestStoredActiveTokenIgnoresPinnedAccount`, which documents why `storedActiveToken` exists.

- #12459 — the feature request this implements, including the `github.account` key name.
- #12628, #12681 — earlier attempts, closed procedurally for not being linked to a `help wanted` issue.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @bwt615 will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
