### PR TITLE
Clarify PR testing guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,19 +18,23 @@ background they need before the problem makes sense, and avoid jargon.
 ### How did you test this change?
 
 <!--
-Show how you exercised the change yourself, as a user of `gh` would.
+Report only actions you actually performed and results you actually observed, using factual
+first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
+hypothetical, inferred, or merely expected scenarios as testing.
 
 Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
 coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.
+
+If you did not exercise the changed behavior, write `Not tested` and explain why.
 
 Use one or more of these, whichever communicates best:
 
 1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
    in terminal output. If output changed, show it before and after.
-2. Given/When/Then scenarios. For example:
-   Given I am in a repo with no open pull requests
-   When I run `gh pr list`
-   Then I see "no open pull requests in cli/cli"
+2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
+   Given I was in a repo with no open pull requests
+   When I ran `gh pr list`
+   Then I saw "no open pull requests in cli/cli"
 3. A natural language walkthrough of what you did by hand, the states you covered, and what
    you saw, including error and edge cases.
 


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

PR testing descriptions can make expected behavior look like behavior the author actually observed. This updates the `How did you test this change?` guidance to require factual first-person accounts of performed actions and observed results, while directing authors to write `Not tested` with an explanation when they did not exercise the changed behavior.

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

### How did you test this change?

Not tested. This documentation-only change does not alter `gh` runtime behavior. I reviewed the final diff and confirmed that it changes only the testing guidance in the pull request template.

<!--
Report only actions you actually performed and results you actually observed, using factual
first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
hypothetical, inferred, or merely expected scenarios as testing.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

If you did not exercise the changed behavior, write `Not tested` and explain why.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
   Given I was in a repo with no open pull requests
   When I ran `gh pr list`
   Then I saw "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

### Key points

The change keeps Given/When/Then available for executed scenarios, changes its example to factual past tense, and explicitly excludes planned, hypothetical, inferred, and expected scenarios from reported testing.

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

### Notes for reviewers

Review the `How did you test this change?` guidance in `.github/PULL_REQUEST_TEMPLATE.md`. PRs #14271 and #14252 provide the motivating context for distinguishing observed behavior from expected behavior.

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.