### PR TITLE
Do not allow dependabot to bump aw

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,9 @@ updates:
   cooldown:
     default-days: 3
   ignore:
-    - dependency-name: "*"
-      update-types:
-        - version-update:semver-major
+  - dependency-name: "*"
+    update-types:
+    - version-update:semver-major
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
@@ -20,6 +20,5 @@ updates:
     codeql-actions:
       patterns:
         - "github/codeql-action/*"
-    aw-actions:
-      patterns:
-        - "github/gh-aw-actions/*"
+  ignore:
+  - dependency-name: "github/gh-aw-actions/*" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

Allowing dependabot to bump aw easily breaks things and causes confusion when recompiled locally. https://github.github.com/gh-aw/reference/dependabot/ has more details.

### How did you test this change?

I didn't.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [x] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
