### PR TITLE
Modernize Go code with go fix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Ensure go.mod and go.sum are up to date
+      - name: Ensure Go source and modules are up to date
         run: |
           STATUS=0
           assert-nothing-changed() {
@@ -45,6 +45,7 @@ jobs:
             fi
           }
           assert-nothing-changed go mod tidy
+          assert-nothing-changed go fix ./...
           exit $STATUS
 
       - name: golangci-lint

--- a/api/client.go
+++ b/api/client.go
@@ -54,7 +54,7 @@ func (err HTTPError) ScopesSuggestion() string {
 
 // GraphQL performs a GraphQL request using the query string and parses the response into data receiver. If there are errors in the response,
 // GraphQLError will be returned, but the receiver will also be partially populated.
-func (c Client) GraphQL(hostname string, query string, variables map[string]interface{}, data interface{}) error {
+func (c Client) GraphQL(hostname string, query string, variables map[string]any, data any) error {
 	opts := clientOptions(hostname, c.http.Transport)
 	opts.Headers[graphqlFeatures] = features
 	gqlClient, err := ghAPI.NewGraphQLClient(opts)
@@ -66,7 +66,7 @@ func (c Client) GraphQL(hostname string, query string, variables map[string]inte
 
 // Mutate performs a GraphQL mutation based on a struct and parses the response with the same struct as the receiver. If there are errors in the response,
 // GraphQLError will be returned, but the receiver will also be partially populated.
-func (c Client) Mutate(hostname, name string, mutation interface{}, variables map[string]interface{}) error {
+func (c Client) Mutate(hostname, name string, mutation any, variables map[string]any) error {
 	opts := clientOptions(hostname, c.http.Transport)
 	opts.Headers[graphqlFeatures] = features
 	gqlClient, err := ghAPI.NewGraphQLClient(opts)
@@ -78,7 +78,7 @@ func (c Client) Mutate(hostname, name string, mutation interface{}, variables ma
 
 // Query performs a GraphQL query based on a struct and parses the response with the same struct as the receiver. If there are errors in the response,
 // GraphQLError will be returned, but the receiver will also be partially populated.
-func (c Client) Query(hostname, name string, query interface{}, variables map[string]interface{}) error {
+func (c Client) Query(hostname, name string, query any, variables map[string]any) error {
 	opts := clientOptions(hostname, c.http.Transport)
 	opts.Headers[graphqlFeatures] = features
 	gqlClient, err := ghAPI.NewGraphQLClient(opts)
@@ -90,7 +90,7 @@ func (c Client) Query(hostname, name string, query interface{}, variables map[st
 
 // QueryWithContext performs a GraphQL query based on a struct and parses the response with the same struct as the receiver. If there are errors in the response,
 // GraphQLError will be returned, but the receiver will also be partially populated.
-func (c Client) QueryWithContext(ctx context.Context, hostname, name string, query interface{}, variables map[string]interface{}) error {
+func (c Client) QueryWithContext(ctx context.Context, hostname, name string, query any, variables map[string]any) error {
 	opts := clientOptions(hostname, c.http.Transport)
 	opts.Headers[graphqlFeatures] = features
 	gqlClient, err := ghAPI.NewGraphQLClient(opts)
@@ -101,7 +101,7 @@ func (c Client) QueryWithContext(ctx context.Context, hostname, name string, que
 }
 
 // REST performs a REST request and parses the response.
-func (c Client) REST(hostname string, method string, p string, body io.Reader, data interface{}) error {
+func (c Client) REST(hostname string, method string, p string, body io.Reader, data any) error {
 	opts := clientOptions(hostname, c.http.Transport)
 	restClient, err := ghAPI.NewRESTClient(opts)
 	if err != nil {
@@ -110,7 +110,7 @@ func (c Client) REST(hostname string, method string, p string, body io.Reader, d
 	return handleResponse(restClient.Do(method, p, body, data))
 }
 
-func (c Client) RESTWithNext(hostname string, method string, p string, body io.Reader, data interface{}) (string, error) {
+func (c Client) RESTWithNext(hostname string, method string, p string, body io.Reader, data any) (string, error) {
 	opts := clientOptions(hostname, c.http.Transport)
 	restClient, err := ghAPI.NewRESTClient(opts)
 	if err != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -230,11 +230,11 @@ func generateScopesSuggestion(statusCode int, endpointNeedsScopes, tokenHasScope
 			gotScopes["user:follow"] = struct{}{}
 		} else if s == "codespace" {
 			gotScopes["codespace:secrets"] = struct{}{}
-		} else if strings.HasPrefix(s, "admin:") {
-			gotScopes["read:"+strings.TrimPrefix(s, "admin:")] = struct{}{}
+		} else if after, ok := strings.CutPrefix(s, "admin:"); ok {
+			gotScopes["read:"+after] = struct{}{}
 			gotScopes["write:"+strings.TrimPrefix(s, "admin:")] = struct{}{}
-		} else if strings.HasPrefix(s, "write:") {
-			gotScopes["read:"+strings.TrimPrefix(s, "write:")] = struct{}{}
+		} else if after, ok := strings.CutPrefix(s, "write:"); ok {
+			gotScopes["read:"+after] = struct{}{}
 		}
 	}
 

--- a/api/client.go
+++ b/api/client.go
@@ -211,7 +211,7 @@ func generateScopesSuggestion(statusCode int, endpointNeedsScopes, tokenHasScope
 	}
 
 	gotScopes := map[string]struct{}{}
-	for _, s := range strings.Split(tokenHasScopes, ",") {
+	for s := range strings.SplitSeq(tokenHasScopes, ",") {
 		s = strings.TrimSpace(s)
 		gotScopes[s] = struct{}{}
 
@@ -238,7 +238,7 @@ func generateScopesSuggestion(statusCode int, endpointNeedsScopes, tokenHasScope
 		}
 	}
 
-	for _, s := range strings.Split(endpointNeedsScopes, ",") {
+	for s := range strings.SplitSeq(endpointNeedsScopes, ",") {
 		s = strings.TrimSpace(s)
 		if _, gotScope := gotScopes[s]; s == "" || gotScope {
 			continue

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -24,7 +24,7 @@ func TestGraphQL(t *testing.T) {
 	http := &httpmock.Registry{}
 	client := newTestClient(http)
 
-	vars := map[string]interface{}{"name": "Mona"}
+	vars := map[string]any{"name": "Mona"}
 	response := struct {
 		Viewer struct {
 			Login string

--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-func (issue *Issue) ExportData(fields []string) map[string]interface{} {
+func (issue *Issue) ExportData(fields []string) map[string]any {
 	v := reflect.ValueOf(issue).Elem()
-	data := map[string]interface{}{}
+	data := map[string]any{}
 
 	for _, f := range fields {
 		switch f {
@@ -20,25 +20,25 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 		case "projectCards":
 			data[f] = issue.ProjectCards.Nodes
 		case "projectItems":
-			items := make([]map[string]interface{}, 0, len(issue.ProjectItems.Nodes))
+			items := make([]map[string]any, 0, len(issue.ProjectItems.Nodes))
 			for _, n := range issue.ProjectItems.Nodes {
-				items = append(items, map[string]interface{}{
+				items = append(items, map[string]any{
 					"status": n.Status,
 					"title":  n.Project.Title,
 				})
 			}
 			data[f] = items
 		case "closedByPullRequestsReferences":
-			items := make([]map[string]interface{}, 0, len(issue.ClosedByPullRequestsReferences.Nodes))
+			items := make([]map[string]any, 0, len(issue.ClosedByPullRequestsReferences.Nodes))
 			for _, n := range issue.ClosedByPullRequestsReferences.Nodes {
-				items = append(items, map[string]interface{}{
+				items = append(items, map[string]any{
 					"id":     n.ID,
 					"number": n.Number,
 					"url":    n.URL,
-					"repository": map[string]interface{}{
+					"repository": map[string]any{
 						"id":   n.Repository.ID,
 						"name": n.Repository.Name,
-						"owner": map[string]interface{}{
+						"owner": map[string]any{
 							"id":    n.Repository.Owner.ID,
 							"login": n.Repository.Owner.Login,
 						},
@@ -50,7 +50,7 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 			data[f] = issue.IssueType
 		case "parent":
 			if issue.Parent != nil {
-				data[f] = map[string]interface{}{
+				data[f] = map[string]any{
 					"id":     issue.Parent.ID,
 					"number": issue.Parent.Number,
 					"title":  issue.Parent.Title,
@@ -61,9 +61,9 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 				data[f] = nil
 			}
 		case "subIssues":
-			items := make([]map[string]interface{}, 0, len(issue.SubIssues.Nodes))
+			items := make([]map[string]any, 0, len(issue.SubIssues.Nodes))
 			for _, n := range issue.SubIssues.Nodes {
-				items = append(items, map[string]interface{}{
+				items = append(items, map[string]any{
 					"id":     n.ID,
 					"number": n.Number,
 					"title":  n.Title,
@@ -71,20 +71,20 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 					"state":  n.State,
 				})
 			}
-			data[f] = map[string]interface{}{
+			data[f] = map[string]any{
 				"nodes":      items,
 				"totalCount": issue.SubIssues.TotalCount,
 			}
 		case "subIssuesSummary":
-			data[f] = map[string]interface{}{
+			data[f] = map[string]any{
 				"total":            issue.SubIssuesSummary.Total,
 				"completed":        issue.SubIssuesSummary.Completed,
 				"percentCompleted": issue.SubIssuesSummary.PercentCompleted,
 			}
 		case "blockedBy":
-			items := make([]map[string]interface{}, 0, len(issue.BlockedBy.Nodes))
+			items := make([]map[string]any, 0, len(issue.BlockedBy.Nodes))
 			for _, n := range issue.BlockedBy.Nodes {
-				items = append(items, map[string]interface{}{
+				items = append(items, map[string]any{
 					"id":     n.ID,
 					"number": n.Number,
 					"title":  n.Title,
@@ -92,14 +92,14 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 					"state":  n.State,
 				})
 			}
-			data[f] = map[string]interface{}{
+			data[f] = map[string]any{
 				"nodes":      items,
 				"totalCount": issue.BlockedBy.TotalCount,
 			}
 		case "blocking":
-			items := make([]map[string]interface{}, 0, len(issue.Blocking.Nodes))
+			items := make([]map[string]any, 0, len(issue.Blocking.Nodes))
 			for _, n := range issue.Blocking.Nodes {
-				items = append(items, map[string]interface{}{
+				items = append(items, map[string]any{
 					"id":     n.ID,
 					"number": n.Number,
 					"title":  n.Title,
@@ -107,7 +107,7 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 					"state":  n.State,
 				})
 			}
-			data[f] = map[string]interface{}{
+			data[f] = map[string]any{
 				"nodes":      items,
 				"totalCount": issue.Blocking.TotalCount,
 			}
@@ -120,9 +120,9 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 	return data
 }
 
-func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
+func (pr *PullRequest) ExportData(fields []string) map[string]any {
 	v := reflect.ValueOf(pr).Elem()
-	data := map[string]interface{}{}
+	data := map[string]any{}
 
 	for _, f := range fields {
 		switch f {
@@ -130,10 +130,10 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 			data[f] = pr.HeadRepository
 		case "statusCheckRollup":
 			if n := pr.StatusCheckRollup.Nodes; len(n) > 0 {
-				checks := make([]interface{}, 0, len(n[0].Commit.StatusCheckRollup.Contexts.Nodes))
+				checks := make([]any, 0, len(n[0].Commit.StatusCheckRollup.Contexts.Nodes))
 				for _, c := range n[0].Commit.StatusCheckRollup.Contexts.Nodes {
 					if c.TypeName == "CheckRun" {
-						checks = append(checks, map[string]interface{}{
+						checks = append(checks, map[string]any{
 							"__typename":   c.TypeName,
 							"name":         c.Name,
 							"workflowName": c.CheckSuite.WorkflowRun.Workflow.Name,
@@ -144,7 +144,7 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 							"detailsUrl":   c.DetailsURL,
 						})
 					} else {
-						checks = append(checks, map[string]interface{}{
+						checks = append(checks, map[string]any{
 							"__typename": c.TypeName,
 							"context":    c.Context,
 							"state":      c.State,
@@ -158,19 +158,19 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 				data[f] = nil
 			}
 		case "commits":
-			commits := make([]interface{}, 0, len(pr.Commits.Nodes))
+			commits := make([]any, 0, len(pr.Commits.Nodes))
 			for _, c := range pr.Commits.Nodes {
 				commit := c.Commit
-				authors := make([]interface{}, 0, len(commit.Authors.Nodes))
+				authors := make([]any, 0, len(commit.Authors.Nodes))
 				for _, author := range commit.Authors.Nodes {
-					authors = append(authors, map[string]interface{}{
+					authors = append(authors, map[string]any{
 						"name":  author.Name,
 						"email": author.Email,
 						"id":    author.User.ID,
 						"login": author.User.Login,
 					})
 				}
-				commits = append(commits, map[string]interface{}{
+				commits = append(commits, map[string]any{
 					"oid":             commit.OID,
 					"messageHeadline": commit.MessageHeadline,
 					"messageBody":     commit.MessageBody,
@@ -189,9 +189,9 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 		case "projectCards":
 			data[f] = pr.ProjectCards.Nodes
 		case "projectItems":
-			items := make([]map[string]interface{}, 0, len(pr.ProjectItems.Nodes))
+			items := make([]map[string]any, 0, len(pr.ProjectItems.Nodes))
 			for _, n := range pr.ProjectItems.Nodes {
-				items = append(items, map[string]interface{}{
+				items = append(items, map[string]any{
 					"status": n.Status,
 					"title":  n.Project.Title,
 				})
@@ -204,7 +204,7 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 		case "files":
 			data[f] = pr.Files.Nodes
 		case "reviewRequests":
-			requests := make([]interface{}, 0, len(pr.ReviewRequests.Nodes))
+			requests := make([]any, 0, len(pr.ReviewRequests.Nodes))
 			for _, req := range pr.ReviewRequests.Nodes {
 				r := req.RequestedReviewer
 				switch r.TypeName {
@@ -223,16 +223,16 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 			}
 			data[f] = &requests
 		case "closingIssuesReferences":
-			items := make([]map[string]interface{}, 0, len(pr.ClosingIssuesReferences.Nodes))
+			items := make([]map[string]any, 0, len(pr.ClosingIssuesReferences.Nodes))
 			for _, n := range pr.ClosingIssuesReferences.Nodes {
-				items = append(items, map[string]interface{}{
+				items = append(items, map[string]any{
 					"id":     n.ID,
 					"number": n.Number,
 					"url":    n.URL,
-					"repository": map[string]interface{}{
+					"repository": map[string]any{
 						"id":   n.Repository.ID,
 						"name": n.Repository.Name,
-						"owner": map[string]interface{}{
+						"owner": map[string]any{
 							"id":    n.Repository.Owner.ID,
 							"login": n.Repository.Owner.Login,
 						},

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -414,10 +414,10 @@ func TestIssue_ExportData(t *testing.T) {
 			enc.SetIndent("", "\t")
 			require.NoError(t, enc.Encode(exported))
 
-			var gotData interface{}
+			var gotData any
 			dec = json.NewDecoder(&buf)
 			require.NoError(t, dec.Decode(&gotData))
-			var expectData interface{}
+			var expectData any
 			require.NoError(t, json.Unmarshal([]byte(tt.outputJSON), &expectData))
 
 			assert.Equal(t, expectData, gotData)
@@ -669,10 +669,10 @@ func TestPullRequest_ExportData(t *testing.T) {
 			enc.SetIndent("", "\t")
 			require.NoError(t, enc.Encode(exported))
 
-			var gotData interface{}
+			var gotData any
 			dec = json.NewDecoder(&buf)
 			require.NoError(t, dec.Decode(&gotData))
-			var expectData interface{}
+			var expectData any
 			require.NoError(t, json.Unmarshal([]byte(tt.outputJSON), &expectData))
 
 			assert.Equal(t, expectData, gotData)

--- a/api/export_repo.go
+++ b/api/export_repo.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 )
 
-func (repo *Repository) ExportData(fields []string) map[string]interface{} {
+func (repo *Repository) ExportData(fields []string) map[string]any {
 	v := reflect.ValueOf(repo).Elem()
-	data := map[string]interface{}{}
+	data := map[string]any{}
 
 	for _, f := range fields {
 		switch f {
@@ -41,11 +41,11 @@ func (repo *Repository) ExportData(fields []string) map[string]interface{} {
 	return data
 }
 
-func miniRepoExport(r *Repository) map[string]interface{} {
+func miniRepoExport(r *Repository) map[string]any {
 	if r == nil {
 		return nil
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"id":    r.ID,
 		"name":  r.Name,
 		"owner": r.Owner,

--- a/api/queries_branch_issue_reference.go
+++ b/api/queries_branch_issue_reference.go
@@ -36,7 +36,7 @@ func CreateLinkedBranch(client *Client, host string, repoID, issueID, branchID, 
 		name := githubv4.String(branchName)
 		input.Name = &name
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": input,
 	}
 
@@ -66,7 +66,7 @@ func ListLinkedBranches(client *Client, repo ghrepo.Interface, issueNumber int) 
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"number": githubv4.Int(issueNumber),
 		"owner":  githubv4.String(repo.RepoOwner()),
 		"name":   githubv4.String(repo.RepoName()),
@@ -126,7 +126,7 @@ func FindRepoBranchID(client *Client, repo ghrepo.Interface, ref string) (string
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"ref":   githubv4.String(ref),
 		"owner": githubv4.String(repo.RepoOwner()),
 		"name":  githubv4.String(repo.RepoName()),

--- a/api/queries_comments.go
+++ b/api/queries_comments.go
@@ -64,7 +64,7 @@ func CommentCreate(client *Client, repoHost string, params CommentCreateInput) (
 		} `graphql:"addComment(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.AddCommentInput{
 			Body:      githubv4.String(params.Body),
 			SubjectID: githubv4.ID(params.SubjectId),
@@ -88,7 +88,7 @@ func CommentUpdate(client *Client, repoHost string, params CommentUpdateInput) (
 		} `graphql:"updateIssueComment(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.UpdateIssueCommentInput{
 			Body: githubv4.String(params.Body),
 			ID:   githubv4.ID(params.CommentId),
@@ -110,7 +110,7 @@ func CommentDelete(client *Client, repoHost string, params CommentDeleteInput) e
 		} `graphql:"deleteIssueComment(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.DeleteIssueCommentInput{
 			ID: githubv4.ID(params.CommentId),
 		},

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -293,12 +293,12 @@ func (a Author) DisplayName() string {
 
 func (author Author) MarshalJSON() ([]byte, error) {
 	if author.ID == "" {
-		return json.Marshal(map[string]interface{}{
+		return json.Marshal(map[string]any{
 			"is_bot": true,
 			"login":  "app/" + author.Login,
 		})
 	}
-	return json.Marshal(map[string]interface{}{
+	return json.Marshal(map[string]any{
 		"is_bot": false,
 		"login":  author.Login,
 		"id":     author.ID,
@@ -323,7 +323,7 @@ func (a CommentAuthor) DisplayName() string {
 }
 
 // IssueCreate creates an issue in a GitHub repository
-func IssueCreate(client *Client, repo *Repository, params map[string]interface{}) (*Issue, error) {
+func IssueCreate(client *Client, repo *Repository, params map[string]any) (*Issue, error) {
 	query := `
 	mutation IssueCreate($input: CreateIssueInput!) {
 		createIssue(input: $input) {
@@ -334,7 +334,7 @@ func IssueCreate(client *Client, repo *Repository, params map[string]interface{}
 		}
 	}`
 
-	inputParams := map[string]interface{}{
+	inputParams := map[string]any{
 		"repositoryId": repo.ID,
 	}
 	for key, val := range params {
@@ -347,7 +347,7 @@ func IssueCreate(client *Client, repo *Repository, params map[string]interface{}
 			return nil, fmt.Errorf("invalid IssueCreate mutation parameter %s", key)
 		}
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": inputParams,
 	}
 
@@ -438,7 +438,7 @@ func IssueStatus(client *Client, repo ghrepo.Interface, options IssueStatusOptio
 		}
 	}`
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":  repo.RepoOwner(),
 		"repo":   repo.RepoName(),
 		"viewer": options.Username,
@@ -524,7 +524,7 @@ func UpdateIssueIssueType(client *Client, hostname string, issueID string, issue
 		typeID = &id
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": UpdateIssueIssueTypeInput{
 			IssueID:     githubv4.ID(issueID),
 			IssueTypeID: typeID,
@@ -550,7 +550,7 @@ func AddSubIssue(client *Client, hostname string, parentID string, subIssueID st
 		} `graphql:"addSubIssue(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": AddSubIssueInput{
 			IssueID:       githubv4.ID(parentID),
 			SubIssueID:    githubv4.ID(subIssueID),
@@ -576,7 +576,7 @@ func RemoveSubIssue(client *Client, hostname string, parentID string, subIssueID
 		} `graphql:"removeSubIssue(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": RemoveSubIssueInput{
 			IssueID:    githubv4.ID(parentID),
 			SubIssueID: githubv4.ID(subIssueID),
@@ -601,7 +601,7 @@ func AddBlockedBy(client *Client, hostname string, issueID string, blockingIssue
 		} `graphql:"addBlockedBy(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": AddBlockedByInput{
 			IssueID:         githubv4.ID(issueID),
 			BlockingIssueID: githubv4.ID(blockingIssueID),
@@ -626,7 +626,7 @@ func RemoveBlockedBy(client *Client, hostname string, issueID string, blockingIs
 		} `graphql:"removeBlockedBy(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": RemoveBlockedByInput{
 			IssueID:         githubv4.ID(issueID),
 			BlockingIssueID: githubv4.ID(blockingIssueID),
@@ -754,7 +754,7 @@ func RepoIssueTypes(client *Client, repo ghrepo.Interface) ([]IssueType, error) 
 			}
 		}
 	}`
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": repo.RepoOwner(),
 		"name":  repo.RepoName(),
 	}
@@ -782,7 +782,7 @@ func IssueNodeID(client *Client, repo ghrepo.Interface, number int) (string, err
 			}
 		}
 	}`
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":  repo.RepoOwner(),
 		"name":   repo.RepoName(),
 		"number": number,

--- a/api/queries_org.go
+++ b/api/queries_org.go
@@ -20,7 +20,7 @@ func OrganizationProjects(client *Client, repo ghrepo.Interface) ([]RepoProject,
 		} `graphql:"organization(login: $owner)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"endCursor": (*githubv4.String)(nil),
 	}
@@ -56,7 +56,7 @@ func OrganizationTeam(client *Client, hostname string, org string, teamSlug stri
 		} `graphql:"organization(login: $owner)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":    githubv4.String(org),
 		"teamSlug": githubv4.String(teamSlug),
 	}
@@ -87,7 +87,7 @@ func OrganizationTeams(client *Client, repo ghrepo.Interface) ([]OrgTeam, error)
 		} `graphql:"organization(login: $owner)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"endCursor": (*githubv4.String)(nil),
 	}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -487,7 +487,7 @@ func parseCheckStatusFromCheckConclusionState(state CheckConclusionState) checkS
 }
 
 // CreatePullRequest creates a pull request in a GitHub repository
-func CreatePullRequest(client *Client, repo *Repository, params map[string]interface{}) (*PullRequest, error) {
+func CreatePullRequest(client *Client, repo *Repository, params map[string]any) (*PullRequest, error) {
 	query := `
 		mutation PullRequestCreate($input: CreatePullRequestInput!) {
 			createPullRequest(input: $input) {
@@ -498,7 +498,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 			}
 	}`
 
-	inputParams := map[string]interface{}{
+	inputParams := map[string]any{
 		"repositoryId": repo.ID,
 	}
 	for key, val := range params {
@@ -507,7 +507,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 			inputParams[key] = val
 		}
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": inputParams,
 	}
 
@@ -525,7 +525,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 
 	// metadata parameters aren't currently available in `createPullRequest`,
 	// but they are in `updatePullRequest`
-	updateParams := make(map[string]interface{})
+	updateParams := make(map[string]any)
 	for key, val := range params {
 		switch key {
 		case "assigneeIds", "labelIds", "projectIds", "milestoneId":
@@ -540,7 +540,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 			updatePullRequest(input: $input) { clientMutationId }
 		}`
 		updateParams["pullRequestId"] = pr.ID
-		variables := map[string]interface{}{
+		variables := map[string]any{
 			"input": updateParams,
 		}
 		err := client.GraphQL(repo.RepoHost(), updateQuery, variables, &result)
@@ -572,7 +572,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 		}
 	} else {
 		// Use ID-based mutation (requestReviews) for GHES compatibility
-		reviewParams := make(map[string]interface{})
+		reviewParams := make(map[string]any)
 		if ids, ok := params["userReviewerIds"]; ok && !isBlank(ids) {
 			reviewParams["userIds"] = ids
 		}
@@ -588,7 +588,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 		}`
 			reviewParams["pullRequestId"] = pr.ID
 			reviewParams["union"] = true
-			variables := map[string]interface{}{
+			variables := map[string]any{
 				"input": reviewParams,
 			}
 			err := client.GraphQL(repo.RepoHost(), reviewQuery, variables, &result)
@@ -639,7 +639,7 @@ func ReplaceActorsForAssignableByLogin(client *Client, repo ghrepo.Interface, as
 		} `graphql:"replaceActorsForAssignable(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": ReplaceActorsForAssignableInput{
 			AssignableID: githubv4.ID(assignableID),
 			ActorLogins:  actorLogins,
@@ -695,7 +695,7 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 		} `graphql:"node(id: $id)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id":    githubv4.ID(assignableID),
 		"query": githubv4.String(query),
 		"owner": githubv4.String(repo.RepoOwner()),
@@ -749,11 +749,11 @@ func UpdatePullRequestBranch(client *Client, repo ghrepo.Interface, params githu
 			}
 		} `graphql:"updatePullRequestBranch(input: $input)"`
 	}
-	variables := map[string]interface{}{"input": params}
+	variables := map[string]any{"input": params}
 	return client.Mutate(repo.RepoHost(), "PullRequestUpdateBranch", &mutation, variables)
 }
 
-func isBlank(v interface{}) bool {
+func isBlank(v any) bool {
 	switch vv := v.(type) {
 	case string:
 		return vv == ""
@@ -773,7 +773,7 @@ func PullRequestClose(httpClient *http.Client, repo ghrepo.Interface, prID strin
 		} `graphql:"closePullRequest(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.ClosePullRequestInput{
 			PullRequestID: prID,
 		},
@@ -792,7 +792,7 @@ func PullRequestReopen(httpClient *http.Client, repo ghrepo.Interface, prID stri
 		} `graphql:"reopenPullRequest(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.ReopenPullRequestInput{
 			PullRequestID: prID,
 		},
@@ -811,7 +811,7 @@ func PullRequestReady(client *Client, repo ghrepo.Interface, pr *PullRequest) er
 		} `graphql:"markPullRequestReadyForReview(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.MarkPullRequestReadyForReviewInput{
 			PullRequestID: pr.ID,
 		},
@@ -834,7 +834,7 @@ func PullRequestRevert(client *Client, repo ghrepo.Interface, params githubv4.Re
 		} `graphql:"revertPullRequest(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": params,
 	}
 	err := client.Mutate(repo.RepoHost(), "PullRequestRevert", &mutation, variables)
@@ -860,7 +860,7 @@ func ConvertPullRequestToDraft(client *Client, repo ghrepo.Interface, pr *PullRe
 		} `graphql:"convertPullRequestToDraft(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.ConvertPullRequestToDraftInput{
 			PullRequestID: pr.ID,
 		},
@@ -905,7 +905,7 @@ func ComparePullRequestBaseBranchWith(client *Client, repo ghrepo.Interface, prN
 			}
 		}
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":             repo.RepoOwner(),
 		"repo":              repo.RepoName(),
 		"pullRequestNumber": prNumber,

--- a/api/queries_pr_review.go
+++ b/api/queries_pr_review.go
@@ -262,7 +262,7 @@ func AddReview(client *Client, repo ghrepo.Interface, pr *PullRequest, input *Pu
 	}
 
 	body := githubv4.String(input.Body)
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.AddPullRequestReviewInput{
 			PullRequestID: pr.ID,
 			Event:         &state,
@@ -391,7 +391,7 @@ func RequestReviewsByLogin(client *Client, repo ghrepo.Interface, prID string, u
 	teamSlugValues := toGitHubV4Strings(teamSlugs, "")
 	input.TeamSlugs = &teamSlugValues
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": input,
 	}
 
@@ -462,7 +462,7 @@ func SuggestedReviewerActors(client *Client, repo ghrepo.Interface, prID string,
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id":    githubv4.ID(prID),
 		"query": githubv4.String(query),
 		"owner": githubv4.String(repo.RepoOwner()),
@@ -612,7 +612,7 @@ func SuggestedReviewerActorsForRepo(client *Client, repo ghrepo.Interface, query
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"query": githubv4.String(query),
 		"owner": githubv4.String(repo.RepoOwner()),
 		"name":  githubv4.String(repo.RepoName()),

--- a/api/queries_pr_test.go
+++ b/api/queries_pr_test.go
@@ -578,8 +578,8 @@ func TestPRRepositorySelectionMatchesStruct(t *testing.T) {
 
 	var declared []string
 	repositoryType := reflect.TypeFor[PRRepository]()
-	for i := range repositoryType.NumField() {
-		name, _, _ := strings.Cut(repositoryType.Field(i).Tag.Get("json"), ",")
+	for field := range repositoryType.Fields() {
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
 		declared = append(declared, name)
 	}
 

--- a/api/queries_pr_test.go
+++ b/api/queries_pr_test.go
@@ -577,7 +577,7 @@ func TestPRRepositorySelectionMatchesStruct(t *testing.T) {
 	selected := strings.Split(inner, ",")
 
 	var declared []string
-	repositoryType := reflect.TypeOf(PRRepository{})
+	repositoryType := reflect.TypeFor[PRRepository]()
 	for i := range repositoryType.NumField() {
 		name, _, _ := strings.Cut(repositoryType.Field(i).Tag.Get("json"), ",")
 		declared = append(declared, name)

--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -39,20 +39,20 @@ func UpdateProjectV2Items(client *Client, repo ghrepo.Interface, addProjectItems
 	}
 	inputs := make([]string, 0, l)
 	mutations := make([]string, 0, l)
-	variables := make(map[string]interface{}, l)
+	variables := make(map[string]any, l)
 	var i int
 
 	for project, item := range addProjectItems {
 		inputs = append(inputs, fmt.Sprintf("$input_%03d: AddProjectV2ItemByIdInput!", i))
 		mutations = append(mutations, fmt.Sprintf("add_%03d: addProjectV2ItemById(input: $input_%03d) { item { id } }", i, i))
-		variables[fmt.Sprintf("input_%03d", i)] = map[string]interface{}{"contentId": item, "projectId": project}
+		variables[fmt.Sprintf("input_%03d", i)] = map[string]any{"contentId": item, "projectId": project}
 		i++
 	}
 
 	for project, item := range deleteProjectItems {
 		inputs = append(inputs, fmt.Sprintf("$input_%03d: DeleteProjectV2ItemInput!", i))
 		mutations = append(mutations, fmt.Sprintf("delete_%03d: deleteProjectV2Item(input: $input_%03d) { deletedItemId }", i, i))
-		variables[fmt.Sprintf("input_%03d", i)] = map[string]interface{}{"itemId": item, "projectId": project}
+		variables[fmt.Sprintf("input_%03d", i)] = map[string]any{"itemId": item, "projectId": project}
 		i++
 	}
 
@@ -93,7 +93,7 @@ func ProjectsV2ItemsForIssue(client *Client, repo ghrepo.Interface, issue *Issue
 			} `graphql:"issue(number: $number)"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"number":    githubv4.Int(issue.Number),
@@ -164,7 +164,7 @@ func ProjectsV2ItemsForPullRequest(client *Client, repo ghrepo.Interface, pr *Pu
 			} `graphql:"pullRequest(number: $number)"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"number":    githubv4.Int(pr.Number),
@@ -218,7 +218,7 @@ func OrganizationProjectsV2(client *Client, repo ghrepo.Interface) ([]ProjectV2,
 		} `graphql:"organization(login: $owner)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"endCursor": (*githubv4.String)(nil),
 		"query":     githubv4.String("is:open"),
@@ -257,7 +257,7 @@ func RepoProjectsV2(client *Client, repo ghrepo.Interface) ([]ProjectV2, error) 
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"endCursor": (*githubv4.String)(nil),
@@ -297,7 +297,7 @@ func CurrentUserProjectsV2(client *Client, hostname string) ([]ProjectV2, error)
 		} `graphql:"viewer"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"endCursor": (*githubv4.String)(nil),
 		"query":     githubv4.String("is:open"),
 	}

--- a/api/queries_projects_v2_test.go
+++ b/api/queries_projects_v2_test.go
@@ -26,7 +26,7 @@ func TestUpdateProjectV2Items(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation UpdateProjectV2Items\b`),
 					httpmock.GraphQLQuery(`{"data":{"add_000":{"item":{"id":"1"}},"delete_001":{"item":{"id":"2"}}}}`,
-						func(mutations string, inputs map[string]interface{}) {
+						func(mutations string, inputs map[string]any) {
 							expectedMutations := `
                 mutation UpdateProjectV2Items(
                   $input_000: AddProjectV2ItemByIdInput!
@@ -43,10 +43,10 @@ func TestUpdateProjectV2Items(t *testing.T) {
 							if len(inputs) != 4 {
 								t.Fatalf("expected 4 inputs, got %d", len(inputs))
 							}
-							i0 := inputs["input_000"].(map[string]interface{})
-							i1 := inputs["input_001"].(map[string]interface{})
-							i2 := inputs["input_002"].(map[string]interface{})
-							i3 := inputs["input_003"].(map[string]interface{})
+							i0 := inputs["input_000"].(map[string]any)
+							i1 := inputs["input_001"].(map[string]any)
+							i2 := inputs["input_002"].(map[string]any)
+							i3 := inputs["input_003"].(map[string]any)
 							adds := []string{
 								fmt.Sprintf("%v -> %v", i0["contentId"], i0["projectId"]),
 								fmt.Sprintf("%v -> %v", i1["contentId"], i1["projectId"]),
@@ -67,7 +67,7 @@ func TestUpdateProjectV2Items(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`mutation UpdateProjectV2Items\b`),
-					httpmock.GraphQLMutation(`{"data":{}, "errors": [{"message": "some gql error"}]}`, func(inputs map[string]interface{}) {}),
+					httpmock.GraphQLMutation(`{"data":{}, "errors": [{"message": "some gql error"}]}`, func(inputs map[string]any) {}),
 				)
 			},
 			expectError: true,
@@ -108,7 +108,7 @@ func TestProjectsV2ItemsForIssue(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query IssueProjectItems\b`),
 					httpmock.GraphQLQuery(`{"data":{"repository":{"issue":{"projectItems":{"nodes": [{"id":"projectItem1"},{"id":"projectItem2"}]}}}}}`,
-						func(query string, inputs map[string]interface{}) {}),
+						func(query string, inputs map[string]any) {}),
 				)
 			},
 			expectItems: ProjectItems{
@@ -124,7 +124,7 @@ func TestProjectsV2ItemsForIssue(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query IssueProjectItems\b`),
 					httpmock.GraphQLQuery(`{"data":{}, "errors": [{"message": "some gql error"}]}`,
-						func(query string, inputs map[string]interface{}) {}),
+						func(query string, inputs map[string]any) {}),
 				)
 			},
 			expectError: true,
@@ -135,7 +135,7 @@ func TestProjectsV2ItemsForIssue(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query IssueProjectItems\b`),
 					httpmock.GraphQLQuery(`{"data":{"repository":{"issue":{"projectItems":{"totalCount":1,"nodes":[null]}}}}}`,
-						func(query string, inputs map[string]interface{}) {}),
+						func(query string, inputs map[string]any) {}),
 				)
 			},
 			expectItems: ProjectItems{},
@@ -176,7 +176,7 @@ func TestProjectsV2ItemsForPullRequest(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query PullRequestProjectItems\b`),
 					httpmock.GraphQLQuery(`{"data":{"repository":{"pullRequest":{"projectItems":{"nodes": [{"id":"projectItem3"},{"id":"projectItem4"}]}}}}}`,
-						func(query string, inputs map[string]interface{}) {}),
+						func(query string, inputs map[string]any) {}),
 				)
 			},
 			expectItems: ProjectItems{
@@ -192,7 +192,7 @@ func TestProjectsV2ItemsForPullRequest(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query PullRequestProjectItems\b`),
 					httpmock.GraphQLQuery(`{"data":{}, "errors": [{"message": "some gql error"}]}`,
-						func(query string, inputs map[string]interface{}) {}),
+						func(query string, inputs map[string]any) {}),
 				)
 			},
 			expectError: true,
@@ -203,7 +203,7 @@ func TestProjectsV2ItemsForPullRequest(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query PullRequestProjectItems\b`),
 					httpmock.GraphQLQuery(`{"data":{"repository":{"pullRequest":{"projectItems":{"totalCount":1,"nodes":[null]}}}}}`,
-						func(query string, inputs map[string]interface{}) {}),
+						func(query string, inputs map[string]any) {}),
 				)
 			},
 			expectItems: ProjectItems{},
@@ -240,7 +240,7 @@ func TestProjectsV2ItemsForPullRequest(t *testing.T) {
                           }
                         }
                       }`,
-						func(query string, inputs map[string]interface{}) {
+						func(query string, inputs map[string]any) {
 							require.Equal(t, float64(1), inputs["number"])
 							require.Equal(t, "OWNER", inputs["owner"])
 							require.Equal(t, "REPO", inputs["name"])

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -289,7 +289,7 @@ func FetchRepository(client *Client, repo ghrepo.Interface, fields []string) (*R
 		repository(owner: $owner, name: $name) {%s}
 	}`, RepositoryGraphQL(fields))
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": repo.RepoOwner(),
 		"name":  repo.RepoName(),
 	}
@@ -331,7 +331,7 @@ func IssueRepoInfo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 			viewerPermission
 		}
 	}`
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": repo.RepoOwner(),
 		"name":  repo.RepoName(),
 	}
@@ -385,7 +385,7 @@ func GitHubRepo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 			squashMergeAllowed
 		}
 	}`
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": repo.RepoOwner(),
 		"name":  repo.RepoName(),
 	}
@@ -450,7 +450,7 @@ func RepoParent(client *Client, repo ghrepo.Interface) (ghrepo.Interface, error)
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": githubv4.String(repo.RepoOwner()),
 		"name":  githubv4.String(repo.RepoName()),
 	}
@@ -599,7 +599,7 @@ func ForkRepo(client *Client, repo ghrepo.Interface, org, newName string, defaul
 		return nil, err
 	}
 
-	params := map[string]interface{}{}
+	params := map[string]any{}
 	if org != "" {
 		params["organization"] = org
 	}
@@ -684,7 +684,7 @@ func LastCommit(client *Client, repo ghrepo.Interface) (*Commit, error) {
 			}
 		} `graphql:"repository(owner: $owner, name: $repo)"`
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": githubv4.String(repo.RepoOwner()), "repo": githubv4.String(repo.RepoName()),
 	}
 	if err := client.Query(repo.RepoHost(), "LastCommit", &responseData, variables); err != nil {
@@ -703,7 +703,7 @@ func RepoFindForks(client *Client, repo ghrepo.Interface, limit int) ([]*Reposit
 		}
 	}{}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": repo.RepoOwner(),
 		"repo":  repo.RepoName(),
 		"limit": limit,
@@ -1113,7 +1113,7 @@ func RepoProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, error) 
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"endCursor": (*githubv4.String)(nil),
@@ -1252,7 +1252,7 @@ func RepoAssignableUsers(client *Client, repo ghrepo.Interface) ([]AssignableUse
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"endCursor": (*githubv4.String)(nil),
@@ -1311,7 +1311,7 @@ func RepoAssignableActors(client *Client, repo ghrepo.Interface) ([]AssignableAc
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"endCursor": (*githubv4.String)(nil),
@@ -1383,7 +1383,7 @@ func SearchRepoAssignableActors(client *Client, repo ghrepo.Interface, query str
 		q = &v
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": githubv4.String(repo.RepoOwner()),
 		"name":  githubv4.String(repo.RepoName()),
 		"query": q,
@@ -1432,7 +1432,7 @@ func RepoLabels(client *Client, repo ghrepo.Interface) ([]RepoLabel, error) {
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"endCursor": (*githubv4.String)(nil),
@@ -1487,7 +1487,7 @@ func RepoMilestones(client *Client, repo ghrepo.Interface, state string) ([]Repo
 		return nil, fmt.Errorf("invalid state: %s", state)
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"states":    states,

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -180,7 +180,7 @@ func TestBaseRepoQueriesSelectDatabaseID(t *testing.T) {
 			defer httpReg.Verify(t)
 
 			var query string
-			httpReg.Register(tt.matcher, httpmock.GraphQLQuery(tt.body, func(q string, _ map[string]interface{}) {
+			httpReg.Register(tt.matcher, httpmock.GraphQLQuery(tt.body, func(q string, _ map[string]any) {
 				query = q
 			}))
 

--- a/git/client.go
+++ b/git/client.go
@@ -305,9 +305,9 @@ func (c *Client) WorktreePrune(ctx context.Context) error {
 func parseWorktrees(output []byte) []Worktree {
 	var worktrees []Worktree
 	output = bytes.ReplaceAll(output, []byte("\r\n"), []byte("\n"))
-	for _, record := range strings.Split(string(output), "\n\n") {
+	for record := range strings.SplitSeq(string(output), "\n\n") {
 		var worktree Worktree
-		for _, line := range strings.Split(record, "\n") {
+		for line := range strings.SplitSeq(record, "\n") {
 			key, value, _ := strings.Cut(line, " ")
 			switch key {
 			case "worktree":

--- a/internal/browser/stub.go
+++ b/internal/browser/stub.go
@@ -17,7 +17,7 @@ func (b *Stub) BrowsedURL() string {
 }
 
 type _testing interface {
-	Errorf(string, ...interface{})
+	Errorf(string, ...any)
 	Helper()
 }
 

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -318,9 +318,9 @@ var ViewCodespaceFields = []string{
 	"environmentId",
 }
 
-func (c *Codespace) ExportData(fields []string) map[string]interface{} {
+func (c *Codespace) ExportData(fields []string) map[string]any {
 	v := reflect.ValueOf(c).Elem()
-	data := map[string]interface{}{}
+	data := map[string]any{}
 
 	for _, f := range fields {
 		switch f {
@@ -335,7 +335,7 @@ func (c *Codespace) ExportData(fields []string) map[string]interface{} {
 		case "retentionPeriodDays":
 			data[f] = c.RetentionPeriodMinutes / 1440
 		case "gitStatus":
-			data[f] = map[string]interface{}{
+			data[f] = map[string]any{
 				"ref":                   c.GitStatus.Ref,
 				"hasUnpushedChanges":    c.GitStatus.HasUnpushedChanges,
 				"hasUncommittedChanges": c.GitStatus.HasUncommittedChanges,

--- a/internal/codespaces/api/api_test.go
+++ b/internal/codespaces/api/api_test.go
@@ -608,7 +608,7 @@ func TestCodespace_ExportData(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   map[string]interface{}
+		want   map[string]any
 	}{
 		{
 			name: "just name",
@@ -618,7 +618,7 @@ func TestCodespace_ExportData(t *testing.T) {
 			args: args{
 				fields: []string{"name"},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"name": "test",
 			},
 		},
@@ -632,7 +632,7 @@ func TestCodespace_ExportData(t *testing.T) {
 			args: args{
 				fields: []string{"owner"},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"owner": "test",
 			},
 		},
@@ -646,7 +646,7 @@ func TestCodespace_ExportData(t *testing.T) {
 			args: args{
 				fields: []string{"machineName"},
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"machineName": "test",
 			},
 		},
@@ -690,7 +690,7 @@ func createFakeEditServer(t *testing.T, codespaceName string) *httptest.Server {
 		}
 		defer body.Close()
 
-		var data map[string]interface{}
+		var data map[string]any
 		err := json.NewDecoder(body).Decode(&data)
 
 		if err != nil {

--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"strings"
 
 	"github.com/cli/cli/v2/internal/codespaces/connection"
@@ -158,13 +159,7 @@ func (fwd *CodespacesPortForwarder) createTunnelPort(ctx context.Context, port u
 	// If no visibility is provided, Dev Tunnels will use the default (private)
 	if opts.Visibility != "" {
 		// Check if the requested visibility is allowed
-		allowed := false
-		for _, allowedVisibility := range fwd.connection.AllowedPortPrivacySettings {
-			if allowedVisibility == opts.Visibility {
-				allowed = true
-				break
-			}
-		}
+		allowed := slices.Contains(fwd.connection.AllowedPortPrivacySettings, opts.Visibility)
 
 		// If the requested visibility is not allowed, return an error
 		if !allowed {

--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -12,7 +12,7 @@ import (
 )
 
 type printer interface {
-	Printf(fmt string, v ...interface{})
+	Printf(fmt string, v ...any)
 }
 
 // Shell runs an interactive secure shell over an existing

--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -121,7 +121,7 @@ func newSCPCommand(ctx context.Context, port int, dst string, cmdArgs []string) 
 
 	for _, arg := range command {
 		// Replace "remote:" prefix with (e.g.) "root@localhost:".
-		if rest := strings.TrimPrefix(arg, "remote:"); rest != arg {
+		if rest, ok := strings.CutPrefix(arg, "remote:"); ok {
 			arg = dst + ":" + rest
 		}
 		cmdArgs = append(cmdArgs, arg)

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -82,7 +82,7 @@ func IsSame(a, b Interface) bool {
 		normalizeHostname(a.RepoHost()) == normalizeHostname(b.RepoHost())
 }
 
-func GenerateRepoURL(repo Interface, p string, args ...interface{}) string {
+func GenerateRepoURL(repo Interface, p string, args ...any) string {
 	baseURL := fmt.Sprintf("%s%s/%s", ghinstance.HostPrefix(repo.RepoHost()), repo.RepoOwner(), repo.RepoName())
 	if p != "" {
 		if path := fmt.Sprintf(p, args...); path != "" {

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -540,7 +540,7 @@ func (p *surveyPrompter) ConfirmDeletion(requiredValue string) error {
 		},
 		&result,
 		survey.WithValidator(
-			func(val interface{}) error {
+			func(val any) error {
 				if str := val.(string); !strings.EqualFold(str, requiredValue) {
 					return fmt.Errorf("You entered %s", str)
 				}
@@ -553,7 +553,7 @@ func (p *surveyPrompter) InputHostname() (string, error) {
 	err := p.ask(
 		&survey.Input{
 			Message: "Hostname:",
-		}, &result, survey.WithValidator(func(v interface{}) error {
+		}, &result, survey.WithValidator(func(v any) error {
 			return ghinstance.HostnameValidator(v.(string))
 		}))
 	return result, err
@@ -575,7 +575,7 @@ func (p *surveyPrompter) MarkdownEditor(prompt, defaultValue string, blankAllowe
 	return result, err
 }
 
-func (p *surveyPrompter) ask(q survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
+func (p *surveyPrompter) ask(q survey.Prompt, response any, opts ...survey.AskOpt) error {
 	opts = append(opts, survey.WithStdio(p.stdin, p.stdout, p.stderr))
 	err := survey.AskOne(q, response, opts...)
 	if err == nil {

--- a/internal/run/stub.go
+++ b/internal/run/stub.go
@@ -14,7 +14,7 @@ const (
 
 type T interface {
 	Helper()
-	Errorf(string, ...interface{})
+	Errorf(string, ...any)
 }
 
 // Stub installs a catch-all for all external commands invoked from gh. It returns a restore func that, when

--- a/internal/skills/discovery/discovery.go
+++ b/internal/skills/discovery/discovery.go
@@ -1099,7 +1099,7 @@ func validateName(name string) bool {
 
 // hasHiddenSegment reports whether any path component starts with a dot.
 func hasHiddenSegment(p string) bool {
-	for _, seg := range strings.Split(p, "/") {
+	for seg := range strings.SplitSeq(p, "/") {
 		if strings.HasPrefix(seg, ".") {
 			return true
 		}

--- a/internal/skills/discovery/discovery.go
+++ b/internal/skills/discovery/discovery.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -1108,12 +1109,7 @@ func hasHiddenSegment(p string) bool {
 
 // hasPluginsAncestor reports whether any path component is "plugins".
 func hasPluginsAncestor(p string) bool {
-	for _, seg := range strings.Split(p, "/") {
-		if seg == "plugins" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.Split(p, "/"), "plugins")
 }
 
 // IsSpecCompliant checks if a skill name matches the strict agentskills.io spec.

--- a/internal/skills/discovery/discovery_test.go
+++ b/internal/skills/discovery/discovery_test.go
@@ -432,8 +432,8 @@ func TestResolveRef(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/ref/heads%2Fmain"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "branch-sha"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "branch-sha"},
 					}))
 			},
 			wantRef: "refs/heads/main",
@@ -448,8 +448,8 @@ func TestResolveRef(t *testing.T) {
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/ref/tags%2Fv1.0"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "abc123", "type": "commit"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "abc123", "type": "commit"},
 					}))
 			},
 			wantRef: "refs/tags/v1.0",
@@ -464,13 +464,13 @@ func TestResolveRef(t *testing.T) {
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/ref/tags%2Fv2.0"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "tag-obj-sha", "type": "tag"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "tag-obj-sha", "type": "tag"},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/tags/tag-obj-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "real-commit-sha"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "real-commit-sha"},
 					}))
 			},
 			wantRef: "refs/tags/v2.0",
@@ -488,7 +488,7 @@ func TestResolveRef(t *testing.T) {
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/commits/deadbeef"),
-					httpmock.JSONResponse(map[string]interface{}{"sha": "deadbeef"}))
+					httpmock.JSONResponse(map[string]any{"sha": "deadbeef"}))
 			},
 			wantRef: "deadbeef",
 			wantSHA: "deadbeef",
@@ -515,8 +515,8 @@ func TestResolveRef(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/ref/heads%2Frelease"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "branch-sha"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "branch-sha"},
 					}))
 				// tag stub is not registered because branch succeeds first
 			},
@@ -529,8 +529,8 @@ func TestResolveRef(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/ref/tags%2Fv1.0"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "tag-sha", "type": "commit"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "tag-sha", "type": "commit"},
 					}))
 			},
 			wantRef: "refs/tags/v1.0",
@@ -542,8 +542,8 @@ func TestResolveRef(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/ref/heads%2Ffeature"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "feature-sha"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "feature-sha"},
 					}))
 			},
 			wantRef: "refs/heads/feature",
@@ -574,11 +574,11 @@ func TestResolveRef(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/releases/latest"),
-					httpmock.JSONResponse(map[string]interface{}{"tag_name": "v3.0"}))
+					httpmock.JSONResponse(map[string]any{"tag_name": "v3.0"}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/ref/tags%2Fv3.0"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "release-sha", "type": "commit"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "release-sha", "type": "commit"},
 					}))
 			},
 			wantRef: "refs/tags/v3.0",
@@ -592,11 +592,11 @@ func TestResolveRef(t *testing.T) {
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills"),
-					httpmock.JSONResponse(map[string]interface{}{"default_branch": "main"}))
+					httpmock.JSONResponse(map[string]any{"default_branch": "main"}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/ref/heads%2Fmain"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "branch-sha"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "branch-sha"},
 					}))
 			},
 			wantRef: "refs/heads/main",
@@ -608,8 +608,8 @@ func TestResolveRef(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/ref/tags%2Fv4.0"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "tag-obj-sha", "type": "tag"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "tag-obj-sha", "type": "tag"},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/tags/tag-obj-sha"),
@@ -640,14 +640,14 @@ func TestResolveRef(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/releases/latest"),
-					httpmock.JSONResponse(map[string]interface{}{"tag_name": ""}))
+					httpmock.JSONResponse(map[string]any{"tag_name": ""}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills"),
-					httpmock.JSONResponse(map[string]interface{}{"default_branch": "main"}))
+					httpmock.JSONResponse(map[string]any{"default_branch": "main"}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/ref/heads%2Fmain"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"object": map[string]interface{}{"sha": "fallback-sha"},
+					httpmock.JSONResponse(map[string]any{
+						"object": map[string]any{"sha": "fallback-sha"},
 					}))
 			},
 			wantRef: "refs/heads/main",
@@ -661,7 +661,7 @@ func TestResolveRef(t *testing.T) {
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills"),
-					httpmock.JSONResponse(map[string]interface{}{"default_branch": ""}))
+					httpmock.JSONResponse(map[string]any{"default_branch": ""}))
 			},
 			wantErr: "could not determine default branch",
 		},
@@ -731,7 +731,7 @@ func TestFetchBlob(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/abc"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "abc", "encoding": "base64", "content": "SGVsbG8gV29ybGQ=",
 					}))
 			},
@@ -742,7 +742,7 @@ func TestFetchBlob(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/abc"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "abc", "encoding": "utf-8", "content": "raw",
 					}))
 			},
@@ -789,7 +789,7 @@ func TestFetchRepoVisibility(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"visibility": "public",
 					}))
 			},
@@ -800,7 +800,7 @@ func TestFetchRepoVisibility(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"visibility": "private",
 					}))
 			},
@@ -811,7 +811,7 @@ func TestFetchRepoVisibility(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"visibility": "internal",
 					}))
 			},
@@ -822,7 +822,7 @@ func TestFetchRepoVisibility(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"visibility": "cool-visibility",
 					}))
 			},
@@ -869,9 +869,9 @@ func TestDiscoverSkills(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/abc123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "abc123", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "skills/code-review", "type": "tree", "sha": "tree-sha-1"},
 							{"path": "skills/code-review/SKILL.md", "type": "blob", "sha": "blob-1"},
 							{"path": "skills/issue-triage", "type": "tree", "sha": "tree-sha-2"},
@@ -887,8 +887,8 @@ func TestDiscoverSkills(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/abc123"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"sha": "abc123", "truncated": true, "tree": []map[string]interface{}{},
+					httpmock.JSONResponse(map[string]any{
+						"sha": "abc123", "truncated": true, "tree": []map[string]any{},
 					}))
 			},
 			wantErr: "too large",
@@ -898,9 +898,9 @@ func TestDiscoverSkills(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/abc123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "abc123", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "README.md", "type": "blob", "sha": "readme"},
 						},
 					}))
@@ -921,9 +921,9 @@ func TestDiscoverSkills(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/abc123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "abc123", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "skills/code-review", "type": "tree", "sha": "tree-sha"},
 							{"path": "skills/code-review/SKILL.md", "type": "blob", "sha": "blob-1"},
 							{"path": "skills/code-review/SKILL.md", "type": "blob", "sha": "blob-2"},
@@ -937,9 +937,9 @@ func TestDiscoverSkills(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/abc123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "abc123", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "terraform/code-generation/skills/terraform-style-guide", "type": "tree", "sha": "tree-sha-1"},
 							{"path": "terraform/code-generation/skills/terraform-style-guide/SKILL.md", "type": "blob", "sha": "blob-1"},
 							{"path": "terraform/code-generation/skills/terraform-test", "type": "tree", "sha": "tree-sha-2"},
@@ -955,9 +955,9 @@ func TestDiscoverSkills(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/abc123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "abc123", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "skills/code-review", "type": "tree", "sha": "tree-sha-1"},
 							{"path": "skills/code-review/SKILL.md", "type": "blob", "sha": "blob-1"},
 							{"path": "terraform/skills/tf-lint", "type": "tree", "sha": "tree-sha-2"},
@@ -992,9 +992,9 @@ func TestDiscoverSkills(t *testing.T) {
 }
 
 func TestDiscoverSkillsWithOptions(t *testing.T) {
-	hiddenDirTree := map[string]interface{}{
+	hiddenDirTree := map[string]any{
 		"sha": "abc123", "truncated": false,
-		"tree": []map[string]interface{}{
+		"tree": []map[string]any{
 			{"path": ".claude/skills/code-review", "type": "tree", "sha": "tree-sha-1"},
 			{"path": ".claude/skills/code-review/SKILL.md", "type": "blob", "sha": "blob-1"},
 			{"path": ".agents/skills/git-commit", "type": "tree", "sha": "tree-sha-2"},
@@ -1003,9 +1003,9 @@ func TestDiscoverSkillsWithOptions(t *testing.T) {
 		},
 	}
 
-	mixedTree := map[string]interface{}{
+	mixedTree := map[string]any{
 		"sha": "abc123", "truncated": false,
-		"tree": []map[string]interface{}{
+		"tree": []map[string]any{
 			{"path": "skills/standard-skill", "type": "tree", "sha": "tree-sha-1"},
 			{"path": "skills/standard-skill/SKILL.md", "type": "blob", "sha": "blob-1"},
 			{"path": ".claude/skills/hidden-skill", "type": "tree", "sha": "tree-sha-2"},
@@ -1013,9 +1013,9 @@ func TestDiscoverSkillsWithOptions(t *testing.T) {
 		},
 	}
 
-	nestedHiddenTree := map[string]interface{}{
+	nestedHiddenTree := map[string]any{
 		"sha": "abc123", "truncated": false,
-		"tree": []map[string]interface{}{
+		"tree": []map[string]any{
 			{"path": "foo/bar/.claude/skills/hidden-skill", "type": "tree", "sha": "tree-sha-1"},
 			{"path": "foo/bar/.claude/skills/hidden-skill/SKILL.md", "type": "blob", "sha": "blob-1"},
 			{"path": "foo/bar/.claude/nested/skills/deep-hidden-skill", "type": "tree", "sha": "tree-sha-2"},
@@ -1023,16 +1023,16 @@ func TestDiscoverSkillsWithOptions(t *testing.T) {
 		},
 	}
 
-	emptyTree := map[string]interface{}{
+	emptyTree := map[string]any{
 		"sha": "abc123", "truncated": false,
-		"tree": []map[string]interface{}{
+		"tree": []map[string]any{
 			{"path": "README.md", "type": "blob", "sha": "readme"},
 		},
 	}
 
 	tests := []struct {
 		name       string
-		tree       map[string]interface{}
+		tree       map[string]any
 		wantSkills []string
 		wantErr    string
 	}{
@@ -1098,20 +1098,20 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/skills"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"name": "code-review", "path": "skills/code-review", "sha": "tree-sha", "type": "dir"},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree-sha", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "blob-sha"},
 						},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/blob-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "blob-sha", "encoding": "base64", "content": "IyBTa2lsbA==",
 					}))
 			},
@@ -1123,20 +1123,20 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/skills%2Fmonalisa"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"name": "issue-triage", "path": "skills/monalisa/issue-triage", "sha": "tree-sha", "type": "dir"},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree-sha", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "blob-sha"},
 						},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/blob-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "blob-sha", "encoding": "base64", "content": "IyBTa2lsbA==",
 					}))
 			},
@@ -1149,20 +1149,20 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/my%20skills"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"name": "code-review", "path": "my skills/code-review", "sha": "tree-sha", "type": "dir"},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree-sha", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "blob-sha"},
 						},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/blob-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "blob-sha", "encoding": "base64", "content": "IyBTa2lsbA==",
 					}))
 			},
@@ -1174,20 +1174,20 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/skills"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"name": "code-review", "path": "skills/code-review", "sha": "tree-sha", "type": "dir"},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree-sha", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "blob-sha"},
 						},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/blob-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "blob-sha", "encoding": "base64", "content": "IyBTa2lsbA==",
 					}))
 			},
@@ -1204,7 +1204,7 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/skills"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"name": "other-skill", "path": "skills/other-skill", "sha": "tree-sha", "type": "dir"},
 					}))
 			},
@@ -1216,14 +1216,14 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/skills"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"name": "code-review", "path": "skills/code-review", "sha": "tree-sha", "type": "dir"},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree-sha", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "README.md", "type": "blob", "sha": "readme"},
 						},
 					}))
@@ -1236,20 +1236,20 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/terraform%2Fcode-generation%2Fskills"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"name": "terraform-style-guide", "path": "terraform/code-generation/skills/terraform-style-guide", "sha": "tree-sha", "type": "dir"},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree-sha", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "blob-sha"},
 						},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/blob-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "blob-sha", "encoding": "base64", "content": "IyBTa2lsbA==",
 					}))
 			},
@@ -1261,20 +1261,20 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/terraform%2Fcode-generation%2Fskills%2Fhashicorp"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"name": "terraform-style-guide", "path": "terraform/code-generation/skills/hashicorp/terraform-style-guide", "sha": "tree-sha", "type": "dir"},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree-sha", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "blob-sha"},
 						},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/blob-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "blob-sha", "encoding": "base64", "content": "IyBTa2lsbA==",
 					}))
 			},
@@ -1287,20 +1287,20 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/plugins%2Fhubot%2Fskills"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"name": "pr-summary", "path": "plugins/hubot/skills/pr-summary", "sha": "tree-sha", "type": "dir"},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree-sha", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "blob-sha"},
 						},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/blob-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "blob-sha", "encoding": "base64", "content": "IyBTa2lsbA==",
 					}))
 			},
@@ -1340,14 +1340,14 @@ func TestDiscoverSkillByPathWithOptionsSkipsDescription(t *testing.T) {
 
 	reg.Register(
 		httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/skills"),
-		httpmock.JSONResponse([]map[string]interface{}{
+		httpmock.JSONResponse([]map[string]any{
 			{"name": "code-review", "path": "skills/code-review", "sha": "tree-sha", "type": "dir"},
 		}))
 	reg.Register(
 		httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree-sha"),
-		httpmock.JSONResponse(map[string]interface{}{
+		httpmock.JSONResponse(map[string]any{
 			"sha": "tree-sha", "truncated": false,
-			"tree": []map[string]interface{}{
+			"tree": []map[string]any{
 				{"path": "SKILL.md", "type": "blob", "sha": "blob-sha"},
 			},
 		}))
@@ -1605,9 +1605,9 @@ func TestDiscoverSkillFiles(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree123", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "sha1", "size": 10},
 							{"path": "scripts/setup.sh", "type": "blob", "sha": "sha2", "size": 50},
 							{"path": "scripts", "type": "tree", "sha": "treesub"},
@@ -1621,14 +1621,14 @@ func TestDiscoverSkillFiles(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"sha": "tree123", "truncated": true, "tree": []map[string]interface{}{},
+					httpmock.JSONResponse(map[string]any{
+						"sha": "tree123", "truncated": true, "tree": []map[string]any{},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree123",
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "sha1", "size": 10},
 						},
 					}))
@@ -1680,9 +1680,9 @@ func TestListSkillFiles(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree123", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "sha1", "size": 10},
 							{"path": "prompt.txt", "type": "blob", "sha": "sha2", "size": 20},
 						},
@@ -1695,15 +1695,15 @@ func TestListSkillFiles(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"sha": "tree123", "truncated": true, "tree": []map[string]interface{}{},
+					httpmock.JSONResponse(map[string]any{
+						"sha": "tree123", "truncated": true, "tree": []map[string]any{},
 					}))
 				// walkTree fetches the top-level tree non-recursively
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree123",
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "sha1", "size": 10},
 							{"path": "scripts", "type": "tree", "sha": "subtree1"},
 						},
@@ -1711,9 +1711,9 @@ func TestListSkillFiles(t *testing.T) {
 				// walkTree recurses into the "scripts" subtree
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/subtree1"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "subtree1",
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "setup.sh", "type": "blob", "sha": "sha2", "size": 50},
 						},
 					}))
@@ -1769,7 +1769,7 @@ func TestFetchDescriptionsConcurrent(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/blob1"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "blob1", "encoding": "base64",
 						"content": "LS0tCm5hbWU6IGNvZGUtcmV2aWV3CmRlc2NyaXB0aW9uOiBSZXZpZXdzIFBScwotLS0KIyBUZXN0",
 					}))

--- a/internal/skills/frontmatter/frontmatter.go
+++ b/internal/skills/frontmatter/frontmatter.go
@@ -36,13 +36,13 @@ func Parse(content string) (*ParseResult, error) {
 
 	rest := trimmed[len(delimiter):]
 	rest = strings.TrimLeft(rest, "\r\n")
-	endIdx := strings.Index(rest, "\n"+delimiter)
-	if endIdx == -1 {
+	before, after, ok := strings.Cut(rest, "\n"+delimiter)
+	if !ok {
 		return &ParseResult{Body: content}, nil
 	}
 
-	yamlContent := rest[:endIdx]
-	body := rest[endIdx+len("\n"+delimiter):]
+	yamlContent := before
+	body := after
 	body = strings.TrimLeft(body, "\r\n")
 
 	var rawYAML map[string]any

--- a/internal/skills/frontmatter/frontmatter.go
+++ b/internal/skills/frontmatter/frontmatter.go
@@ -13,17 +13,17 @@ const delimiter = "---"
 
 // Metadata represents the parsed YAML frontmatter of a SKILL.md file.
 type Metadata struct {
-	Name        string                 `yaml:"name"`
-	Description string                 `yaml:"description"`
-	License     string                 `yaml:"license,omitempty"`
-	Meta        map[string]interface{} `yaml:"metadata,omitempty"`
+	Name        string         `yaml:"name"`
+	Description string         `yaml:"description"`
+	License     string         `yaml:"license,omitempty"`
+	Meta        map[string]any `yaml:"metadata,omitempty"`
 }
 
 // ParseResult contains the parsed frontmatter and remaining body.
 type ParseResult struct {
 	Metadata Metadata
 	Body     string
-	RawYAML  map[string]interface{}
+	RawYAML  map[string]any
 }
 
 // Parse extracts YAML frontmatter from a SKILL.md file.
@@ -45,7 +45,7 @@ func Parse(content string) (*ParseResult, error) {
 	body := rest[endIdx+len("\n"+delimiter):]
 	body = strings.TrimLeft(body, "\r\n")
 
-	var rawYAML map[string]interface{}
+	var rawYAML map[string]any
 	if err := yaml.Unmarshal([]byte(yamlContent), &rawYAML); err != nil {
 		return nil, fmt.Errorf("invalid frontmatter YAML: %w", err)
 	}
@@ -74,12 +74,12 @@ func InjectGitHubMetadata(content string, host, owner, repo, ref, treeSHA, pinne
 	}
 
 	if result.RawYAML == nil {
-		result.RawYAML = make(map[string]interface{})
+		result.RawYAML = make(map[string]any)
 	}
 
-	meta, _ := result.RawYAML["metadata"].(map[string]interface{})
+	meta, _ := result.RawYAML["metadata"].(map[string]any)
 	if meta == nil {
-		meta = make(map[string]interface{})
+		meta = make(map[string]any)
 	}
 	delete(meta, "github-owner")
 	meta["github-repo"] = source.BuildRepoURL(host, owner, repo)
@@ -106,12 +106,12 @@ func InjectLocalMetadata(content string, sourcePath string) (string, error) {
 	}
 
 	if result.RawYAML == nil {
-		result.RawYAML = make(map[string]interface{})
+		result.RawYAML = make(map[string]any)
 	}
 
-	meta, _ := result.RawYAML["metadata"].(map[string]interface{})
+	meta, _ := result.RawYAML["metadata"].(map[string]any)
 	if meta == nil {
-		meta = make(map[string]interface{})
+		meta = make(map[string]any)
 	}
 	delete(meta, "github-owner")
 	delete(meta, "github-repo")
@@ -127,7 +127,7 @@ func InjectLocalMetadata(content string, sourcePath string) (string, error) {
 }
 
 // Serialize writes a frontmatter map and body back to a SKILL.md string.
-func Serialize(frontmatter map[string]interface{}, body string) (string, error) {
+func Serialize(frontmatter map[string]any, body string) (string, error) {
 	var buf bytes.Buffer
 
 	yamlBytes, err := yaml.Marshal(frontmatter)

--- a/internal/skills/frontmatter/frontmatter_test.go
+++ b/internal/skills/frontmatter/frontmatter_test.go
@@ -207,7 +207,7 @@ func TestInjectLocalMetadata(t *testing.T) {
 func TestSerialize(t *testing.T) {
 	tests := []struct {
 		name         string
-		frontmatter  map[string]interface{}
+		frontmatter  map[string]any
 		body         string
 		wantPrefix   string
 		wantSuffix   string
@@ -215,7 +215,7 @@ func TestSerialize(t *testing.T) {
 	}{
 		{
 			name:        "with body",
-			frontmatter: map[string]interface{}{"name": "test"},
+			frontmatter: map[string]any{"name": "test"},
 			body:        "# Body content",
 			wantPrefix:  "---\n",
 			wantContains: []string{
@@ -225,13 +225,13 @@ func TestSerialize(t *testing.T) {
 		},
 		{
 			name:        "empty body",
-			frontmatter: map[string]interface{}{"name": "test"},
+			frontmatter: map[string]any{"name": "test"},
 			body:        "",
 			wantSuffix:  "---\n",
 		},
 		{
 			name:        "body without trailing newline gets one added",
-			frontmatter: map[string]interface{}{"name": "test"},
+			frontmatter: map[string]any{"name": "test"},
 			body:        "# No trailing newline",
 			wantSuffix:  "# No trailing newline\n",
 		},

--- a/internal/skills/installer/installer_test.go
+++ b/internal/skills/installer/installer_test.go
@@ -195,22 +195,22 @@ func TestInstallSkill(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree123", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "skill-sha", "size": 10},
 							{"path": "prompt.txt", "type": "blob", "sha": "prompt-sha", "size": 5},
 						},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/skill-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "skill-sha", "encoding": "base64",
 						"content": base64.StdEncoding.EncodeToString([]byte("# Code Review")),
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/prompt-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "prompt-sha", "encoding": "base64",
 						"content": base64.StdEncoding.EncodeToString([]byte("review this PR")),
 					}))
@@ -231,15 +231,15 @@ func TestInstallSkill(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree456"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree456", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "md-sha", "size": 20},
 						},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/md-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "md-sha", "encoding": "base64",
 						"content": base64.StdEncoding.EncodeToString([]byte("# PR Summary\nSummarize pull requests")),
 					}))
@@ -258,22 +258,22 @@ func TestInstallSkill(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "tree123", "truncated": false,
-						"tree": []map[string]interface{}{
+						"tree": []map[string]any{
 							{"path": "SKILL.md", "type": "blob", "sha": "safe-sha", "size": 10},
 							{"path": "../../etc/passwd", "type": "blob", "sha": "evil-sha", "size": 100},
 						},
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/safe-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "safe-sha", "encoding": "base64",
 						"content": base64.StdEncoding.EncodeToString([]byte("# Safe Skill")),
 					}))
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/evil-sha"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"sha": "evil-sha", "encoding": "base64",
 						"content": base64.StdEncoding.EncodeToString([]byte("malicious content")),
 					}))
@@ -316,15 +316,15 @@ func TestInstallSkill(t *testing.T) {
 func stubTreeAndBlob(reg *httpmock.Registry, treeSHA string) {
 	reg.Register(
 		httpmock.REST("GET", fmt.Sprintf("repos/monalisa/octocat-skills/git/trees/%s", treeSHA)),
-		httpmock.JSONResponse(map[string]interface{}{
+		httpmock.JSONResponse(map[string]any{
 			"sha": treeSHA, "truncated": false,
-			"tree": []map[string]interface{}{
+			"tree": []map[string]any{
 				{"path": "SKILL.md", "type": "blob", "sha": treeSHA + "-blob", "size": 10},
 			},
 		}))
 	reg.Register(
 		httpmock.REST("GET", fmt.Sprintf("repos/monalisa/octocat-skills/git/blobs/%s-blob", treeSHA)),
-		httpmock.JSONResponse(map[string]interface{}{
+		httpmock.JSONResponse(map[string]any{
 			"sha": treeSHA + "-blob", "encoding": "base64",
 			"content": base64.StdEncoding.EncodeToString([]byte("# Skill")),
 		}))

--- a/internal/skills/source/source.go
+++ b/internal/skills/source/source.go
@@ -32,7 +32,7 @@ func ParseRepoURL(raw string) (ghrepo.Interface, error) {
 }
 
 // ParseMetadataRepo extracts repository information from skill metadata.
-func ParseMetadataRepo(meta map[string]interface{}) (ghrepo.Interface, bool, error) {
+func ParseMetadataRepo(meta map[string]any) (ghrepo.Interface, bool, error) {
 	if meta == nil {
 		return nil, false, nil
 	}

--- a/internal/skills/source/source_test.go
+++ b/internal/skills/source/source_test.go
@@ -14,7 +14,7 @@ func TestBuildRepoURL(t *testing.T) {
 func TestParseMetadataRepo(t *testing.T) {
 	tests := []struct {
 		name      string
-		meta      map[string]interface{}
+		meta      map[string]any
 		wantOwner string
 		wantRepo  string
 		wantHost  string
@@ -23,7 +23,7 @@ func TestParseMetadataRepo(t *testing.T) {
 	}{
 		{
 			name: "parses repo url metadata",
-			meta: map[string]interface{}{
+			meta: map[string]any{
 				"github-repo": "https://github.com/monalisa/octocat-skills",
 			},
 			wantOwner: "monalisa",
@@ -33,7 +33,7 @@ func TestParseMetadataRepo(t *testing.T) {
 		},
 		{
 			name: "invalid repo url",
-			meta: map[string]interface{}{
+			meta: map[string]any{
 				"github-repo": "not a url",
 			},
 			wantFound: true,
@@ -41,7 +41,7 @@ func TestParseMetadataRepo(t *testing.T) {
 		},
 		{
 			name:      "missing repo metadata",
-			meta:      map[string]interface{}{},
+			meta:      map[string]any{},
 			wantFound: false,
 		},
 	}

--- a/pkg/cmd/agent-task/capi/job.go
+++ b/pkg/cmd/agent-task/capi/job.go
@@ -26,8 +26,8 @@ type Job struct {
 	Status            string          `json:"status,omitempty"`
 	Result            string          `json:"result,omitempty"`
 	Actor             *JobActor       `json:"actor,omitempty"`
-	CreatedAt         time.Time       `json:"created_at,omitempty"`
-	UpdatedAt         time.Time       `json:"updated_at,omitempty"`
+	CreatedAt         time.Time       `json:"created_at"`
+	UpdatedAt         time.Time       `json:"updated_at"`
 	PullRequest       *JobPullRequest `json:"pull_request,omitempty"`
 	WorkflowRun       *struct {
 		ID string `json:"id"`

--- a/pkg/cmd/agent-task/capi/job_test.go
+++ b/pkg/cmd/agent-task/capi/job_test.go
@@ -233,7 +233,7 @@ func TestCreateJob(t *testing.T) {
 								"updated_at": "%[1]s"
 							}
 						`, sampleDateString),
-						func(payload map[string]interface{}) {
+						func(payload map[string]any) {
 							assert.Equal(t, "Do the thing", payload["problem_statement"])
 							assert.Equal(t, "gh_cli", payload["event_type"])
 						},
@@ -280,10 +280,10 @@ func TestCreateJob(t *testing.T) {
 								"updated_at": "%[1]s"
 							}
 						`, sampleDateString),
-						func(payload map[string]interface{}) {
+						func(payload map[string]any) {
 							assert.Equal(t, "Do the thing", payload["problem_statement"])
 							assert.Equal(t, "gh_cli", payload["event_type"])
-							assert.Equal(t, "refs/heads/some-branch", payload["pull_request"].(map[string]interface{})["base_ref"])
+							assert.Equal(t, "refs/heads/some-branch", payload["pull_request"].(map[string]any)["base_ref"])
 						},
 					),
 				)
@@ -329,7 +329,7 @@ func TestCreateJob(t *testing.T) {
 								"updated_at": "%[1]s"
 							}
 						`, sampleDateString),
-						func(payload map[string]interface{}) {
+						func(payload map[string]any) {
 							assert.Equal(t, "Do the thing", payload["problem_statement"])
 							assert.Equal(t, "gh_cli", payload["event_type"])
 							assert.Equal(t, "my-custom-agent", payload["custom_agent"])

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -119,8 +119,8 @@ var SessionFields = []string{
 }
 
 // ExportData implements the exportable interface for JSON output.
-func (s *Session) ExportData(fields []string) map[string]interface{} {
-	data := make(map[string]interface{}, len(fields))
+func (s *Session) ExportData(fields []string) map[string]any {
+	data := make(map[string]any, len(fields))
 	for _, f := range fields {
 		switch f {
 		case "id":
@@ -528,7 +528,7 @@ func (c *CAPIClient) GetPullRequestDatabaseID(ctx context.Context, hostname stri
 		} `graphql:"repository(owner: $owner, name: $repo)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":  githubv4.String(owner),
 		"repo":   githubv4.String(repo),
 		"number": githubv4.Int(number),

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -39,9 +39,9 @@ type session struct {
 	ResourceType     string    `json:"resource_type"`
 	ResourceID       int64     `json:"resource_id"`
 	ResourceGlobalID string    `json:"resource_global_id"`
-	LastUpdatedAt    time.Time `json:"last_updated_at,omitempty"`
-	CreatedAt        time.Time `json:"created_at,omitempty"`
-	CompletedAt      time.Time `json:"completed_at,omitempty"`
+	LastUpdatedAt    time.Time `json:"last_updated_at"`
+	CreatedAt        time.Time `json:"created_at"`
+	CompletedAt      time.Time `json:"completed_at"`
 	EventURL         string    `json:"event_url"`
 	EventType        string    `json:"event_type"`
 	PremiumRequests  float64   `json:"premium_requests"`

--- a/pkg/cmd/agent-task/capi/sessions_test.go
+++ b/pkg/cmd/agent-task/capi/sessions_test.go
@@ -116,8 +116,8 @@ func TestListLatestSessionsForViewer(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
-						assert.Equal(t, []interface{}{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
+					), func(q string, vars map[string]any) {
+						assert.Equal(t, []any{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -211,8 +211,8 @@ func TestListLatestSessionsForViewer(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
-						assert.Equal(t, []interface{}{"U_kgAB"}, vars["ids"])
+					), func(q string, vars map[string]any) {
+						assert.Equal(t, []any{"U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -355,8 +355,8 @@ func TestListLatestSessionsForViewer(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
-						assert.Equal(t, []interface{}{"PR_kwDNA-jNB9A", "PR_kwDNA-jNB9E", "U_kgAB"}, vars["ids"])
+					), func(q string, vars map[string]any) {
+						assert.Equal(t, []any{"PR_kwDNA-jNB9A", "PR_kwDNA-jNB9E", "U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -585,9 +585,9 @@ func TestListLatestSessionsForViewer(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
+					), func(q string, vars map[string]any) {
 						// Expected encoded node IDs for resource IDs 3000,3001,3002 and user octocat
-						assert.Equal(t, []interface{}{"PR_kwDNA-jNC7g", "PR_kwDNA-jNC7k", "PR_kwDNA-jNC7o", "U_kgAB"}, vars["ids"])
+						assert.Equal(t, []any{"PR_kwDNA-jNC7g", "PR_kwDNA-jNC7k", "PR_kwDNA-jNC7o", "U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -807,9 +807,9 @@ func TestListLatestSessionsForViewer(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
+					), func(q string, vars map[string]any) {
 						// Expected encoded node IDs for resource IDs 3000 and user octocat
-						assert.Equal(t, []interface{}{"PR_kwDNA-jNC7g", "U_kgAB"}, vars["ids"])
+						assert.Equal(t, []any{"PR_kwDNA-jNC7g", "U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -943,9 +943,9 @@ func TestListLatestSessionsForViewer(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
+					), func(q string, vars map[string]any) {
 						// Expected encoded node IDs for resource IDs 3000 and user octocat
-						assert.Equal(t, []interface{}{"PR_kwDNA-jNC7g", "U_kgAB"}, vars["ids"])
+						assert.Equal(t, []any{"PR_kwDNA-jNC7g", "U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -1052,9 +1052,9 @@ func TestListLatestSessionsForViewer(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
+					), func(q string, vars map[string]any) {
 						// Expected encoded node IDs for resource IDs 3000 and user octocat
-						assert.Equal(t, []interface{}{"PR_kwDNA-jNC7g", "U_kgAB"}, vars["ids"])
+						assert.Equal(t, []any{"PR_kwDNA-jNC7g", "U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -1295,8 +1295,8 @@ func TestListSessionsByResourceID(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
-						assert.Equal(t, []interface{}{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
+					), func(q string, vars map[string]any) {
+						assert.Equal(t, []any{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -1418,8 +1418,8 @@ func TestListSessionsByResourceID(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
-						assert.Equal(t, []interface{}{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
+					), func(q string, vars map[string]any) {
+						assert.Equal(t, []any{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -1670,8 +1670,8 @@ func TestGetSession(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
-						assert.Equal(t, []interface{}{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
+					), func(q string, vars map[string]any) {
+						assert.Equal(t, []any{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -1751,8 +1751,8 @@ func TestGetSession(t *testing.T) {
 							}
 						}`,
 						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
-						assert.Equal(t, []interface{}{"U_kgAB"}, vars["ids"])
+					), func(q string, vars map[string]any) {
+						assert.Equal(t, []any{"U_kgAB"}, vars["ids"])
 					}),
 				)
 			},
@@ -1873,7 +1873,7 @@ func TestGetPullRequestDatabaseID(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.WithHost(httpmock.GraphQL(`query GetPullRequestFullDatabaseID\b`), "api.github.com"),
-					httpmock.GraphQLQuery(`{"data": {"repository": {"pullRequest": {"fullDatabaseId": "999", "url": "some-url"}}}}`, func(s string, m map[string]interface{}) {
+					httpmock.GraphQLQuery(`{"data": {"repository": {"pullRequest": {"fullDatabaseId": "999", "url": "some-url"}}}}`, func(s string, m map[string]any) {
 						assert.Equal(t, "OWNER", m["owner"])
 						assert.Equal(t, "REPO", m["repo"])
 						assert.Equal(t, float64(42), m["number"])

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -317,7 +317,7 @@ func apiRun(opts *ApiOptions) error {
 	}
 	method := opts.RequestMethod
 	requestHeaders := opts.RequestHeaders
-	var requestBody interface{}
+	var requestBody any
 	if len(params) > 0 {
 		requestBody = params
 	}

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -1066,7 +1066,7 @@ func Test_apiRun_paginationGraphQL(t *testing.T) {
 	assert.Equal(t, "", stderr.String(), "stderr")
 
 	var requestData struct {
-		Variables map[string]interface{}
+		Variables map[string]any
 	}
 
 	bb, err := io.ReadAll(responses[0].Request.Body)
@@ -1169,7 +1169,7 @@ func Test_apiRun_paginationGraphQL_slurp(t *testing.T) {
 	assert.Equal(t, "", stderr.String(), "stderr")
 
 	var requestData struct {
-		Variables map[string]interface{}
+		Variables map[string]any
 	}
 
 	bb, err := io.ReadAll(responses[0].Request.Body)
@@ -1265,7 +1265,7 @@ func Test_apiRun_paginated_template(t *testing.T) {
 	assert.Equal(t, "", stderr.String(), "stderr")
 
 	var requestData struct {
-		Variables map[string]interface{}
+		Variables map[string]any
 	}
 
 	bb, err := io.ReadAll(responses[0].Request.Body)

--- a/pkg/cmd/api/fields.go
+++ b/pkg/cmd/api/fields.go
@@ -13,8 +13,8 @@ const (
 	keySeparator = '='
 )
 
-func parseFields(opts *ApiOptions) (map[string]interface{}, error) {
-	params := make(map[string]interface{})
+func parseFields(opts *ApiOptions) (map[string]any, error) {
+	params := make(map[string]any)
 	parseField := func(f string, isMagic bool) error {
 		var valueIndex int
 		var keystack []string
@@ -43,7 +43,7 @@ func parseFields(opts *ApiOptions) (map[string]interface{}, error) {
 		}
 
 		key := f
-		var value interface{} = nil
+		var value any = nil
 		if valueIndex == 0 {
 			if keystack[len(keystack)-1] != "" {
 				return fmt.Errorf("field %q requires a value separated by an '=' sign", key)
@@ -86,16 +86,16 @@ func parseFields(opts *ApiOptions) (map[string]interface{}, error) {
 
 		if isArray {
 			if value == nil {
-				destMap[subkey] = []interface{}{}
+				destMap[subkey] = []any{}
 			} else {
 				if v, exists := destMap[subkey]; exists {
-					if existSlice, ok := v.([]interface{}); ok {
+					if existSlice, ok := v.([]any); ok {
 						destMap[subkey] = append(existSlice, value)
 					} else {
 						return fmt.Errorf("expected array type under %q, got %T", subkey, v)
 					}
 				} else {
-					destMap[subkey] = []interface{}{value}
+					destMap[subkey] = []any{value}
 				}
 			}
 		} else {
@@ -119,25 +119,25 @@ func parseFields(opts *ApiOptions) (map[string]interface{}, error) {
 	return params, nil
 }
 
-func addParamsMap(m map[string]interface{}, key string) (map[string]interface{}, error) {
+func addParamsMap(m map[string]any, key string) (map[string]any, error) {
 	if v, exists := m[key]; exists {
-		if existMap, ok := v.(map[string]interface{}); ok {
+		if existMap, ok := v.(map[string]any); ok {
 			return existMap, nil
 		} else {
 			return nil, fmt.Errorf("expected map type under %q, got %T", key, v)
 		}
 	}
-	newMap := make(map[string]interface{})
+	newMap := make(map[string]any)
 	m[key] = newMap
 	return newMap, nil
 }
 
-func addParamsSlice(m map[string]interface{}, prevkey, newkey string) (map[string]interface{}, error) {
+func addParamsSlice(m map[string]any, prevkey, newkey string) (map[string]any, error) {
 	if v, exists := m[prevkey]; exists {
-		if existSlice, ok := v.([]interface{}); ok {
+		if existSlice, ok := v.([]any); ok {
 			if len(existSlice) > 0 {
 				lastItem := existSlice[len(existSlice)-1]
-				if lastMap, ok := lastItem.(map[string]interface{}); ok {
+				if lastMap, ok := lastItem.(map[string]any); ok {
 					if _, keyExists := lastMap[newkey]; !keyExists {
 						return lastMap, nil
 					} else if reflect.TypeOf(lastMap[newkey]).Kind() == reflect.Slice {
@@ -145,19 +145,19 @@ func addParamsSlice(m map[string]interface{}, prevkey, newkey string) (map[strin
 					}
 				}
 			}
-			newMap := make(map[string]interface{})
+			newMap := make(map[string]any)
 			m[prevkey] = append(existSlice, newMap)
 			return newMap, nil
 		} else {
 			return nil, fmt.Errorf("expected array type under %q, got %T", prevkey, v)
 		}
 	}
-	newMap := make(map[string]interface{})
-	m[prevkey] = []interface{}{newMap}
+	newMap := make(map[string]any)
+	m[prevkey] = []any{newMap}
 	return newMap, nil
 }
 
-func magicFieldValue(v string, opts *ApiOptions) (interface{}, error) {
+func magicFieldValue(v string, opts *ApiOptions) (any, error) {
 	if strings.HasPrefix(v, "@") {
 		b, err := opts.IO.ReadUserFile(v[1:])
 		if err != nil {

--- a/pkg/cmd/api/fields_test.go
+++ b/pkg/cmd/api/fields_test.go
@@ -38,7 +38,7 @@ func Test_parseFields(t *testing.T) {
 		t.Fatalf("parseFields error: %v", err)
 	}
 
-	expect := map[string]interface{}{
+	expect := map[string]any{
 		"robot":     "Hubot",
 		"destroyer": "false",
 		"helper":    "true",
@@ -239,7 +239,7 @@ func Test_magicFieldValue(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{

--- a/pkg/cmd/api/http.go
+++ b/pkg/cmd/api/http.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghinstance"
 )
 
-func httpRequest(client *http.Client, hostname string, method string, p string, params interface{}, headers []string) (*http.Response, error) {
+func httpRequest(client *http.Client, hostname string, method string, p string, params any, headers []string) (*http.Response, error) {
 	isGraphQL := p == "graphql"
 	var requestURL string
 	if strings.Contains(p, "://") {
@@ -30,7 +30,7 @@ func httpRequest(client *http.Client, hostname string, method string, p string, 
 	var bodyIsJSON bool
 
 	switch pp := params.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		if strings.EqualFold(method, "GET") {
 			requestURL = addQuery(requestURL, pp)
 		} else {
@@ -83,9 +83,9 @@ func httpRequest(client *http.Client, hostname string, method string, p string, 
 	return client.Do(req)
 }
 
-func groupGraphQLVariables(params map[string]interface{}) map[string]interface{} {
-	topLevel := make(map[string]interface{})
-	variables := make(map[string]interface{})
+func groupGraphQLVariables(params map[string]any) map[string]any {
+	topLevel := make(map[string]any)
+	variables := make(map[string]any)
 
 	for key, val := range params {
 		switch key {
@@ -102,7 +102,7 @@ func groupGraphQLVariables(params map[string]interface{}) map[string]interface{}
 	return topLevel
 }
 
-func addQuery(path string, params map[string]interface{}) string {
+func addQuery(path string, params map[string]any) string {
 	if len(params) == 0 {
 		return path
 	}
@@ -119,7 +119,7 @@ func addQuery(path string, params map[string]interface{}) string {
 	return path + sep + query.Encode()
 }
 
-func addQueryParam(query url.Values, key string, value interface{}) error {
+func addQueryParam(query url.Values, key string, value any) error {
 	switch v := value.(type) {
 	case string:
 		query.Add(key, v)
@@ -131,14 +131,14 @@ func addQueryParam(query url.Values, key string, value interface{}) error {
 		query.Add(key, fmt.Sprintf("%d", v))
 	case bool:
 		query.Add(key, fmt.Sprintf("%v", v))
-	case map[string]interface{}:
+	case map[string]any:
 		for subkey, value := range v {
 			// support for nested subkeys can be added here if that is ever necessary
 			if err := addQueryParam(query, subkey, value); err != nil {
 				return err
 			}
 		}
-	case []interface{}:
+	case []any:
 		for _, entry := range v {
 			if err := addQueryParam(query, key+"[]", entry); err != nil {
 				return err

--- a/pkg/cmd/api/http_test.go
+++ b/pkg/cmd/api/http_test.go
@@ -12,44 +12,44 @@ import (
 func Test_groupGraphQLVariables(t *testing.T) {
 	tests := []struct {
 		name string
-		args map[string]interface{}
-		want map[string]interface{}
+		args map[string]any
+		want map[string]any
 	}{
 		{
 			name: "empty",
-			args: map[string]interface{}{},
-			want: map[string]interface{}{},
+			args: map[string]any{},
+			want: map[string]any{},
 		},
 		{
 			name: "query only",
-			args: map[string]interface{}{
+			args: map[string]any{
 				"query": "QUERY",
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"query": "QUERY",
 			},
 		},
 		{
 			name: "variables only",
-			args: map[string]interface{}{
+			args: map[string]any{
 				"name": "hubot",
 			},
-			want: map[string]interface{}{
-				"variables": map[string]interface{}{
+			want: map[string]any{
+				"variables": map[string]any{
 					"name": "hubot",
 				},
 			},
 		},
 		{
 			name: "query + variables",
-			args: map[string]interface{}{
+			args: map[string]any{
 				"query": "QUERY",
 				"name":  "hubot",
 				"power": 9001,
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"query": "QUERY",
-				"variables": map[string]interface{}{
+				"variables": map[string]any{
 					"name":  "hubot",
 					"power": 9001,
 				},
@@ -57,15 +57,15 @@ func Test_groupGraphQLVariables(t *testing.T) {
 		},
 		{
 			name: "query + operationName + variables",
-			args: map[string]interface{}{
+			args: map[string]any{
 				"query":         "query Q1{} query Q2{}",
 				"operationName": "Q1",
 				"power":         9001,
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"query":         "query Q1{} query Q2{}",
 				"operationName": "Q1",
-				"variables": map[string]interface{}{
+				"variables": map[string]any{
 					"power": 9001,
 				},
 			},
@@ -96,7 +96,7 @@ func Test_httpRequest(t *testing.T) {
 		host    string
 		method  string
 		p       string
-		params  interface{}
+		params  any
 		headers []string
 	}
 	type expects struct {
@@ -208,7 +208,7 @@ func Test_httpRequest(t *testing.T) {
 				host:   "github.com",
 				method: "GET",
 				p:      "repos/octocat/spoon-knife",
-				params: map[string]interface{}{
+				params: map[string]any{
 					"a": "b",
 				},
 				headers: []string{},
@@ -228,7 +228,7 @@ func Test_httpRequest(t *testing.T) {
 				host:   "github.com",
 				method: "POST",
 				p:      "repos",
-				params: map[string]interface{}{
+				params: map[string]any{
 					"a": "b",
 				},
 				headers: []string{},
@@ -248,7 +248,7 @@ func Test_httpRequest(t *testing.T) {
 				host:   "github.com",
 				method: "POST",
 				p:      "graphql",
-				params: map[string]interface{}{
+				params: map[string]any{
 					"a": "b",
 				},
 				headers: []string{},
@@ -268,7 +268,7 @@ func Test_httpRequest(t *testing.T) {
 				host:    "example.org",
 				method:  "POST",
 				p:       "graphql",
-				params:  map[string]interface{}{},
+				params:  map[string]any{},
 				headers: []string{},
 			},
 			wantErr: false,
@@ -343,7 +343,7 @@ func Test_httpRequest(t *testing.T) {
 func Test_addQuery(t *testing.T) {
 	type args struct {
 		path   string
-		params map[string]interface{}
+		params map[string]any
 	}
 	tests := []struct {
 		name string
@@ -354,7 +354,7 @@ func Test_addQuery(t *testing.T) {
 			name: "string",
 			args: args{
 				path:   "",
-				params: map[string]interface{}{"a": "hello"},
+				params: map[string]any{"a": "hello"},
 			},
 			want: "?a=hello",
 		},
@@ -362,7 +362,7 @@ func Test_addQuery(t *testing.T) {
 			name: "array",
 			args: args{
 				path:   "",
-				params: map[string]interface{}{"a": []interface{}{"hello", "world"}},
+				params: map[string]any{"a": []any{"hello", "world"}},
 			},
 			want: "?a%5B%5D=hello&a%5B%5D=world",
 		},
@@ -370,7 +370,7 @@ func Test_addQuery(t *testing.T) {
 			name: "append",
 			args: args{
 				path:   "path",
-				params: map[string]interface{}{"a": "b"},
+				params: map[string]any{"a": "b"},
 			},
 			want: "path?a=b",
 		},
@@ -378,7 +378,7 @@ func Test_addQuery(t *testing.T) {
 			name: "append query",
 			args: args{
 				path:   "path?foo=bar",
-				params: map[string]interface{}{"a": "b"},
+				params: map[string]any{"a": "b"},
 			},
 			want: "path?foo=bar&a=b",
 		},
@@ -386,7 +386,7 @@ func Test_addQuery(t *testing.T) {
 			name: "[]byte",
 			args: args{
 				path:   "",
-				params: map[string]interface{}{"a": []byte("hello")},
+				params: map[string]any{"a": []byte("hello")},
 			},
 			want: "?a=hello",
 		},
@@ -394,7 +394,7 @@ func Test_addQuery(t *testing.T) {
 			name: "int",
 			args: args{
 				path:   "",
-				params: map[string]interface{}{"a": 123},
+				params: map[string]any{"a": 123},
 			},
 			want: "?a=123",
 		},
@@ -402,7 +402,7 @@ func Test_addQuery(t *testing.T) {
 			name: "nil",
 			args: args{
 				path:   "",
-				params: map[string]interface{}{"a": nil},
+				params: map[string]any{"a": nil},
 			},
 			want: "?a=",
 		},
@@ -410,7 +410,7 @@ func Test_addQuery(t *testing.T) {
 			name: "bool",
 			args: args{
 				path:   "",
-				params: map[string]interface{}{"a": true, "b": false},
+				params: map[string]any{"a": true, "b": false},
 			},
 			want: "?a=true&b=false",
 		},

--- a/pkg/cmd/api/pagination.go
+++ b/pkg/cmd/api/pagination.go
@@ -91,7 +91,7 @@ loop:
 	return ""
 }
 
-func addPerPage(p string, perPage int, params map[string]interface{}) string {
+func addPerPage(p string, perPage int, params map[string]any) string {
 	if _, hasPerPage := params["per_page"]; hasPerPage {
 		return p
 	}

--- a/pkg/cmd/api/pagination_test.go
+++ b/pkg/cmd/api/pagination_test.go
@@ -124,7 +124,7 @@ func Test_addPerPage(t *testing.T) {
 	type args struct {
 		p       string
 		perPage int
-		params  map[string]interface{}
+		params  map[string]any
 	}
 	tests := []struct {
 		name string
@@ -145,7 +145,7 @@ func Test_addPerPage(t *testing.T) {
 			args: args{
 				p:       "items",
 				perPage: 13,
-				params: map[string]interface{}{
+				params: map[string]any{
 					"state":    "open",
 					"per_page": 99,
 				},

--- a/pkg/cmd/attestation/api/client.go
+++ b/pkg/cmd/attestation/api/client.go
@@ -126,10 +126,7 @@ func (c *LiveClient) buildRequestURL(params FetchParams) (safeurl.SafeURL, error
 		}
 	}
 
-	perPage := params.Limit
-	if perPage > maxLimitForFetch {
-		perPage = maxLimitForFetch
-	}
+	perPage := min(params.Limit, maxLimitForFetch)
 
 	// ref: https://github.com/cli/go-gh/blob/d32c104a9a25c9de3d7c7b07a43ae0091441c858/example_gh_test.go#L96
 	u.SetQuery("per_page", strconv.Itoa(perPage))

--- a/pkg/cmd/attestation/api/client.go
+++ b/pkg/cmd/attestation/api/client.go
@@ -54,8 +54,8 @@ func (p *FetchParams) Validate() error {
 
 // githubApiClient makes REST calls to the GitHub API
 type githubApiClient interface {
-	REST(hostname, method, p string, body io.Reader, data interface{}) error
-	RESTWithNext(hostname, method, p string, body io.Reader, data interface{}) (string, error)
+	REST(hostname, method, p string, body io.Reader, data any) error
+	RESTWithNext(hostname, method, p string, body io.Reader, data any) (string, error)
 }
 
 // httpClient makes HTTP calls to all non-GitHub API endpoints

--- a/pkg/cmd/attestation/api/mock_githubApiClient_test.go
+++ b/pkg/cmd/attestation/api/mock_githubApiClient_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 type mockAPIClient struct {
-	OnRESTWithNext func(hostname, method, p string, body io.Reader, data interface{}) (string, error)
-	OnREST         func(hostname, method, p string, body io.Reader, data interface{}) error
+	OnRESTWithNext func(hostname, method, p string, body io.Reader, data any) (string, error)
+	OnREST         func(hostname, method, p string, body io.Reader, data any) error
 }
 
-func (m mockAPIClient) RESTWithNext(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m mockAPIClient) RESTWithNext(hostname, method, p string, body io.Reader, data any) (string, error) {
 	return m.OnRESTWithNext(hostname, method, p, body, data)
 }
 
-func (m mockAPIClient) REST(hostname, method, p string, body io.Reader, data interface{}) error {
+func (m mockAPIClient) REST(hostname, method, p string, body io.Reader, data any) error {
 	return m.OnREST(hostname, method, p, body, data)
 }
 
@@ -31,11 +31,11 @@ type mockDataGenerator struct {
 	NumGitHubAttestations int
 }
 
-func (m *mockDataGenerator) OnRESTSuccess(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m *mockDataGenerator) OnRESTSuccess(hostname, method, p string, body io.Reader, data any) (string, error) {
 	return m.OnRESTWithNextSuccessHelper(hostname, method, p, body, data, false)
 }
 
-func (m *mockDataGenerator) OnRESTSuccessWithNextPage(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m *mockDataGenerator) OnRESTSuccessWithNextPage(hostname, method, p string, body io.Reader, data any) (string, error) {
 	// if path doesn't contain after, it means first time hitting the mock server
 	// so return the first page and return the link header in the response
 	if !strings.Contains(p, "after") {
@@ -48,12 +48,12 @@ func (m *mockDataGenerator) OnRESTSuccessWithNextPage(hostname, method, p string
 
 // Returns a func that just calls OnRESTSuccessWithNextPage but half the time
 // it returns a 500 error.
-func (m *mockDataGenerator) FlakyOnRESTSuccessWithNextPageHandler() func(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m *mockDataGenerator) FlakyOnRESTSuccessWithNextPageHandler() func(hostname, method, p string, body io.Reader, data any) (string, error) {
 	// set up the flake counter
 	m.On("FlakyOnRESTSuccessWithNextPage:error").Return()
 
 	count := 0
-	return func(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+	return func(hostname, method, p string, body io.Reader, data any) (string, error) {
 		if count%2 == 0 {
 			m.MethodCalled("FlakyOnRESTSuccessWithNextPage:error")
 
@@ -67,16 +67,16 @@ func (m *mockDataGenerator) FlakyOnRESTSuccessWithNextPageHandler() func(hostnam
 }
 
 // always returns a 500
-func (m *mockDataGenerator) OnREST500ErrorHandler() func(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m *mockDataGenerator) OnREST500ErrorHandler() func(hostname, method, p string, body io.Reader, data any) (string, error) {
 	m.On("OnREST500Error").Return()
-	return func(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+	return func(hostname, method, p string, body io.Reader, data any) (string, error) {
 		m.MethodCalled("OnREST500Error")
 
 		return "", cliAPI.HTTPError{HTTPError: &ghAPI.HTTPError{StatusCode: 500}}
 	}
 }
 
-func (m *mockDataGenerator) OnRESTWithNextSuccessHelper(hostname, method, p string, body io.Reader, data interface{}, hasNext bool) (string, error) {
+func (m *mockDataGenerator) OnRESTWithNextSuccessHelper(hostname, method, p string, body io.Reader, data any, hasNext bool) (string, error) {
 	atts := make([]*Attestation, m.NumUserAttestations+m.NumGitHubAttestations)
 	for j := 0; j < m.NumUserAttestations; j++ {
 		att := makeTestAttestation()
@@ -109,7 +109,7 @@ func (m *mockDataGenerator) OnRESTWithNextSuccessHelper(hostname, method, p stri
 	return "", nil
 }
 
-func (m *mockDataGenerator) OnRESTWithNextNoAttestations(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m *mockDataGenerator) OnRESTWithNextNoAttestations(hostname, method, p string, body io.Reader, data any) (string, error) {
 	resp := AttestationsResponse{
 		Attestations: make([]*Attestation, 0),
 	}
@@ -128,7 +128,7 @@ func (m *mockDataGenerator) OnRESTWithNextNoAttestations(hostname, method, p str
 	return "", nil
 }
 
-func (m *mockDataGenerator) OnRESTWithNextError(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m *mockDataGenerator) OnRESTWithNextError(hostname, method, p string, body io.Reader, data any) (string, error) {
 	return "", errors.New("failed to get attestations")
 }
 
@@ -136,7 +136,7 @@ type mockMetaGenerator struct {
 	TrustDomain string
 }
 
-func (m mockMetaGenerator) OnREST(hostname, method, p string, body io.Reader, data interface{}) error {
+func (m mockMetaGenerator) OnREST(hostname, method, p string, body io.Reader, data any) error {
 	var template = `
 {
   "domains": {
@@ -151,6 +151,6 @@ func (m mockMetaGenerator) OnREST(hostname, method, p string, body io.Reader, da
 
 }
 
-func (m mockMetaGenerator) OnRESTError(hostname, method, p string, body io.Reader, data interface{}) error {
+func (m mockMetaGenerator) OnRESTError(hostname, method, p string, body io.Reader, data any) error {
 	return errors.New("test error")
 }

--- a/pkg/cmd/attestation/io/handler.go
+++ b/pkg/cmd/attestation/io/handler.go
@@ -30,26 +30,26 @@ func NewTestHandler() *Handler {
 }
 
 // Printf writes the formatted arguments to the stderr writer.
-func (h *Handler) Printf(f string, v ...interface{}) (int, error) {
+func (h *Handler) Printf(f string, v ...any) (int, error) {
 	if !h.IO.IsStdoutTTY() {
 		return 0, nil
 	}
 	return fmt.Fprintf(h.IO.ErrOut, f, v...)
 }
 
-func (h *Handler) OutPrintf(f string, v ...interface{}) (int, error) {
+func (h *Handler) OutPrintf(f string, v ...any) (int, error) {
 	return fmt.Fprintf(h.IO.Out, f, v...)
 }
 
 // Println writes the arguments to the stderr writer with a newline at the end.
-func (h *Handler) Println(v ...interface{}) (int, error) {
+func (h *Handler) Println(v ...any) (int, error) {
 	if !h.IO.IsStdoutTTY() {
 		return 0, nil
 	}
 	return fmt.Fprintln(h.IO.ErrOut, v...)
 }
 
-func (h *Handler) OutPrintln(v ...interface{}) (int, error) {
+func (h *Handler) OutPrintln(v ...any) (int, error) {
 	return fmt.Fprintln(h.IO.Out, v...)
 }
 
@@ -61,7 +61,7 @@ func (h *Handler) VerbosePrint(msg string) (int, error) {
 	return fmt.Fprintln(h.IO.ErrOut, msg)
 }
 
-func (h *Handler) VerbosePrintf(f string, v ...interface{}) (int, error) {
+func (h *Handler) VerbosePrintf(f string, v ...any) (int, error) {
 	if !h.debugEnabled || !h.IO.IsStdoutTTY() {
 		return 0, nil
 	}

--- a/pkg/cmd/attestation/io/handler.go
+++ b/pkg/cmd/attestation/io/handler.go
@@ -79,10 +79,10 @@ func (h *Handler) PrintBulletPoints(rows [][]string) (int, error) {
 		}
 	}
 
-	info := ""
+	var info strings.Builder
 	for _, row := range rows {
 		dots := strings.Repeat(".", maxColLen-len(row[0]))
-		info += fmt.Sprintf("%s:%s %s\n", row[0], dots, row[1])
+		info.WriteString(fmt.Sprintf("%s:%s %s\n", row[0], dots, row[1]))
 	}
-	return fmt.Fprintln(h.IO.ErrOut, info)
+	return fmt.Fprintln(h.IO.ErrOut, info.String())
 }

--- a/pkg/cmd/attestation/verification/policy.go
+++ b/pkg/cmd/attestation/verification/policy.go
@@ -90,13 +90,13 @@ func (c EnforcementCriteria) BuildPolicyInformation() string {
 		}
 	}
 
-	policyInfo := ""
+	var policyInfo strings.Builder
 	for _, attr := range policyAttr {
 		dots := strings.Repeat(".", maxColLen-len(attr[0]))
-		policyInfo += fmt.Sprintf("%s:%s %s\n", attr[0], dots, attr[1])
+		policyInfo.WriteString(fmt.Sprintf("%s:%s %s\n", attr[0], dots, attr[1]))
 	}
 
-	return policyInfo
+	return policyInfo.String()
 }
 
 func appendStr(arr [][]string, a, b string) [][]string {

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -3,6 +3,7 @@ package refresh
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -154,11 +155,8 @@ func refreshRun(opts *RefreshOptions) error {
 		}
 	} else {
 		var found bool
-		for _, c := range candidates {
-			if c == hostname {
-				found = true
-				break
-			}
+		if slices.Contains(candidates, hostname) {
+			found = true
 		}
 
 		if !found {

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -175,7 +175,7 @@ func refreshRun(opts *RefreshOptions) error {
 	if !opts.ResetScopes {
 		if oldToken, _ := authCfg.ActiveToken(hostname); oldToken != "" {
 			if oldScopes, err := shared.GetScopes(plainHTTPClient, hostname, oldToken); err == nil {
-				for _, s := range strings.Split(oldScopes, ",") {
+				for s := range strings.SplitSeq(oldScopes, ",") {
 					s = strings.TrimSpace(s)
 					if s != "" {
 						additionalScopes.Add(s)

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -252,7 +252,7 @@ func sshKeyUpload(httpClient *http.Client, hostname, keyFile string, title strin
 
 func GetCurrentLogin(httpClient httpClient, hostname, authToken string) (string, error) {
 	query := `query UserCurrent{viewer{login}}`
-	reqBody, err := json.Marshal(map[string]interface{}{"query": query})
+	reqBody, err := json.Marshal(map[string]any{"query": query})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/auth/shared/oauth_scopes.go
+++ b/pkg/cmd/auth/shared/oauth_scopes.go
@@ -90,7 +90,7 @@ func HeaderHasMinimumScopes(scopesHeader string) error {
 		"read:org":  false,
 		"admin:org": false,
 	}
-	for _, s := range strings.Split(scopesHeader, ",") {
+	for s := range strings.SplitSeq(scopesHeader, ",") {
 		search[strings.TrimSpace(s)] = true
 	}
 

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -53,7 +53,7 @@ var authStatusFields = []string{
 	"hosts",
 }
 
-func (a authStatus) ExportData(fields []string) map[string]interface{} {
+func (a authStatus) ExportData(fields []string) map[string]any {
 	return cmdutil.StructExportData(a, fields)
 }
 

--- a/pkg/cmd/cache/list/list_test.go
+++ b/pkg/cmd/cache/list/list_test.go
@@ -358,7 +358,7 @@ func (e *verboseExporter) Fields() []string {
 }
 
 func (e *verboseExporter) Write(io *iostreams.IOStreams, data any) error {
-	_, err := io.Out.Write([]byte(fmt.Sprintf("%+v", data)))
+	_, err := io.Out.Write(fmt.Appendf(nil, "%+v", data))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/cache/list/list_test.go
+++ b/pkg/cmd/cache/list/list_test.go
@@ -357,7 +357,7 @@ func (e *verboseExporter) Fields() []string {
 	return nil
 }
 
-func (e *verboseExporter) Write(io *iostreams.IOStreams, data interface{}) error {
+func (e *verboseExporter) Write(io *iostreams.IOStreams, data any) error {
 	_, err := io.Out.Write([]byte(fmt.Sprintf("%+v", data)))
 	if err != nil {
 		return err

--- a/pkg/cmd/cache/shared/shared.go
+++ b/pkg/cmd/cache/shared/shared.go
@@ -96,6 +96,6 @@ pagination:
 	return result, nil
 }
 
-func (c *Cache) ExportData(fields []string) map[string]interface{} {
+func (c *Cache) ExportData(fields []string) map[string]any {
 	return cmdutil.StructExportData(c, fields)
 }

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -148,14 +148,14 @@ func safeClose(closer io.Closer, err *error) {
 var hasTTY = term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
 
 type SurveyPrompter interface {
-	Ask(qs []*survey.Question, response interface{}) error
+	Ask(qs []*survey.Question, response any) error
 }
 
 type Prompter struct{}
 
 // ask asks survey questions on the terminal, using standard options.
 // It fails unless hasTTY, but ideally callers should avoid calling it in that case.
-func (p *Prompter) Ask(qs []*survey.Question, response interface{}) error {
+func (p *Prompter) Ask(qs []*survey.Question, response any) error {
 	if !hasTTY {
 		return fmt.Errorf("no terminal")
 	}

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -605,10 +606,5 @@ func buildDisplayName(displayName string, prebuildAvailability string) string {
 }
 
 func stringInSlice(a string, slice []string) bool {
-	for _, b := range slice {
-		if b == a {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, a)
 }

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -532,7 +532,7 @@ func getMachineName(ctx context.Context, apiClient apiClient, prompter SurveyPro
 		}
 
 		availableMachines := make([]string, len(machines))
-		for i := 0; i < len(machines); i++ {
+		for i := range machines {
 			availableMachines[i] = machines[i].Name
 		}
 

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -710,10 +710,10 @@ func TestBuildDisplayName(t *testing.T) {
 }
 
 type MockSurveyPrompter struct {
-	AskFunc func(qs []*survey.Question, response interface{}) error
+	AskFunc func(qs []*survey.Question, response any) error
 }
 
-func (m *MockSurveyPrompter) Ask(qs []*survey.Question, response interface{}) error {
+func (m *MockSurveyPrompter) Ask(qs []*survey.Question, response any) error {
 	return m.AskFunc(qs, response)
 }
 
@@ -815,7 +815,7 @@ func TestHandleAdditionalPermissions(t *testing.T) {
 
 			params := &api.CreateCodespaceParams{}
 			_, err := a.handleAdditionalPermissions(context.Background(), &MockSurveyPrompter{
-				AskFunc: func(qs []*survey.Question, response interface{}) error {
+				AskFunc: func(qs []*survey.Question, response any) error {
 					*response.(*struct{ Accept string }) = struct{ Accept string }{Accept: tt.accept}
 					return nil
 				},

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -865,8 +865,3 @@ func apiCreateDefaults(c *apiClientMock) *apiClientMock {
 	}
 	return c
 }
-
-//go:fix inline
-func durationPtr(d time.Duration) *time.Duration {
-	return new(d)
-}

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -866,6 +866,7 @@ func apiCreateDefaults(c *apiClientMock) *apiClientMock {
 	return c
 }
 
+//go:fix inline
 func durationPtr(d time.Duration) *time.Duration {
-	return &d
+	return new(d)
 }

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -104,7 +104,7 @@ func TestApp_Create(t *testing.T) {
 				machine:         "GIGA",
 				showStatus:      false,
 				idleTimeout:     30 * time.Minute,
-				retentionPeriod: NullableDuration{durationPtr(48 * time.Hour)},
+				retentionPeriod: NullableDuration{new(48 * time.Hour)},
 			},
 			wantStdout: "monalisa-dotfiles-abcd1234\n",
 			wantStderr: "  ✓ Codespaces usage for this repository is paid for by monalisa\n",

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -338,8 +338,8 @@ func TestDelete(t *testing.T) {
 
 func sortLines(s string) string {
 	trailing := ""
-	if strings.HasSuffix(s, "\n") {
-		s = strings.TrimSuffix(s, "\n")
+	if before, ok := strings.CutSuffix(s, "\n"); ok {
+		s = before
 		trailing = "\n"
 	}
 	lines := strings.Split(s, "\n")

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -151,8 +151,8 @@ var portFields = []string{
 	"browseUrl",
 }
 
-func (pi *portInfo) ExportData(fields []string) map[string]interface{} {
-	data := map[string]interface{}{}
+func (pi *portInfo) ExportData(fields []string) map[string]any {
+	data := map[string]any{}
 
 	for _, f := range fields {
 		switch f {

--- a/pkg/cmd/codespace/ports_test.go
+++ b/pkg/cmd/codespace/ports_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestListPorts(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	mockApi := GetMockApi(false)
 	ios, _, _, _ := iostreams.Test()

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -767,7 +767,7 @@ func (a *App) Copy(ctx context.Context, args []string, opts cpOptions) error {
 
 	hasRemote := false
 	for _, arg := range args {
-		if rest := strings.TrimPrefix(arg, "remote:"); rest != arg {
+		if rest, ok := strings.CutPrefix(arg, "remote:"); ok {
 			hasRemote = true
 			// scp treats each filename argument as a shell expression,
 			// subjecting it to expansion of environment variables, braces,

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -498,8 +498,8 @@ func firstConfiguredKeyPair(
 		return nil, fmt.Errorf("could not load ssh configuration: %w", err)
 	}
 
-	configLines := strings.Split(string(configBytes), "\n")
-	for _, line := range configLines {
+	configLines := strings.SplitSeq(string(configBytes), "\n")
+	for line := range configLines {
 		line = strings.TrimSpace(line)
 
 		if strings.HasPrefix(line, "identityfile ") {

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -213,13 +213,14 @@ func TestSelectSSHKeys(t *testing.T) {
 		configPath := filepath.Join(sshDir, "test-config")
 
 		// Seed the config with a non-existent key so that the default config won't apply
-		configContent := "IdentityFile dummy\n"
+		var configContent strings.Builder
+		configContent.WriteString("IdentityFile dummy\n")
 
 		for _, key := range tt.sshConfigKeys {
-			configContent += fmt.Sprintf("IdentityFile %s\n", filepath.Join(sshDir, key))
+			configContent.WriteString(fmt.Sprintf("IdentityFile %s\n", filepath.Join(sshDir, key)))
 		}
 
-		err := os.WriteFile(configPath, []byte(configContent), 0666)
+		err := os.WriteFile(configPath, []byte(configContent.String()), 0666)
 		if err != nil {
 			t.Fatalf("could not write test config %v", err)
 		}

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -108,13 +109,7 @@ func TestGenerateAutomaticSSHKeys(t *testing.T) {
 		}
 		for _, file := range allExistingFiles {
 			filename := file.Name()
-			isWantedFile := false
-			for _, wantedFile := range tt.wantFinalFiles {
-				if filename == wantedFile {
-					isWantedFile = true
-					break
-				}
-			}
+			isWantedFile := slices.Contains(tt.wantFinalFiles, filename)
 
 			if !isWantedFile {
 				t.Errorf("Unexpected file %q exists after generateAutomaticSSHKeys", filename)

--- a/pkg/cmd/config/set/set.go
+++ b/pkg/cmd/config/set/set.go
@@ -3,6 +3,7 @@ package set
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -119,10 +120,8 @@ func ValidateValue(key, value string) error {
 		return nil
 	}
 
-	for _, v := range validValues {
-		if v == value {
-			return nil
-		}
+	if slices.Contains(validValues, value) {
+		return nil
 	}
 
 	return InvalidValueError{ValidValues: validValues}

--- a/pkg/cmd/discussion/client/client.go
+++ b/pkg/cmd/discussion/client/client.go
@@ -220,7 +220,7 @@ func (c *discussionClient) List(repo ghrepo.Interface, filters ListFilters, afte
 		}
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":      githubv4.String(repo.RepoOwner()),
 		"name":       githubv4.String(repo.RepoName()),
 		"after":      (*githubv4.String)(nil),
@@ -364,7 +364,7 @@ func (c *discussionClient) Search(repo ghrepo.Interface, filters SearchFilters, 
 		searchQuery += " " + filters.Keywords
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"query": githubv4.String(searchQuery),
 		"after": (*githubv4.String)(nil),
 	}
@@ -421,7 +421,7 @@ func (c *discussionClient) GetByNumber(repo ghrepo.Interface, number int32) (*Di
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":  githubv4.String(repo.RepoOwner()),
 		"name":   githubv4.String(repo.RepoName()),
 		"number": githubv4.Int(number),
@@ -562,7 +562,7 @@ func (c *discussionClient) GetWithComments(repo ghrepo.Interface, number int32, 
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":  githubv4.String(repo.RepoOwner()),
 		"name":   githubv4.String(repo.RepoName()),
 		"number": githubv4.Int(number),
@@ -675,7 +675,7 @@ func (c *discussionClient) GetCommentReplies(host string, commentID string, limi
 		} `graphql:"node(id: $commentID)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"commentID": githubv4.ID(commentID),
 		"first":     (*githubv4.Int)(nil),
 		"last":      (*githubv4.Int)(nil),
@@ -794,7 +794,7 @@ func (c *discussionClient) ListCategories(repo ghrepo.Interface) ([]DiscussionCa
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": githubv4.String(repo.RepoOwner()),
 		"name":  githubv4.String(repo.RepoName()),
 	}
@@ -838,7 +838,7 @@ func (c *discussionClient) getRepositoryMeta(repo ghrepo.Interface) (*repository
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": githubv4.String(repo.RepoOwner()),
 		"name":  githubv4.String(repo.RepoName()),
 	}
@@ -872,7 +872,7 @@ func (c *discussionClient) ListLabels(repo ghrepo.Interface) ([]DiscussionLabel,
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"endCursor": (*githubv4.String)(nil),
@@ -917,7 +917,7 @@ func (c *discussionClient) editDiscussionLabels(repo ghrepo.Interface, discussio
 			} `graphql:"removeLabelsFromLabelable(input: $input)"`
 		}
 
-		variables := map[string]interface{}{
+		variables := map[string]any{
 			"input": githubv4.RemoveLabelsFromLabelableInput{
 				LabelableID: githubv4.ID(discussionID),
 				LabelIDs:    ids,
@@ -946,7 +946,7 @@ func (c *discussionClient) editDiscussionLabels(repo ghrepo.Interface, discussio
 			} `graphql:"addLabelsToLabelable(input: $input)"`
 		}
 
-		variables := map[string]interface{}{
+		variables := map[string]any{
 			"input": githubv4.AddLabelsToLabelableInput{
 				LabelableID: githubv4.ID(discussionID),
 				LabelIDs:    ids,
@@ -983,7 +983,7 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 		} `graphql:"createDiscussion(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.CreateDiscussionInput{
 			RepositoryID: githubv4.ID(meta.ID),
 			CategoryID:   githubv4.ID(input.CategoryID),
@@ -1059,7 +1059,7 @@ func (c *discussionClient) Update(repo ghrepo.Interface, input UpdateDiscussionI
 			} `graphql:"updateDiscussion(input: $input)"`
 		}
 
-		variables := map[string]interface{}{
+		variables := map[string]any{
 			"input": gqlInput,
 		}
 
@@ -1131,7 +1131,7 @@ func (c *discussionClient) AddComment(repo ghrepo.Interface, discussionID, body,
 		input.ReplyToID = &id
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": input,
 	}
 
@@ -1180,7 +1180,7 @@ func (c *discussionClient) UpdateComment(repo ghrepo.Interface, commentID, body 
 		} `graphql:"updateDiscussionComment(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.UpdateDiscussionCommentInput{
 			CommentID: githubv4.ID(commentID),
 			Body:      githubv4.String(body),
@@ -1220,7 +1220,7 @@ func (c *discussionClient) DeleteComment(repo ghrepo.Interface, commentID string
 		} `graphql:"deleteDiscussionComment(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.DeleteDiscussionCommentInput{
 			ID: githubv4.ID(commentID),
 		},
@@ -1255,7 +1255,7 @@ func (c *discussionClient) GetComment(host string, commentID string) (*Discussio
 		} `graphql:"node(id: $id)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id": githubv4.ID(commentID),
 	}
 

--- a/pkg/cmd/discussion/client/client.go
+++ b/pkg/cmd/discussion/client/client.go
@@ -1041,10 +1041,10 @@ func (c *discussionClient) Update(repo ghrepo.Interface, input UpdateDiscussionI
 			DiscussionID: githubv4.ID(input.DiscussionID),
 		}
 		if input.Title != nil {
-			gqlInput.Title = githubv4.NewString(githubv4.String(*input.Title))
+			gqlInput.Title = new(githubv4.String(*input.Title))
 		}
 		if input.Body != nil {
-			gqlInput.Body = githubv4.NewString(githubv4.String(*input.Body))
+			gqlInput.Body = new(githubv4.String(*input.Body))
 		}
 		if input.CategoryID != nil {
 			id := githubv4.ID(*input.CategoryID)

--- a/pkg/cmd/discussion/client/client_test.go
+++ b/pkg/cmd/discussion/client/client_test.go
@@ -287,7 +287,7 @@ func TestList(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionList\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Equal(t, "someCursor", vars["after"])
 					}),
 				)
@@ -301,8 +301,8 @@ func TestList(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionList\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
-						assert.Equal(t, []interface{}{"OPEN"}, vars["states"])
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
+						assert.Equal(t, []any{"OPEN"}, vars["states"])
 					}),
 				)
 			},
@@ -314,8 +314,8 @@ func TestList(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionList\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
-						assert.Equal(t, []interface{}{"CLOSED"}, vars["states"])
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
+						assert.Equal(t, []any{"CLOSED"}, vars["states"])
 					}),
 				)
 			},
@@ -327,7 +327,7 @@ func TestList(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionList\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Equal(t, true, vars["answered"])
 					}),
 				)
@@ -340,7 +340,7 @@ func TestList(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionList\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Equal(t, false, vars["answered"])
 					}),
 				)
@@ -353,7 +353,7 @@ func TestList(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionList\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Equal(t, "CAT123", vars["categoryId"])
 					}),
 				)
@@ -366,8 +366,8 @@ func TestList(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionList\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
-						orderBy, ok := vars["orderBy"].(map[string]interface{})
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
+						orderBy, ok := vars["orderBy"].(map[string]any)
 						require.True(t, ok, "orderBy should be a map")
 						assert.Equal(t, "CREATED_AT", orderBy["field"])
 						assert.Equal(t, "ASC", orderBy["direction"])
@@ -382,8 +382,8 @@ func TestList(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionList\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
-						orderBy, ok := vars["orderBy"].(map[string]interface{})
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
+						orderBy, ok := vars["orderBy"].(map[string]any)
 						require.True(t, ok, "orderBy should be a map")
 						assert.Equal(t, "UPDATED_AT", orderBy["field"])
 						assert.Equal(t, "DESC", orderBy["direction"])
@@ -456,13 +456,13 @@ func TestList(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionList\b`),
-					httpmock.GraphQLQuery(listResp(true, "pg2cursor", 101, minimalNodes(100)), func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(listResp(true, "pg2cursor", 101, minimalNodes(100)), func(_ string, vars map[string]any) {
 						assert.Equal(t, float64(100), vars["first"])
 					}),
 				)
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionList\b`),
-					httpmock.GraphQLQuery(listResp(false, "", 101, minimalNode("D101", "Discussion 101")), func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(listResp(false, "", 101, minimalNode("D101", "Discussion 101")), func(_ string, vars map[string]any) {
 						assert.Equal(t, float64(1), vars["first"])
 					}),
 				)
@@ -694,7 +694,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Equal(t, "someCursor", vars["after"])
 					}),
 				)
@@ -708,7 +708,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Contains(t, vars["query"].(string), "is:open")
 					}),
 				)
@@ -721,7 +721,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Contains(t, vars["query"].(string), "is:closed")
 					}),
 				)
@@ -734,7 +734,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Contains(t, vars["query"].(string), "is:answered")
 					}),
 				)
@@ -747,7 +747,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Contains(t, vars["query"].(string), "is:unanswered")
 					}),
 				)
@@ -760,7 +760,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Contains(t, vars["query"].(string), `author:"alice"`)
 					}),
 				)
@@ -773,7 +773,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						q := vars["query"].(string)
 						assert.Contains(t, q, `label:"bug"`)
 						assert.Contains(t, q, `label:"enhancement"`)
@@ -788,7 +788,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Contains(t, vars["query"].(string), `category:"Q&A"`)
 					}),
 				)
@@ -801,7 +801,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Contains(t, vars["query"].(string), "some keyword")
 					}),
 				)
@@ -814,7 +814,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Contains(t, vars["query"].(string), "sort:created-asc")
 					}),
 				)
@@ -827,7 +827,7 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(emptyResp, func(_ string, vars map[string]any) {
 						assert.Contains(t, vars["query"].(string), "sort:updated-desc")
 					}),
 				)
@@ -841,13 +841,13 @@ func TestSearch(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(searchResp(true, "pg2cursor", 101, minimalNodes(100)), func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(searchResp(true, "pg2cursor", 101, minimalNodes(100)), func(_ string, vars map[string]any) {
 						assert.Equal(t, float64(100), vars["first"])
 					}),
 				)
 				reg.Register(
 					httpmock.GraphQL(`query DiscussionListSearch\b`),
-					httpmock.GraphQLQuery(searchResp(false, "", 101, minimalNode("D101", "Discussion 101")), func(_ string, vars map[string]interface{}) {
+					httpmock.GraphQLQuery(searchResp(false, "", 101, minimalNode("D101", "Discussion 101")), func(_ string, vars map[string]any) {
 						assert.Equal(t, float64(1), vars["first"])
 					}),
 				)
@@ -2375,7 +2375,7 @@ func TestCreate(t *testing.T) {
 					httpmock.StringResponse(repoMetaResp("R_1", true)),
 				)
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation CreateDiscussion\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation CreateDiscussion\b`, func(input map[string]any) bool {
 						assert.Equal(t, "R_1", input["repositoryId"])
 						assert.Equal(t, "CAT_1", input["categoryId"])
 						assert.Equal(t, "New Discussion", input["title"])
@@ -2550,11 +2550,11 @@ func TestCreate(t *testing.T) {
 					`)),
 				)
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation AddLabelsToDiscussion\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation AddLabelsToDiscussion\b`, func(input map[string]any) bool {
 						assert.Equal(t, "D_new", input["labelableId"])
-						labelIDs, ok := input["labelIds"].([]interface{})
+						labelIDs, ok := input["labelIds"].([]any)
 						assert.True(t, ok)
-						assert.Equal(t, []interface{}{"L_bug", "L_enh"}, labelIDs)
+						assert.Equal(t, []any{"L_bug", "L_enh"}, labelIDs)
 						return true
 					}),
 					httpmock.StringResponse(heredoc.Doc(`
@@ -2899,18 +2899,18 @@ func TestEditDiscussionLabels(t *testing.T) {
 			removeIDs: []string{"L_old"},
 			setupMock: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation RemoveLabelsFromDiscussion\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation RemoveLabelsFromDiscussion\b`, func(input map[string]any) bool {
 						assert.Equal(t, "D_1", input["labelableId"])
-						assert.Equal(t, []interface{}{"L_old"}, input["labelIds"])
+						assert.Equal(t, []any{"L_old"}, input["labelIds"])
 						return true
 					}),
 					// This response is superseded by the subsequent add mutation so we don't need all fields.
 					httpmock.StringResponse(`{"data":{"removeLabelsFromLabelable":{"labelable":{"id": "D_1"}}}}`),
 				)
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation AddLabelsToDiscussion\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation AddLabelsToDiscussion\b`, func(input map[string]any) bool {
 						assert.Equal(t, "D_1", input["labelableId"])
-						assert.Equal(t, []interface{}{"L_bug", "L_enh"}, input["labelIds"])
+						assert.Equal(t, []any{"L_bug", "L_enh"}, input["labelIds"])
 						return true
 					}),
 					httpmock.StringResponse(heredoc.Doc(`
@@ -3429,7 +3429,7 @@ func TestAddComment(t *testing.T) {
 			body:         "Hello world",
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation AddDiscussionComment\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation AddDiscussionComment\b`, func(input map[string]any) bool {
 						assert.Equal(t, "D_123", input["discussionId"])
 						assert.Equal(t, "Hello world", input["body"])
 						assert.Nil(t, input["replyToId"])
@@ -3470,7 +3470,7 @@ func TestAddComment(t *testing.T) {
 			replyToID:    "DC_parent",
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation AddDiscussionComment\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation AddDiscussionComment\b`, func(input map[string]any) bool {
 						assert.Equal(t, "D_123", input["discussionId"])
 						assert.Equal(t, "Reply text", input["body"])
 						assert.Equal(t, "DC_parent", input["replyToId"])
@@ -3559,7 +3559,7 @@ func TestUpdateComment(t *testing.T) {
 			body:      "Updated body",
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation UpdateDiscussionComment\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation UpdateDiscussionComment\b`, func(input map[string]any) bool {
 						assert.Equal(t, "DC_1", input["commentId"])
 						assert.Equal(t, "Updated body", input["body"])
 						return true

--- a/pkg/cmd/discussion/client/types.go
+++ b/pkg/cmd/discussion/client/types.go
@@ -31,8 +31,8 @@ type Discussion struct {
 // ExportData returns a map of the requested fields for JSON output.
 // Because domain types carry no JSON struct tags, each field is mapped
 // explicitly rather than using reflection.
-func (d Discussion) ExportData(fields []string) map[string]interface{} {
-	data := map[string]interface{}{}
+func (d Discussion) ExportData(fields []string) map[string]any {
+	data := map[string]any{}
 	for _, f := range fields {
 		switch f {
 		case "id":
@@ -60,7 +60,7 @@ func (d Discussion) ExportData(fields []string) map[string]interface{} {
 		case "category":
 			data[f] = d.Category.Export()
 		case "labels":
-			labels := make([]interface{}, len(d.Labels))
+			labels := make([]any, len(d.Labels))
 			for i, l := range d.Labels {
 				labels[i] = l.Export()
 			}
@@ -80,11 +80,11 @@ func (d Discussion) ExportData(fields []string) map[string]interface{} {
 				data[f] = d.AnswerChosenBy.Export()
 			}
 		case "comments":
-			comments := make([]interface{}, len(d.Comments.Comments))
+			comments := make([]any, len(d.Comments.Comments))
 			for i, c := range d.Comments.Comments {
 				comments[i] = c.Export()
 			}
-			m := map[string]interface{}{
+			m := map[string]any{
 				"totalCount": d.Comments.TotalCount,
 				"nodes":      comments,
 			}
@@ -96,7 +96,7 @@ func (d Discussion) ExportData(fields []string) map[string]interface{} {
 			}
 			data[f] = m
 		case "reactionGroups":
-			reactions := make([]interface{}, len(d.ReactionGroups))
+			reactions := make([]any, len(d.ReactionGroups))
 			for i, rg := range d.ReactionGroups {
 				reactions[i] = rg.Export()
 			}
@@ -126,8 +126,8 @@ type DiscussionActor struct {
 }
 
 // Export returns the author as a map for JSON output.
-func (a DiscussionActor) Export() map[string]interface{} {
-	return map[string]interface{}{
+func (a DiscussionActor) Export() map[string]any {
+	return map[string]any{
 		"id":    a.ID,
 		"login": a.Login,
 		"name":  a.Name,
@@ -144,8 +144,8 @@ type DiscussionCategory struct {
 }
 
 // Export returns the category as a map for JSON output.
-func (c DiscussionCategory) Export() map[string]interface{} {
-	return map[string]interface{}{
+func (c DiscussionCategory) Export() map[string]any {
+	return map[string]any{
 		"id":           c.ID,
 		"name":         c.Name,
 		"slug":         c.Slug,
@@ -162,8 +162,8 @@ type DiscussionLabel struct {
 }
 
 // Export returns the label as a map for JSON output.
-func (l DiscussionLabel) Export() map[string]interface{} {
-	return map[string]interface{}{
+func (l DiscussionLabel) Export() map[string]any {
+	return map[string]any{
 		"id":    l.ID,
 		"name":  l.Name,
 		"color": l.Color,
@@ -185,16 +185,16 @@ type DiscussionComment struct {
 }
 
 // Export returns the comment as a map for JSON output.
-func (c DiscussionComment) Export() map[string]interface{} {
-	replies := make([]interface{}, len(c.Replies.Comments))
+func (c DiscussionComment) Export() map[string]any {
+	replies := make([]any, len(c.Replies.Comments))
 	for i, r := range c.Replies.Comments {
 		replies[i] = r.ExportReply()
 	}
-	reactions := make([]interface{}, len(c.ReactionGroups))
+	reactions := make([]any, len(c.ReactionGroups))
 	for i, rg := range c.ReactionGroups {
 		reactions[i] = rg.Export()
 	}
-	repliesMap := map[string]interface{}{
+	repliesMap := map[string]any{
 		"totalCount": c.Replies.TotalCount,
 		"nodes":      replies,
 	}
@@ -204,7 +204,7 @@ func (c DiscussionComment) Export() map[string]interface{} {
 	if c.Replies.NextCursor != "" {
 		repliesMap["next"] = c.Replies.NextCursor
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"id":             c.ID,
 		"url":            c.URL,
 		"author":         c.Author.Export(),
@@ -218,12 +218,12 @@ func (c DiscussionComment) Export() map[string]interface{} {
 }
 
 // ExportReply returns a reply as a map for JSON output, without nested replies.
-func (c DiscussionComment) ExportReply() map[string]interface{} {
-	reactions := make([]interface{}, len(c.ReactionGroups))
+func (c DiscussionComment) ExportReply() map[string]any {
+	reactions := make([]any, len(c.ReactionGroups))
 	for i, rg := range c.ReactionGroups {
 		reactions[i] = rg.Export()
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"id":             c.ID,
 		"url":            c.URL,
 		"author":         c.Author.Export(),
@@ -262,8 +262,8 @@ type ReactionGroup struct {
 }
 
 // Export returns the reaction group as a map for JSON output.
-func (rg ReactionGroup) Export() map[string]interface{} {
-	return map[string]interface{}{
+func (rg ReactionGroup) Export() map[string]any {
+	return map[string]any{
 		"content":    rg.Content,
 		"totalCount": rg.TotalCount,
 	}
@@ -298,12 +298,12 @@ type DiscussionListResult struct {
 
 // ExportData returns a map suitable for JSON output, including pagination
 // fields only when they are non-empty.
-func (r DiscussionListResult) ExportData(fields []string) map[string]interface{} {
-	discussions := make([]interface{}, len(r.Discussions))
+func (r DiscussionListResult) ExportData(fields []string) map[string]any {
+	discussions := make([]any, len(r.Discussions))
 	for i, d := range r.Discussions {
 		discussions[i] = d.ExportData(fields)
 	}
-	m := map[string]interface{}{
+	m := map[string]any{
 		"totalCount":  r.TotalCount,
 		"discussions": discussions,
 	}

--- a/pkg/cmd/extension/browse/browse.go
+++ b/pkg/cmd/extension/browse/browse.go
@@ -254,10 +254,7 @@ func (el *extList) PageDown() {
 }
 
 func (el *extList) PageUp() {
-	i := el.ui.List.GetCurrentItem() - pagingOffset
-	if i < 0 {
-		i = 0
-	}
+	i := max(el.ui.List.GetCurrentItem()-pagingOffset, 0)
 	el.ui.List.SetCurrentItem(i)
 }
 
@@ -266,10 +263,7 @@ func (el *extList) ScrollDown() {
 }
 
 func (el *extList) ScrollUp() {
-	i := el.ui.List.GetCurrentItem() - 1
-	if i < 0 {
-		i = 0
-	}
+	i := max(el.ui.List.GetCurrentItem()-1, 0)
 	el.ui.List.SetCurrentItem(i)
 }
 

--- a/pkg/cmd/extension/browse/browse_test.go
+++ b/pkg/cmd/extension/browse/browse_test.go
@@ -86,39 +86,39 @@ func Test_getExtensionRepos(t *testing.T) {
 
 	reg.Register(
 		httpmock.QueryMatcher("GET", "search/repositories", values),
-		httpmock.JSONResponse(map[string]interface{}{
+		httpmock.JSONResponse(map[string]any{
 			"incomplete_results": false,
 			"total_count":        4,
-			"items": []interface{}{
-				map[string]interface{}{
+			"items": []any{
+				map[string]any{
 					"name":        "gh-screensaver",
 					"full_name":   "vilmibm/gh-screensaver",
 					"description": "terminal animations",
-					"owner": map[string]interface{}{
+					"owner": map[string]any{
 						"login": "vilmibm",
 					},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":        "gh-cool",
 					"full_name":   "cli/gh-cool",
 					"description": "it's just cool ok",
-					"owner": map[string]interface{}{
+					"owner": map[string]any{
 						"login": "cli",
 					},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":        "gh-triage",
 					"full_name":   "samcoe/gh-triage",
 					"description": "helps with triage",
-					"owner": map[string]interface{}{
+					"owner": map[string]any{
 						"login": "samcoe",
 					},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name":        "gh-gei",
 					"full_name":   "github/gh-gei",
 					"description": "something something enterprise",
-					"owner": map[string]interface{}{
+					"owner": map[string]any{
 						"login": "github",
 					},
 				},

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -1147,47 +1147,47 @@ func Test_checkValidExtensionWithLocalExtension(t *testing.T) {
 	}
 }
 
-func searchResults(numResults int) interface{} {
-	result := map[string]interface{}{
+func searchResults(numResults int) any {
+	result := map[string]any{
 		"incomplete_results": false,
 		"total_count":        4,
-		"items": []interface{}{
-			map[string]interface{}{
+		"items": []any{
+			map[string]any{
 				"name":        "gh-screensaver",
 				"full_name":   "vilmibm/gh-screensaver",
 				"description": "terminal animations",
-				"owner": map[string]interface{}{
+				"owner": map[string]any{
 					"login": "vilmibm",
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":        "gh-cool",
 				"full_name":   "cli/gh-cool",
 				"description": "it's just cool ok",
-				"owner": map[string]interface{}{
+				"owner": map[string]any{
 					"login": "cli",
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":        "gh-triage",
 				"full_name":   "samcoe/gh-triage",
 				"description": "helps with triage",
-				"owner": map[string]interface{}{
+				"owner": map[string]any{
 					"login": "samcoe",
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"name":        "gh-gei",
 				"full_name":   "github/gh-gei",
 				"description": "something something enterprise",
-				"owner": map[string]interface{}{
+				"owner": map[string]any{
 					"login": "github",
 				},
 			},
 		},
 	}
-	if len(result["items"].([]interface{})) > numResults {
-		fewerItems := result["items"].([]interface{})[0:numResults]
+	if len(result["items"].([]any)) > numResults {
+		fewerItems := result["items"].([]any)[0:numResults]
 		result["items"] = fewerItems
 	}
 	return result

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -337,7 +337,7 @@ func TestManager_UpgradeExtensions(t *testing.T) {
 	exts, err := m.list(false)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(exts))
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		exts[i].currentVersion = "old version"
 		exts[i].latestVersion = "new version"
 	}
@@ -376,7 +376,7 @@ func TestManager_UpgradeExtensions_DryRun(t *testing.T) {
 	exts, err := m.list(false)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(exts))
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		exts[i].currentVersion = fmt.Sprintf("%d", i)
 		exts[i].latestVersion = fmt.Sprintf("%d", i+1)
 	}

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -177,7 +177,7 @@ func Test_createRun(t *testing.T) {
 		stdin          string
 		wantOut        string
 		wantStderr     string
-		wantParams     map[string]interface{}
+		wantParams     map[string]any
 		wantErr        bool
 		wantBrowse     string
 		responseStatus int
@@ -191,12 +191,12 @@ func Test_createRun(t *testing.T) {
 			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",
 			wantStderr: "- Creating gist fixture.txt\n✓ Created public gist fixture.txt\n",
 			wantErr:    false,
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"description": "",
 				"updated_at":  "0001-01-01T00:00:00Z",
 				"public":      true,
-				"files": map[string]interface{}{
-					"fixture.txt": map[string]interface{}{
+				"files": map[string]any{
+					"fixture.txt": map[string]any{
 						"content": "{}",
 					},
 				},
@@ -212,12 +212,12 @@ func Test_createRun(t *testing.T) {
 			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",
 			wantStderr: "- Creating gist fixture.txt\n✓ Created secret gist fixture.txt\n",
 			wantErr:    false,
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"description": "an incredibly interesting gist",
 				"updated_at":  "0001-01-01T00:00:00Z",
 				"public":      false,
-				"files": map[string]interface{}{
-					"fixture.txt": map[string]interface{}{
+				"files": map[string]any{
+					"fixture.txt": map[string]any{
 						"content": "{}",
 					},
 				},
@@ -233,15 +233,15 @@ func Test_createRun(t *testing.T) {
 			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",
 			wantStderr: "- Creating gist with multiple files\n✓ Created secret gist fixture.txt\n",
 			wantErr:    false,
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"description": "",
 				"updated_at":  "0001-01-01T00:00:00Z",
 				"public":      false,
-				"files": map[string]interface{}{
-					"fixture.txt": map[string]interface{}{
+				"files": map[string]any{
+					"fixture.txt": map[string]any{
 						"content": "{}",
 					},
-					"gistfile1.txt": map[string]interface{}{
+					"gistfile1.txt": map[string]any{
 						"content": "cool stdin content",
 					},
 				},
@@ -257,15 +257,15 @@ func Test_createRun(t *testing.T) {
 			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",
 			wantStderr: "- Creating gist with multiple files\n✓ Created secret gist fixture.txt\n",
 			wantErr:    false,
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"description": "",
 				"updated_at":  "0001-01-01T00:00:00Z",
 				"public":      false,
-				"files": map[string]interface{}{
-					"fixture.txt": map[string]interface{}{
+				"files": map[string]any{
+					"fixture.txt": map[string]any{
 						"content": "{}",
 					},
-					"gistfile1.txt": map[string]interface{}{
+					"gistfile1.txt": map[string]any{
 						"content": "cool stdin content",
 					},
 				},
@@ -283,12 +283,12 @@ func Test_createRun(t *testing.T) {
 				X Failed to create gist: a gist file cannot be blank
 			`),
 			wantErr: true,
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"description": "",
 				"updated_at":  "0001-01-01T00:00:00Z",
 				"public":      false,
-				"files": map[string]interface{}{
-					"empty.txt": map[string]interface{}{"content": " \t\n"},
+				"files": map[string]any{
+					"empty.txt": map[string]any{"content": " \t\n"},
 				},
 			},
 			responseStatus: http.StatusUnprocessableEntity,
@@ -302,12 +302,12 @@ func Test_createRun(t *testing.T) {
 			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",
 			wantStderr: "- Creating gist...\n✓ Created secret gist\n",
 			wantErr:    false,
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"description": "",
 				"updated_at":  "0001-01-01T00:00:00Z",
 				"public":      false,
-				"files": map[string]interface{}{
-					"gistfile0.txt": map[string]interface{}{
+				"files": map[string]any{
+					"gistfile0.txt": map[string]any{
 						"content": "cool stdin content",
 					},
 				},
@@ -324,12 +324,12 @@ func Test_createRun(t *testing.T) {
 			wantStderr: "- Creating gist fixture.txt\n✓ Created secret gist fixture.txt\n",
 			wantErr:    false,
 			wantBrowse: "https://gist.github.com/aa5a315d61ae9438b18d",
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"description": "",
 				"updated_at":  "0001-01-01T00:00:00Z",
 				"public":      false,
-				"files": map[string]interface{}{
-					"fixture.txt": map[string]interface{}{
+				"files": map[string]any{
+					"fixture.txt": map[string]any{
 						"content": "{}",
 					},
 				},
@@ -376,7 +376,7 @@ func Test_createRun(t *testing.T) {
 				t.Errorf("createRun() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			bodyBytes, _ := io.ReadAll(reg.Requests[0].Body)
-			reqBody := make(map[string]interface{})
+			reqBody := make(map[string]any)
 			err := json.Unmarshal(bodyBytes, &reqBody)
 			if err != nil {
 				t.Fatalf("error decoding JSON: %v", err)

--- a/pkg/cmd/gist/edit/edit_test.go
+++ b/pkg/cmd/gist/edit/edit_test.go
@@ -152,7 +152,7 @@ func Test_editRun(t *testing.T) {
 		isTTY                     bool
 		stdin                     string
 		wantErr                   string
-		wantLastRequestParameters map[string]interface{}
+		wantLastRequestParameters map[string]any
 	}{
 		{
 			name:    "no such gist",
@@ -182,10 +182,10 @@ func Test_editRun(t *testing.T) {
 				reg.Register(httpmock.REST("POST", "gists/1234"),
 					httpmock.StatusStringResponse(201, "{}"))
 			},
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "",
-				"files": map[string]interface{}{
-					"cicada.txt": map[string]interface{}{
+				"files": map[string]any{
+					"cicada.txt": map[string]any{
 						"content":  "new file content",
 						"filename": "cicada.txt",
 					},
@@ -227,10 +227,10 @@ func Test_editRun(t *testing.T) {
 				reg.Register(httpmock.REST("POST", "gists/1234"),
 					httpmock.StatusStringResponse(201, "{}"))
 			},
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "catbug",
-				"files": map[string]interface{}{
-					"unix.md": map[string]interface{}{
+				"files": map[string]any{
+					"unix.md": map[string]any{
 						"content":  "new file content",
 						"filename": "unix.md",
 					},
@@ -254,10 +254,10 @@ func Test_editRun(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("POST", "gists/1234"), httpmock.StatusStringResponse(201, "{}"))
 			},
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "",
-				"files": map[string]interface{}{
-					"unix.md": map[string]interface{}{
+				"files": map[string]any{
+					"unix.md": map[string]any{
 						"content":  "new file content",
 						"filename": "unix.md",
 					},
@@ -378,10 +378,10 @@ func Test_editRun(t *testing.T) {
 				reg.Register(httpmock.REST("POST", "gists/1234"),
 					httpmock.StatusStringResponse(201, "{}"))
 			},
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "my new description",
-				"files": map[string]interface{}{
-					"sample.txt": map[string]interface{}{
+				"files": map[string]any{
+					"sample.txt": map[string]any{
 						"content":  "new file content",
 						"filename": "sample.txt",
 					},
@@ -410,10 +410,10 @@ func Test_editRun(t *testing.T) {
 				reg.Register(httpmock.REST("POST", "gists/1234"),
 					httpmock.StatusStringResponse(201, "{}"))
 			},
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "",
-				"files": map[string]interface{}{
-					"from_source.txt": map[string]interface{}{
+				"files": map[string]any{
+					"from_source.txt": map[string]any{
 						"content":  "hello",
 						"filename": "from_source.txt",
 					},
@@ -443,10 +443,10 @@ func Test_editRun(t *testing.T) {
 					httpmock.StatusStringResponse(201, "{}"))
 			},
 			stdin: "data from stdin",
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "",
-				"files": map[string]interface{}{
-					"from_source.txt": map[string]interface{}{
+				"files": map[string]any{
+					"from_source.txt": map[string]any{
 						"content":  "data from stdin",
 						"filename": "from_source.txt",
 					},
@@ -498,9 +498,9 @@ func Test_editRun(t *testing.T) {
 				reg.Register(httpmock.REST("POST", "gists/1234"),
 					httpmock.StatusStringResponse(201, "{}"))
 			},
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "",
-				"files": map[string]interface{}{
+				"files": map[string]any{
 					"sample2.txt": nil,
 				},
 			},
@@ -526,10 +526,10 @@ func Test_editRun(t *testing.T) {
 				reg.Register(httpmock.REST("POST", "gists/1234"),
 					httpmock.StatusStringResponse(201, "{}"))
 			},
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "",
-				"files": map[string]interface{}{
-					"sample.txt": map[string]interface{}{
+				"files": map[string]any{
+					"sample.txt": map[string]any{
 						"content":  "hello",
 						"filename": "sample.txt",
 					},
@@ -558,10 +558,10 @@ func Test_editRun(t *testing.T) {
 					httpmock.StatusStringResponse(201, "{}"))
 			},
 			stdin: "data from stdin",
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "",
-				"files": map[string]interface{}{
-					"sample.txt": map[string]interface{}{
+				"files": map[string]any{
+					"sample.txt": map[string]any{
 						"content":  "data from stdin",
 						"filename": "sample.txt",
 					},
@@ -622,10 +622,10 @@ func Test_editRun(t *testing.T) {
 				reg.Register(httpmock.REST("POST", "gists/1234"),
 					httpmock.StatusStringResponse(201, "{}"))
 			},
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "",
-				"files": map[string]interface{}{
-					"large.txt": map[string]interface{}{
+				"files": map[string]any{
+					"large.txt": map[string]any{
 						"content":  "new file content",
 						"filename": "large.txt",
 					},
@@ -662,10 +662,10 @@ func Test_editRun(t *testing.T) {
 				reg.Register(httpmock.REST("POST", "gists/1234"),
 					httpmock.StatusStringResponse(201, "{}"))
 			},
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "",
-				"files": map[string]interface{}{
-					"large.txt": map[string]interface{}{
+				"files": map[string]any{
+					"large.txt": map[string]any{
 						"content":  "new file content",
 						"filename": "large.txt",
 					},
@@ -704,10 +704,10 @@ func Test_editRun(t *testing.T) {
 				// Explicity exclude also-truncated.txt raw URL to ensure it is not fetched since we did not select it.
 				reg.Exclude(t, httpmock.REST("GET", "user/1234/raw/also-truncated.txt"))
 			},
-			wantLastRequestParameters: map[string]interface{}{
+			wantLastRequestParameters: map[string]any{
 				"description": "",
-				"files": map[string]interface{}{
-					"large.txt": map[string]interface{}{
+				"files": map[string]any{
+					"large.txt": map[string]any{
 						"content":  "new file content",
 						"filename": "large.txt",
 					},
@@ -827,7 +827,7 @@ func Test_editRun(t *testing.T) {
 				// has the desired parameters.
 				lastRequest := reg.Requests[len(reg.Requests)-1]
 				bodyBytes, _ := io.ReadAll(lastRequest.Body)
-				reqBody := make(map[string]interface{})
+				reqBody := make(map[string]any)
 				err = json.Unmarshal(bodyBytes, &reqBody)
 				if err != nil {
 					t.Fatalf("error decoding JSON: %v", err)

--- a/pkg/cmd/gist/rename/rename_test.go
+++ b/pkg/cmd/gist/rename/rename_test.go
@@ -96,7 +96,7 @@ func TestRenameRun(t *testing.T) {
 		nontty     bool
 		stdin      string
 		wantOut    string
-		wantParams map[string]interface{}
+		wantParams map[string]any
 	}{
 		{
 			name:    "no such gist",
@@ -123,9 +123,9 @@ func TestRenameRun(t *testing.T) {
 				reg.Register(httpmock.REST("POST", "gists/1234"),
 					httpmock.StatusStringResponse(201, "{}"))
 			},
-			wantParams: map[string]interface{}{
-				"files": map[string]interface{}{
-					"new.txt": map[string]interface{}{
+			wantParams: map[string]any{
+				"files": map[string]any{
+					"new.txt": map[string]any{
 						"filename": "new.txt",
 						"type":     "text/plain",
 					},

--- a/pkg/cmd/gist/shared/shared.go
+++ b/pkg/cmd/gist/shared/shared.go
@@ -127,7 +127,7 @@ func ListGists(client *http.Client, hostname string, limit int, filter *regexp.R
 		perPage = maxPerPage
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"per_page":       githubv4.Int(perPage),
 		"endCursor":      (*githubv4.String)(nil),
 		"visibility":     githubv4.GistPrivacy(strings.ToUpper(visibility)),

--- a/pkg/cmd/gist/shared/shared.go
+++ b/pkg/cmd/gist/shared/shared.go
@@ -122,10 +122,7 @@ func ListGists(client *http.Client, hostname string, limit int, filter *regexp.R
 		}
 	}
 
-	perPage := limit
-	if perPage > maxPerPage {
-		perPage = maxPerPage
-	}
+	perPage := min(limit, maxPerPage)
 
 	variables := map[string]any{
 		"per_page":       githubv4.Int(perPage),

--- a/pkg/cmd/gpg-key/add/add_test.go
+++ b/pkg/cmd/gpg-key/add/add_test.go
@@ -105,7 +105,7 @@ func Test_runAdd(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("POST", "user/gpg_keys"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Contains(t, payload, "armored_public_key")
 						assert.NotContains(t, payload, "title")
 					}))
@@ -121,7 +121,7 @@ func Test_runAdd(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("POST", "user/gpg_keys"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Contains(t, payload, "armored_public_key")
 						assert.Contains(t, payload, "name")
 					}))

--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -195,7 +195,7 @@ func apiClose(httpClient *http.Client, repo ghrepo.Interface, issue *api.Issue, 
 		} `graphql:"closeIssue(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": CloseIssueInput{
 			IssueID:          issue.ID,
 			StateReason:      reason,

--- a/pkg/cmd/issue/close/close_test.go
+++ b/pkg/cmd/issue/close/close_test.go
@@ -136,7 +136,7 @@ func TestCloseRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation IssueClose\b`),
 					httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "THE-ID", inputs["issueId"])
 						}),
 				)
@@ -164,7 +164,7 @@ func TestCloseRun(t *testing.T) {
             { "data": { "addComment": { "commentEdge": { "node": {
               "url": "https://github.com/OWNER/REPO/issues/123#issuecomment-456"
             } } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "THE-ID", inputs["subjectId"])
 							assert.Equal(t, "closing comment", inputs["body"])
 						}),
@@ -172,7 +172,7 @@ func TestCloseRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation IssueClose\b`),
 					httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "THE-ID", inputs["issueId"])
 						}),
 				)
@@ -197,7 +197,7 @@ func TestCloseRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation IssueClose\b`),
 					httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, 2, len(inputs))
 							assert.Equal(t, "THE-ID", inputs["issueId"])
 							assert.Equal(t, "NOT_PLANNED", inputs["stateReason"])
@@ -224,7 +224,7 @@ func TestCloseRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation IssueClose\b`),
 					httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, 2, len(inputs))
 							assert.Equal(t, "THE-ID", inputs["issueId"])
 							assert.Equal(t, "DUPLICATE", inputs["stateReason"])
@@ -259,7 +259,7 @@ func TestCloseRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation IssueClose\b`),
 					httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, 3, len(inputs))
 							assert.Equal(t, "THE-ID", inputs["issueId"])
 							assert.Equal(t, "DUPLICATE", inputs["stateReason"])

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -850,7 +850,7 @@ func mockCommentCreate(t *testing.T, reg *httpmock.Registry) {
 		{ "data": { "addComment": { "commentEdge": { "node": {
 			"url": "https://github.com/OWNER/REPO/issues/123#issuecomment-456"
 		} } } } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, "ISSUE-ID", inputs["subjectId"])
 				assert.Equal(t, "comment body", inputs["body"])
 			}),
@@ -864,7 +864,7 @@ func mockCommentUpdate(t *testing.T, reg *httpmock.Registry) {
 		{ "data": { "updateIssueComment": { "issueComment": {
 			"url": "https://github.com/OWNER/REPO/issues/123#issuecomment-111"
 		} } } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, "id1", inputs["id"])
 				assert.Equal(t, "comment body", inputs["body"])
 			}),
@@ -876,7 +876,7 @@ func mockCommentDelete(t *testing.T, reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation CommentDelete\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "deleteIssueComment": {} } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, "id1", inputs["id"])
 			},
 		),

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -445,7 +445,7 @@ func createRun(opts *CreateOptions) (err error) {
 		}
 		return opts.Browser.Browse(openURL)
 	} else if action == prShared.SubmitAction {
-		params := map[string]interface{}{
+		params := map[string]any{
 			"title": tb.Title,
 			"body":  tb.Body,
 		}

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -534,7 +534,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createIssue": { "issue": {
 							"URL": "https://github.com/OWNER/REPO/issues/12"
 						} } } }
-					`, func(inputs map[string]interface{}) {
+					`, func(inputs map[string]any) {
 						assert.Equal(t, "title", inputs["title"])
 						assert.Equal(t, "body", inputs["body"])
 					}))
@@ -566,7 +566,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createIssue": { "issue": {
 							"URL": "https://github.com/OWNER/REPO/issues/12"
 						} } } }
-					`, func(inputs map[string]interface{}) {
+					`, func(inputs map[string]any) {
 						assert.Equal(t, "title", inputs["title"])
 						assert.Equal(t, "from editor ![shot](https://github.com/user-attachments/assets/AAA)", inputs["body"])
 					}))
@@ -607,7 +607,7 @@ func Test_createRun(t *testing.T) {
 		{ "data": { "createIssue": { "issue": {
 			"URL": "https://github.com/OWNER/REPO/issues/12"
 		} } } }
-	`, func(inputs map[string]interface{}) {
+	`, func(inputs map[string]any) {
 						assert.Equal(t, "bug: ", inputs["title"])
 						assert.Equal(t, "Does not work :((", inputs["body"])
 					}))
@@ -683,7 +683,7 @@ func Test_createRun(t *testing.T) {
 							"id": "ISSUEID",
 							"URL": "https://github.com/OWNER/REPO/issues/12"
 						} } } }
-					`, func(inputs map[string]interface{}) {
+					`, func(inputs map[string]any) {
 						if v, ok := inputs["assigneeIds"]; ok {
 							t.Errorf("did not expect assigneeIds: %v", v)
 						}
@@ -692,9 +692,9 @@ func Test_createRun(t *testing.T) {
 					httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
 					httpmock.GraphQLMutation(`
 						{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }
-					`, func(inputs map[string]interface{}) {
+					`, func(inputs map[string]any) {
 						assert.Equal(t, "ISSUEID", inputs["assignableId"])
-						assert.Equal(t, []interface{}{"copilot-swe-agent[bot]", "MonaLisa"}, inputs["actorLogins"])
+						assert.Equal(t, []any{"copilot-swe-agent[bot]", "MonaLisa"}, inputs["actorLogins"])
 					}))
 			},
 			wantsStdout: "https://github.com/OWNER/REPO/issues/12\n",
@@ -766,8 +766,8 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createIssue": { "issue": {
 							"URL": "https://github.com/OWNER/REPO/issues/12"
 						} } } }
-					`, func(inputs map[string]interface{}) {
-						assert.Equal(t, []interface{}{"HUBOTID", "MONAID"}, inputs["assigneeIds"])
+					`, func(inputs map[string]any) {
+						assert.Equal(t, []any{"HUBOTID", "MONAID"}, inputs["assigneeIds"])
 					}))
 			},
 			wantsStdout: "https://github.com/OWNER/REPO/issues/12\n",
@@ -808,7 +808,7 @@ func Test_createRun(t *testing.T) {
 					httpmock.GraphQL(`mutation UpdateIssueIssueType\b`),
 					httpmock.GraphQLMutation(`
 						{ "data": { "updateIssueIssueType": { "issue": { "id": "ISSUE_ID_123" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "ISSUE_ID_123", inputs["issueId"])
 							assert.Equal(t, "IT_1", inputs["issueTypeId"])
 						}))
@@ -866,7 +866,7 @@ func Test_createRun(t *testing.T) {
 					httpmock.GraphQL(`mutation UpdateIssueIssueType\b`),
 					httpmock.GraphQLMutation(`
 						{ "data": { "updateIssueIssueType": { "issue": { "id": "ISSUE_ID_123" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "ISSUE_ID_123", inputs["issueId"])
 							assert.Equal(t, "IT_2", inputs["issueTypeId"])
 						}))
@@ -939,7 +939,7 @@ func Test_createRun(t *testing.T) {
 					httpmock.GraphQL(`mutation AddSubIssue\b`),
 					httpmock.GraphQLMutation(`
 						{ "data": { "addSubIssue": { "issue": { "id": "PARENT_ID_100" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "PARENT_ID_100", inputs["issueId"])
 							assert.Equal(t, "ISSUE_ID_123", inputs["subIssueId"])
 							assert.Equal(t, false, inputs["replaceParent"])
@@ -990,23 +990,23 @@ func Test_createRun(t *testing.T) {
 				// also don't depend on parallel ordering.
 				// --blocked-by N: this issue is blocked by N
 				r.Register(
-					httpmock.GraphQLMutationMatcher(`mutation AddBlockedBy\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation AddBlockedBy\b`, func(input map[string]any) bool {
 						return input["issueId"] == "ISSUE_ID_123" && input["blockingIssueId"] == "BLOCKER_ID_200"
 					}),
 					httpmock.StringResponse(`{ "data": { "addBlockedBy": { "issue": { "id": "ISSUE_ID_123" } } } }`))
 				r.Register(
-					httpmock.GraphQLMutationMatcher(`mutation AddBlockedBy\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation AddBlockedBy\b`, func(input map[string]any) bool {
 						return input["issueId"] == "ISSUE_ID_123" && input["blockingIssueId"] == "BLOCKER_ID_201"
 					}),
 					httpmock.StringResponse(`{ "data": { "addBlockedBy": { "issue": { "id": "ISSUE_ID_123" } } } }`))
 				// --blocking N: N is blocked by this issue (args swapped)
 				r.Register(
-					httpmock.GraphQLMutationMatcher(`mutation AddBlockedBy\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation AddBlockedBy\b`, func(input map[string]any) bool {
 						return input["issueId"] == "BLOCKED_ID_300" && input["blockingIssueId"] == "ISSUE_ID_123"
 					}),
 					httpmock.StringResponse(`{ "data": { "addBlockedBy": { "issue": { "id": "BLOCKED_ID_300" } } } }`))
 				r.Register(
-					httpmock.GraphQLMutationMatcher(`mutation AddBlockedBy\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation AddBlockedBy\b`, func(input map[string]any) bool {
 						return input["issueId"] == "BLOCKED_ID_301" && input["blockingIssueId"] == "ISSUE_ID_123"
 					}),
 					httpmock.StringResponse(`{ "data": { "addBlockedBy": { "issue": { "id": "BLOCKED_ID_301" } } } }`))
@@ -1039,7 +1039,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createIssue": { "issue": {
 							"URL": "https://github.com/OWNER/REPO/issues/12"
 						} } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "a body\n\n![shot](https://github.com/user-attachments/assets/AAA)", inputs["body"])
 						}))
 			},
@@ -1166,7 +1166,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createIssue": { "issue": {
 							"URL": "https://github.com/OWNER/REPO/issues/12"
 						} } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "a body\n\n![first](https://github.com/user-attachments/assets/AAA)", inputs["body"])
 						}))
 			},
@@ -1259,7 +1259,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createIssue": { "issue": {
 							"URL": "https://acme.ghe.com/OWNER/REPO/issues/12"
 						} } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "a body\n\n![shot](https://acme.ghe.com/user-attachments/assets/AAA)", inputs["body"])
 						}))
 			},
@@ -1492,7 +1492,7 @@ func TestIssueCreate(t *testing.T) {
 				{ "data": { "createIssue": { "issue": {
 					"URL": "https://github.com/OWNER/REPO/issues/12"
 				} } } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["repositoryId"], "REPOID")
 				assert.Equal(t, inputs["title"], "hello")
 				assert.Equal(t, inputs["body"], "cash rules everything around me")
@@ -1536,10 +1536,10 @@ func TestIssueCreate_recover(t *testing.T) {
 		{ "data": { "createIssue": { "issue": {
 			"URL": "https://github.com/OWNER/REPO/issues/12"
 		} } } }
-	`, func(inputs map[string]interface{}) {
+	`, func(inputs map[string]any) {
 			assert.Equal(t, "recovered title", inputs["title"])
 			assert.Equal(t, "recovered body", inputs["body"])
-			assert.Equal(t, []interface{}{"BUGID", "TODOID"}, inputs["labelIds"])
+			assert.Equal(t, []any{"BUGID", "TODOID"}, inputs["labelIds"])
 		}))
 
 	pm := &prompter.PrompterMock{}
@@ -1619,7 +1619,7 @@ func TestIssueCreate_nonLegacyTemplate(t *testing.T) {
 			{ "data": { "createIssue": { "issue": {
 				"URL": "https://github.com/OWNER/REPO/issues/12"
 			} } } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["repositoryId"], "REPOID")
 				assert.Equal(t, inputs["title"], "hello")
 				assert.Equal(t, inputs["body"], "I have a suggestion for an enhancement")
@@ -1781,14 +1781,14 @@ func TestIssueCreate_metadata(t *testing.T) {
 			"id": "NEWISSUEID",
 			"URL": "https://github.com/OWNER/REPO/issues/12"
 		} } } }
-	`, func(inputs map[string]interface{}) {
+	`, func(inputs map[string]any) {
 			assert.Equal(t, "TITLE", inputs["title"])
 			assert.Equal(t, "BODY", inputs["body"])
 			if v, ok := inputs["assigneeIds"]; ok {
 				t.Errorf("did not expect assigneeIds: %v", v)
 			}
-			assert.Equal(t, []interface{}{"BUGID", "TODOID"}, inputs["labelIds"])
-			assert.Equal(t, []interface{}{"ROADMAPID"}, inputs["projectIds"])
+			assert.Equal(t, []any{"BUGID", "TODOID"}, inputs["labelIds"])
+			assert.Equal(t, []any{"ROADMAPID"}, inputs["projectIds"])
 			assert.Equal(t, "BIGONEID", inputs["milestoneId"])
 			assert.NotContains(t, inputs, "userIds")
 			assert.NotContains(t, inputs, "teamIds")
@@ -1798,9 +1798,9 @@ func TestIssueCreate_metadata(t *testing.T) {
 		httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }
-	`, func(inputs map[string]interface{}) {
+	`, func(inputs map[string]any) {
 			assert.Equal(t, "NEWISSUEID", inputs["assignableId"])
-			assert.Equal(t, []interface{}{"monalisa"}, inputs["actorLogins"])
+			assert.Equal(t, []any{"monalisa"}, inputs["actorLogins"])
 		}))
 
 	output, err := runCommand(http, true, `-t TITLE -b BODY -a monalisa -l bug -l todo -p roadmap -m 'big one.oh'`, nil)
@@ -1857,7 +1857,7 @@ func TestIssueCreate_AtMeAssignee(t *testing.T) {
 			"id": "NEWISSUEID",
 			"URL": "https://github.com/OWNER/REPO/issues/12"
 		} } } }
-	`, func(inputs map[string]interface{}) {
+	`, func(inputs map[string]any) {
 			assert.Equal(t, "hello", inputs["title"])
 			assert.Equal(t, "cash rules everything around me", inputs["body"])
 			if v, ok := inputs["assigneeIds"]; ok {
@@ -1868,9 +1868,9 @@ func TestIssueCreate_AtMeAssignee(t *testing.T) {
 		httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }
-	`, func(inputs map[string]interface{}) {
+	`, func(inputs map[string]any) {
 			assert.Equal(t, "NEWISSUEID", inputs["assignableId"])
-			assert.Equal(t, []interface{}{"MonaLisa", "someoneelse"}, inputs["actorLogins"])
+			assert.Equal(t, []any{"MonaLisa", "someoneelse"}, inputs["actorLogins"])
 		}))
 
 	output, err := runCommand(http, true, `-a @me -a someoneelse -t hello -b "cash rules everything around me"`, nil)
@@ -1900,7 +1900,7 @@ func TestIssueCreate_AtCopilotAssignee(t *testing.T) {
 			"id": "NEWISSUEID",
 			"URL": "https://github.com/OWNER/REPO/issues/12"
 		} } } }
-	`, func(inputs map[string]interface{}) {
+	`, func(inputs map[string]any) {
 			assert.Equal(t, "hello", inputs["title"])
 			assert.Equal(t, "cash rules everything around me", inputs["body"])
 			if v, ok := inputs["assigneeIds"]; ok {
@@ -1911,9 +1911,9 @@ func TestIssueCreate_AtCopilotAssignee(t *testing.T) {
 		httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }
-	`, func(inputs map[string]interface{}) {
+	`, func(inputs map[string]any) {
 			assert.Equal(t, "NEWISSUEID", inputs["assignableId"])
-			assert.Equal(t, []interface{}{"copilot-swe-agent[bot]"}, inputs["actorLogins"])
+			assert.Equal(t, []any{"copilot-swe-agent[bot]"}, inputs["actorLogins"])
 		}))
 
 	output, err := runCommand(http, true, `-a @copilot -t hello -b "cash rules everything around me"`, nil)
@@ -1983,7 +1983,7 @@ func TestIssueCreate_projectsV2(t *testing.T) {
 			"id": "Issue#1",
 			"URL": "https://github.com/OWNER/REPO/issues/12"
 		} } } }
-	`, func(inputs map[string]interface{}) {
+	`, func(inputs map[string]any) {
 			assert.Equal(t, "TITLE", inputs["title"])
 			assert.Equal(t, "BODY", inputs["body"])
 			assert.Nil(t, inputs["projectIds"])
@@ -1995,7 +1995,7 @@ func TestIssueCreate_projectsV2(t *testing.T) {
 			{ "data": { "add_000": { "item": {
 				"id": "1"
 			} } } }
-	`, func(mutations string, inputs map[string]interface{}) {
+	`, func(mutations string, inputs map[string]any) {
 			variables, err := json.Marshal(inputs)
 			assert.NoError(t, err)
 			expectedMutations := "mutation UpdateProjectV2Items($input_000: AddProjectV2ItemByIdInput!) {add_000: addProjectV2ItemById(input: $input_000) { item { id } }}"

--- a/pkg/cmd/issue/delete/delete.go
+++ b/pkg/cmd/issue/delete/delete.go
@@ -125,7 +125,7 @@ func apiDelete(httpClient *http.Client, repo ghrepo.Interface, issueID string) e
 		} `graphql:"deleteIssue(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.DeleteIssueInput{
 			IssueID: issueID,
 		},

--- a/pkg/cmd/issue/delete/delete_test.go
+++ b/pkg/cmd/issue/delete/delete_test.go
@@ -79,7 +79,7 @@ func TestIssueDelete(t *testing.T) {
 	httpRegistry.Register(
 		httpmock.GraphQL(`mutation IssueDelete\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["issueId"], "THE-ID")
 			}),
 	)
@@ -114,7 +114,7 @@ func TestIssueDelete_confirm(t *testing.T) {
 	httpRegistry.Register(
 		httpmock.GraphQL(`mutation IssueDelete\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["issueId"], "THE-ID")
 			}),
 	)

--- a/pkg/cmd/issue/develop/develop_test.go
+++ b/pkg/cmd/issue/develop/develop_test.go
@@ -245,7 +245,7 @@ func TestDevelopRun(t *testing.T) {
 					httpmock.GraphQL(`query ListLinkedBranches\b`),
 					httpmock.GraphQLQuery(`
 		        {"data":{"repository":{"issue":{"linkedBranches":{"nodes":[{"ref":{"name":"foo","repository":{"url":"https://github.com/OWNER/REPO"}}},{"ref":{"name":"bar","repository":{"url":"https://github.com/OWNER/REPO"}}}]}}}}}
-					`, func(query string, inputs map[string]interface{}) {
+					`, func(query string, inputs map[string]any) {
 						assert.Equal(t, float64(42), inputs["number"])
 						assert.Equal(t, "OWNER", inputs["owner"])
 						assert.Equal(t, "REPO", inputs["name"])
@@ -273,7 +273,7 @@ func TestDevelopRun(t *testing.T) {
 					httpmock.GraphQL(`query ListLinkedBranches\b`),
 					httpmock.GraphQLQuery(`
 		        {"data":{"repository":{"issue":{"linkedBranches":{"nodes":[{"ref":{"name":"foo","repository":{"url":"https://github.com/OWNER/REPO"}}},{"ref":{"name":"bar","repository":{"url":"https://github.com/OWNER/OTHER-REPO"}}}]}}}}}
-					`, func(query string, inputs map[string]interface{}) {
+					`, func(query string, inputs map[string]any) {
 						assert.Equal(t, float64(42), inputs["number"])
 						assert.Equal(t, "OWNER", inputs["owner"])
 						assert.Equal(t, "REPO", inputs["name"])
@@ -312,7 +312,7 @@ func TestDevelopRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
 					httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"2","ref":{"name":"my-issue-1"}}}}}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "REPOID", inputs["repositoryId"])
 							assert.Equal(t, "SOMEID", inputs["issueId"])
 							assert.Equal(t, "DEFAULTOID", inputs["oid"])
@@ -341,7 +341,7 @@ func TestDevelopRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query IssueByNumber\b`),
 					httpmock.GraphQLQuery(`{"data":{"repository":{"hasIssuesEnabled":true,"issue":{"id": "SOMEID","number":123,"title":"my issue"}}}}`,
-						func(_ string, inputs map[string]interface{}) {
+						func(_ string, inputs map[string]any) {
 							assert.Equal(t, "OWNER", inputs["owner"])
 							assert.Equal(t, "REPO", inputs["repo"])
 							assert.Equal(t, float64(123), inputs["number"])
@@ -350,7 +350,7 @@ func TestDevelopRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query FindRepoBranchID\b`),
 					httpmock.GraphQLQuery(`{"data":{"repository":{"id":"REPOID","defaultBranchRef":{"target":{"oid":"DEFAULTOID"}},"ref":{"target":{"oid":""}}}}}`,
-						func(_ string, inputs map[string]interface{}) {
+						func(_ string, inputs map[string]any) {
 							assert.Equal(t, "OWNER2", inputs["owner"])
 							assert.Equal(t, "REPO", inputs["name"])
 						}),
@@ -358,7 +358,7 @@ func TestDevelopRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
 					httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"2","ref":{"name":"my-issue-1"}}}}}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "REPOID", inputs["repositoryId"])
 							assert.Equal(t, "SOMEID", inputs["issueId"])
 							assert.Equal(t, "DEFAULTOID", inputs["oid"])
@@ -396,7 +396,7 @@ func TestDevelopRun(t *testing.T) {
 					httpmock.GraphQL(`query ListLinkedBranches\b`),
 					httpmock.GraphQLQuery(`
 		        {"data":{"repository":{"issue":{"linkedBranches":{"nodes":[]}}}}}
-					`, func(query string, inputs map[string]interface{}) {
+					`, func(query string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["number"])
 						assert.Equal(t, "OWNER", inputs["owner"])
 						assert.Equal(t, "REPO", inputs["name"])
@@ -405,7 +405,7 @@ func TestDevelopRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
 					httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"2","ref":{"name":"my-branch"}}}}}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "REPOID", inputs["repositoryId"])
 							assert.Equal(t, "SOMEID", inputs["issueId"])
 							assert.Equal(t, "OID", inputs["oid"])
@@ -443,7 +443,7 @@ func TestDevelopRun(t *testing.T) {
 					httpmock.GraphQL(`query ListLinkedBranches\b`),
 					httpmock.GraphQLQuery(`
 		        {"data":{"repository":{"issue":{"linkedBranches":{"nodes":[{"ref":{"name":"my-branch","repository":{"url":"https://github.com/OWNER/REPO"}}}]}}}}}
-					`, func(query string, inputs map[string]interface{}) {
+					`, func(query string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["number"])
 						assert.Equal(t, "OWNER", inputs["owner"])
 						assert.Equal(t, "REPO", inputs["name"])
@@ -486,7 +486,7 @@ func TestDevelopRun(t *testing.T) {
 					httpmock.GraphQL(`query ListLinkedBranches\b`),
 					httpmock.GraphQLQuery(`
 		        {"data":{"repository":{"issue":{"linkedBranches":{"nodes":[{"ref":{"name":"my-branch","repository":{"url":"https://github.com/OWNER/REPO"}}}]}}}}}
-					`, func(query string, inputs map[string]interface{}) {
+					`, func(query string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["number"])
 						assert.Equal(t, "OWNER", inputs["owner"])
 						assert.Equal(t, "REPO", inputs["name"])
@@ -523,7 +523,7 @@ func TestDevelopRun(t *testing.T) {
 					httpmock.GraphQL(`query ListLinkedBranches\b`),
 					httpmock.GraphQLQuery(`
 		        {"data":{"repository":{"issue":{"linkedBranches":{"nodes":[{"ref":{"name":"my-branch","repository":{"url":"https://github.com/OWNER/REPO"}}}]}}}}}
-					`, func(query string, inputs map[string]interface{}) {
+					`, func(query string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["number"])
 						assert.Equal(t, "OWNER", inputs["owner"])
 						assert.Equal(t, "REPO", inputs["name"])
@@ -556,7 +556,7 @@ func TestDevelopRun(t *testing.T) {
 					httpmock.GraphQL(`query ListLinkedBranches\b`),
 					httpmock.GraphQLQuery(`
 		        {"data":{"repository":{"issue":{"linkedBranches":{"nodes":[]}}}}}
-					`, func(query string, inputs map[string]interface{}) {
+					`, func(query string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["number"])
 						assert.Equal(t, "OWNER", inputs["owner"])
 						assert.Equal(t, "REPO", inputs["name"])
@@ -568,7 +568,7 @@ func TestDevelopRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
 					httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"2","ref":{"name":""}}}}}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "REPOID", inputs["repositoryId"])
 							assert.Equal(t, "SOMEID", inputs["issueId"])
 							assert.Equal(t, "OID", inputs["oid"])
@@ -602,7 +602,7 @@ func TestDevelopRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
 					httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"2","ref":{"name":"my-issue-1"}}}}}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "REPOID", inputs["repositoryId"])
 							assert.Equal(t, "SOMEID", inputs["issueId"])
 							assert.Equal(t, "DEFAULTOID", inputs["oid"])
@@ -638,7 +638,7 @@ func TestDevelopRun(t *testing.T) {
 					httpmock.GraphQL(`query ListLinkedBranches\b`),
 					httpmock.GraphQLQuery(`
 		        {"data":{"repository":{"issue":{"linkedBranches":{"nodes":[]}}}}}
-					`, func(query string, inputs map[string]interface{}) {
+					`, func(query string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["number"])
 						assert.Equal(t, "OWNER", inputs["owner"])
 						assert.Equal(t, "REPO", inputs["name"])
@@ -647,7 +647,7 @@ func TestDevelopRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
 					httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"2","ref":{"name":"my-branch"}}}}}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "REPOID", inputs["repositoryId"])
 							assert.Equal(t, "SOMEID", inputs["issueId"])
 							assert.Equal(t, "OID", inputs["oid"])
@@ -690,7 +690,7 @@ func TestDevelopRun(t *testing.T) {
 					httpmock.GraphQL(`query ListLinkedBranches\b`),
 					httpmock.GraphQLQuery(`
 		        {"data":{"repository":{"issue":{"linkedBranches":{"nodes":[]}}}}}
-					`, func(query string, inputs map[string]interface{}) {
+					`, func(query string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["number"])
 						assert.Equal(t, "OWNER", inputs["owner"])
 						assert.Equal(t, "REPO", inputs["name"])
@@ -699,7 +699,7 @@ func TestDevelopRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
 					httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"2","ref":{"name":"my-branch"}}}}}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "REPOID", inputs["repositoryId"])
 							assert.Equal(t, "SOMEID", inputs["issueId"])
 							assert.Equal(t, "OID", inputs["oid"])

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -732,29 +732,29 @@ func Test_editRun(t *testing.T) {
 				mockIssueNumberGet(t, reg, 456)
 				// Updating 123 should succeed.
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation ReplaceActorsForAssignable\b`, func(m map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation ReplaceActorsForAssignable\b`, func(m map[string]any) bool {
 						return m["assignableId"] == "123"
 					}),
 					httpmock.GraphQLMutation(`
 					{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }`,
-						func(inputs map[string]interface{}) {}),
+						func(inputs map[string]any) {}),
 				)
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation IssueUpdate\b`, func(m map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation IssueUpdate\b`, func(m map[string]any) bool {
 						return m["id"] == "123"
 					}),
 					httpmock.GraphQLMutation(`
 							{ "data": { "updateIssue": { "__typename": "" } } }`,
-						func(inputs map[string]interface{}) {}),
+						func(inputs map[string]any) {}),
 				)
 				// Updating 456 should fail.
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation ReplaceActorsForAssignable\b`, func(m map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation ReplaceActorsForAssignable\b`, func(m map[string]any) bool {
 						return m["assignableId"] == "456"
 					}),
 					httpmock.GraphQLMutation(`
 							{ "errors": [ { "message": "test error" } ] }`,
-						func(inputs map[string]interface{}) {}),
+						func(inputs map[string]any) {}),
 				)
 			},
 			stdout: heredoc.Doc(`
@@ -833,8 +833,8 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }`,
-						func(inputs map[string]interface{}) {
-							require.Subset(t, inputs["actorLogins"], []interface{}{"hubot", "MonaLisa"})
+						func(inputs map[string]any) {
+							require.Subset(t, inputs["actorLogins"], []any{"hubot", "MonaLisa"})
 						}),
 				)
 			},
@@ -901,7 +901,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation IssueUpdate\b`),
 					httpmock.GraphQLMutation(`
 								{ "data": { "updateIssue": { "__typename": "" } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							// Checking that we still assigned the expected ID.
 							require.Contains(t, inputs["assigneeIds"], "MONAID")
 						}),
@@ -938,7 +938,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation UpdateIssueIssueType\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "updateIssueIssueType": { "issue": { "id": "123" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "123", inputs["issueId"])
 							assert.Equal(t, "BUG_TYPE_ID", inputs["issueTypeId"])
 						}),
@@ -993,7 +993,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation UpdateIssueIssueType\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "updateIssueIssueType": { "issue": { "id": "123" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "123", inputs["issueId"])
 							assert.Nil(t, inputs["issueTypeId"])
 						}),
@@ -1039,7 +1039,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation UpdateIssueIssueType\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "updateIssueIssueType": { "issue": { "id": "123" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "123", inputs["issueId"])
 							assert.Equal(t, "FEATURE_TYPE_ID", inputs["issueTypeId"])
 						}),
@@ -1070,7 +1070,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation AddSubIssue\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "addSubIssue": { "issue": { "id": "PARENT_100_ID" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "PARENT_100_ID", inputs["issueId"])
 							assert.Equal(t, "123", inputs["subIssueId"])
 							assert.Equal(t, true, inputs["replaceParent"])
@@ -1113,7 +1113,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation RemoveSubIssue\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "removeSubIssue": { "issue": { "id": "PARENT_100_ID" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "PARENT_100_ID", inputs["issueId"])
 							assert.Equal(t, "123", inputs["subIssueId"])
 						}),
@@ -1143,21 +1143,21 @@ func Test_editRun(t *testing.T) {
 					httpmock.StringResponse(`{ "data": { "repository": { "issue": { "id": "SUB_124_ID" } } } }`),
 				)
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation AddSubIssue\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation AddSubIssue\b`, func(input map[string]any) bool {
 						return input["subIssueId"] == "SUB_123_ID"
 					}),
 					httpmock.GraphQLMutation(`{ "data": { "addSubIssue": { "issue": { "id": "100" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "100", inputs["issueId"])
 							assert.Equal(t, true, inputs["replaceParent"])
 						}),
 				)
 				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation AddSubIssue\b`, func(input map[string]interface{}) bool {
+					httpmock.GraphQLMutationMatcher(`mutation AddSubIssue\b`, func(input map[string]any) bool {
 						return input["subIssueId"] == "SUB_124_ID"
 					}),
 					httpmock.GraphQLMutation(`{ "data": { "addSubIssue": { "issue": { "id": "100" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "100", inputs["issueId"])
 							assert.Equal(t, true, inputs["replaceParent"])
 						}),
@@ -1188,7 +1188,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation RemoveSubIssue\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "removeSubIssue": { "issue": { "id": "100" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "100", inputs["issueId"])
 							assert.Equal(t, "SUB_123_ID", inputs["subIssueId"])
 						}),
@@ -1220,7 +1220,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation AddBlockedBy\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "addBlockedBy": { "issue": { "id": "123" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "123", inputs["issueId"])
 							assert.Equal(t, "BLOCKING_200_ID", inputs["blockingIssueId"])
 						}),
@@ -1235,7 +1235,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation RemoveBlockedBy\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "removeBlockedBy": { "issue": { "id": "123" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "123", inputs["issueId"])
 							assert.Equal(t, "BLOCKING_201_ID", inputs["blockingIssueId"])
 						}),
@@ -1266,7 +1266,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation AddBlockedBy\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "addBlockedBy": { "issue": { "id": "BLOCKED_300_ID" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							// --add-blocking swaps: OTHER issue is blocked BY this issue
 							assert.Equal(t, "BLOCKED_300_ID", inputs["issueId"])
 							assert.Equal(t, "123", inputs["blockingIssueId"])
@@ -1298,7 +1298,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation RemoveBlockedBy\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "removeBlockedBy": { "issue": { "id": "BLOCKED_300_ID" } } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							// --remove-blocking swaps: OTHER issue is no longer blocked BY this issue
 							assert.Equal(t, "BLOCKED_300_ID", inputs["issueId"])
 							assert.Equal(t, "123", inputs["blockingIssueId"])
@@ -1336,13 +1336,13 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation UpdateIssueIssueType\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "updateIssueIssueType": { "issue": { "id": "123" } } } }`,
-						func(inputs map[string]interface{}) {}),
+						func(inputs map[string]any) {}),
 				)
 				reg.Register(
 					httpmock.GraphQL(`mutation UpdateIssueIssueType\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "updateIssueIssueType": { "issue": { "id": "456" } } } }`,
-						func(inputs map[string]interface{}) {}),
+						func(inputs map[string]any) {}),
 				)
 			},
 			stdout: heredoc.Doc(`
@@ -1426,7 +1426,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation IssueUpdate\b`),
 					httpmock.GraphQLMutation(`
 						{ "data": { "updateIssue": { "__typename": "" } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.NotContains(t, inputs, "body")
 						}),
 				)
@@ -1594,7 +1594,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation IssueUpdate\b`),
 					httpmock.GraphQLMutation(`
 						{ "data": { "updateIssue": { "__typename": "" } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "a new title", inputs["title"])
 							assert.NotContains(t, inputs, "body")
 						}),
@@ -1621,7 +1621,7 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation UpdateIssueIssueType\b`),
 					httpmock.GraphQLMutation(`
 						{ "data": { "updateIssueIssueType": { "issue": { "id": "123" } } } }`,
-						func(inputs map[string]interface{}) {}),
+						func(inputs map[string]any) {}),
 				)
 			},
 			stdout:          "https://github.com/OWNER/REPO/issue/123\n",
@@ -1971,7 +1971,7 @@ func mockIssueUpdate(t *testing.T, reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation IssueUpdate\b`),
 		httpmock.GraphQLMutation(`
 				{ "data": { "updateIssue": { "__typename": "" } } }`,
-			func(inputs map[string]interface{}) {}),
+			func(inputs map[string]any) {}),
 	)
 }
 
@@ -1982,7 +1982,7 @@ func mockIssueUpdateWithBody(t *testing.T, reg *httpmock.Registry, wantBody stri
 		httpmock.GraphQL(`mutation IssueUpdate\b`),
 		httpmock.GraphQLMutation(`
 				{ "data": { "updateIssue": { "__typename": "" } } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, wantBody, inputs["body"])
 			}),
 	)
@@ -1993,7 +1993,7 @@ func mockIssueUpdateApiActors(t *testing.T, reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }`,
-			func(inputs map[string]interface{}) {}),
+			func(inputs map[string]any) {}),
 	)
 }
 
@@ -2002,13 +2002,13 @@ func mockIssueUpdateLabels(t *testing.T, reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation LabelAdd\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "addLabelsToLabelable": { "__typename": "" } } }`,
-			func(inputs map[string]interface{}) {}),
+			func(inputs map[string]any) {}),
 	)
 	reg.Register(
 		httpmock.GraphQL(`mutation LabelRemove\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "removeLabelsFromLabelable": { "__typename": "" } } }`,
-			func(inputs map[string]interface{}) {}),
+			func(inputs map[string]any) {}),
 	)
 }
 
@@ -2017,7 +2017,7 @@ func mockProjectV2ItemUpdate(t *testing.T, reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation UpdateProjectV2Items\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "add_000": { "item": { "id": "1" } }, "delete_001": { "item": { "id": "2" } } } }`,
-			func(inputs map[string]interface{}) {}),
+			func(inputs map[string]any) {}),
 	)
 }
 

--- a/pkg/cmd/issue/list/http.go
+++ b/pkg/cmd/issue/list/http.go
@@ -44,7 +44,7 @@ func listIssues(client *api.Client, repo ghrepo.Interface, filters prShared.Filt
 	}
 	`
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":  repo.RepoOwner(),
 		"repo":   repo.RepoName(),
 		"states": states,
@@ -162,7 +162,7 @@ func searchIssues(client *api.Client, detector fd.Detector, repo ghrepo.Interfac
 
 	perPage := min(limit, 100)
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": repo.RepoOwner(),
 		"repo":  repo.RepoName(),
 		"limit": perPage,

--- a/pkg/cmd/issue/list/http.go
+++ b/pkg/cmd/issue/list/http.go
@@ -217,10 +217,3 @@ loop:
 
 	return &ic, nil
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -66,7 +66,7 @@ func TestIssueList(t *testing.T) {
 	}
 	var reqBody struct {
 		Query     string
-		Variables map[string]interface{}
+		Variables map[string]any
 	}
 
 	bodyBytes, _ := io.ReadAll(reg.Requests[0].Body)
@@ -199,7 +199,7 @@ func TestSearchIssuesAndAdvancedSearch(t *testing.T) {
 
 			reg.Register(
 				httpmock.GraphQL(`query IssueSearch\b`),
-				httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
+				httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]any) {
 					assert.Equal(t, tt.wantSearchType, vars["type"])
 					// Since no repeated usage of special search qualifiers is possible
 					// with our current implementation, we can assert against the same

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -269,7 +269,7 @@ func milestoneByNumber(client *http.Client, repo ghrepo.Interface, number int32)
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":  githubv4.String(repo.RepoOwner()),
 		"name":   githubv4.String(repo.RepoName()),
 		"number": githubv4.Int(number),

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -174,11 +174,11 @@ func TestIssueList_tty_withFlags(t *testing.T) {
 		{ "data": {	"repository": {
 			"hasIssuesEnabled": true,
 			"issues": { "nodes": [] }
-		} } }`, func(_ string, params map[string]interface{}) {
+		} } }`, func(_ string, params map[string]any) {
 			assert.Equal(t, "probablyCher", params["assignee"].(string))
 			assert.Equal(t, "foo", params["author"].(string))
 			assert.Equal(t, "me", params["mention"].(string))
-			assert.Equal(t, []interface{}{"OPEN"}, params["states"].([]interface{}))
+			assert.Equal(t, []any{"OPEN"}, params["states"].([]any))
 		}))
 
 	output, err := runCommand(http, true, "-a probablyCher -s open -A foo --mention me")
@@ -198,7 +198,7 @@ func TestIssueList_tty_withAppFlag(t *testing.T) {
 		{ "data": {	"repository": {
 			"hasIssuesEnabled": true,
 			"issues": { "nodes": [] }
-		} } }`, func(_ string, params map[string]interface{}) {
+		} } }`, func(_ string, params map[string]any) {
 			assert.Equal(t, "app/dependabot", params["author"].(string))
 		}))
 
@@ -336,12 +336,12 @@ func Test_issueList(t *testing.T) {
 					{ "data": {	"repository": {
 						"hasIssuesEnabled": true,
 						"issues": { "nodes": [] }
-					} } }`, func(_ string, params map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					} } }`, func(_ string, params map[string]any) {
+						assert.Equal(t, map[string]any{
 							"owner":  "OWNER",
 							"repo":   "REPO",
 							"limit":  float64(30),
-							"states": []interface{}{"OPEN"},
+							"states": []any{"OPEN"},
 						}, params)
 					}))
 			},
@@ -377,8 +377,8 @@ func Test_issueList(t *testing.T) {
 							"issueCount": 0,
 							"nodes": []
 						}
-					} }`, func(_ string, params map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					} }`, func(_ string, params map[string]any) {
+						assert.Equal(t, map[string]any{
 							"owner": "OWNER",
 							"repo":  "REPO",
 							"limit": float64(30),
@@ -412,8 +412,8 @@ func Test_issueList(t *testing.T) {
 							"issueCount": 0,
 							"nodes": []
 						}
-					} }`, func(_ string, params map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					} }`, func(_ string, params map[string]any) {
+						assert.Equal(t, map[string]any{
 							"owner": "OWNER",
 							"repo":  "REPO",
 							"limit": float64(30),
@@ -446,12 +446,12 @@ func Test_issueList(t *testing.T) {
 					{ "data": {	"repository": {
 						"hasIssuesEnabled": true,
 						"issues": { "nodes": [] }
-					} } }`, func(_ string, params map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					} } }`, func(_ string, params map[string]any) {
+						assert.Equal(t, map[string]any{
 							"owner":    "OWNER",
 							"repo":     "REPO",
 							"limit":    float64(30),
-							"states":   []interface{}{"OPEN"},
+							"states":   []any{"OPEN"},
 							"assignee": "monalisa",
 							"author":   "monalisa",
 							"mention":  "monalisa",
@@ -486,8 +486,8 @@ func Test_issueList(t *testing.T) {
 							"issueCount": 0,
 							"nodes": []
 						}
-					} }`, func(_ string, params map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					} }`, func(_ string, params map[string]any) {
+						assert.Equal(t, map[string]any{
 							"owner": "OWNER",
 							"repo":  "REPO",
 							"limit": float64(30),
@@ -521,8 +521,8 @@ func Test_issueList(t *testing.T) {
 							"issueCount": 0,
 							"nodes": []
 						}
-					} }`, func(_ string, params map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					} }`, func(_ string, params map[string]any) {
+						assert.Equal(t, map[string]any{
 							"owner": "OWNER",
 							"repo":  "REPO",
 							"limit": float64(30),
@@ -556,8 +556,8 @@ func Test_issueList(t *testing.T) {
 							"issueCount": 0,
 							"nodes": []
 						}
-					} }`, func(_ string, params map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					} }`, func(_ string, params map[string]any) {
+						assert.Equal(t, map[string]any{
 							"owner": "OWNER",
 							"repo":  "REPO",
 							"limit": float64(30),
@@ -621,12 +621,12 @@ func TestIssueList_withProjectItems(t *testing.T) {
 				}
 			  }
 			}
-		  }`, func(_ string, params map[string]interface{}) {
-			require.Equal(t, map[string]interface{}{
+		  }`, func(_ string, params map[string]any) {
+			require.Equal(t, map[string]any{
 				"owner":  "OWNER",
 				"repo":   "REPO",
 				"limit":  float64(30),
-				"states": []interface{}{"OPEN"},
+				"states": []any{"OPEN"},
 			}, params)
 		}))
 
@@ -695,8 +695,8 @@ func TestIssueList_Search_withProjectItems(t *testing.T) {
 				]
 			  }
 			}
-		  }`, func(_ string, params map[string]interface{}) {
-			require.Equal(t, map[string]interface{}{
+		  }`, func(_ string, params map[string]any) {
+			require.Equal(t, map[string]any{
 				"owner": "OWNER",
 				"repo":  "REPO",
 				"type":  "ISSUE_ADVANCED",

--- a/pkg/cmd/issue/lock/lock.go
+++ b/pkg/cmd/issue/lock/lock.go
@@ -314,7 +314,7 @@ func lockLockable(httpClient *http.Client, repo ghrepo.Interface, lockable *api.
 		} `graphql:"lockLockable(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.LockLockableInput{
 			LockableID: lockable.ID,
 			LockReason: reasonsMap[opts.Reason],
@@ -336,7 +336,7 @@ func unlockLockable(httpClient *http.Client, repo ghrepo.Interface, lockable *ap
 		} `graphql:"unlockLockable(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.UnlockLockableInput{
 			LockableID: lockable.ID,
 		},

--- a/pkg/cmd/issue/pin/pin.go
+++ b/pkg/cmd/issue/pin/pin.go
@@ -121,7 +121,7 @@ func pinIssue(httpClient *http.Client, repo ghrepo.Interface, issue *api.Issue) 
 		} `graphql:"pinIssue(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.PinIssueInput{
 			IssueID: issue.ID,
 		},

--- a/pkg/cmd/issue/pin/pin_test.go
+++ b/pkg/cmd/issue/pin/pin_test.go
@@ -42,7 +42,7 @@ func TestPinRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation IssuePin\b`),
 					httpmock.GraphQLMutation(`{"id": "ISSUE-ID"}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, inputs["issueId"], "ISSUE-ID")
 						},
 					),

--- a/pkg/cmd/issue/reopen/reopen.go
+++ b/pkg/cmd/issue/reopen/reopen.go
@@ -128,7 +128,7 @@ func apiReopen(httpClient *http.Client, repo ghrepo.Interface, issue *api.Issue)
 		} `graphql:"reopenIssue(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.ReopenIssueInput{
 			IssueID: issue.ID,
 		},

--- a/pkg/cmd/issue/reopen/reopen_test.go
+++ b/pkg/cmd/issue/reopen/reopen_test.go
@@ -77,7 +77,7 @@ func TestIssueReopen(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation IssueReopen\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["issueId"], "THE-ID")
 			}),
 	)
@@ -170,7 +170,7 @@ func TestIssueReopen_withComment(t *testing.T) {
 		{ "data": { "addComment": { "commentEdge": { "node": {
 			"url": "https://github.com/OWNER/REPO/issues/123#issuecomment-456"
 		} } } } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, "THE-ID", inputs["subjectId"])
 				assert.Equal(t, "reopening comment", inputs["body"])
 			}),
@@ -178,7 +178,7 @@ func TestIssueReopen_withComment(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation IssueReopen\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["issueId"], "THE-ID")
 			}),
 	)

--- a/pkg/cmd/issue/shared/lookup.go
+++ b/pkg/cmd/issue/shared/lookup.go
@@ -165,7 +165,7 @@ func FindIssueOrPR(httpClient *http.Client, repo ghrepo.Interface, number int, f
 		}
 	}`, api.IssueGraphQL(fields), api.PullRequestGraphQL(fields))
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":  repo.RepoOwner(),
 		"repo":   repo.RepoName(),
 		"number": number,

--- a/pkg/cmd/issue/status/status.go
+++ b/pkg/cmd/issue/status/status.go
@@ -96,7 +96,7 @@ func statusRun(opts *StatusOptions) error {
 	defer opts.IO.StopPager()
 
 	if opts.Exporter != nil {
-		data := map[string]interface{}{
+		data := map[string]any{
 			"createdBy": issuePayload.Authored.Issues,
 			"assigned":  issuePayload.Assigned.Issues,
 			"mentioned": issuePayload.Mentioned.Issues,

--- a/pkg/cmd/issue/transfer/transfer.go
+++ b/pkg/cmd/issue/transfer/transfer.go
@@ -120,7 +120,7 @@ func issueTransfer(httpClient *http.Client, issueID string, destRepo ghrepo.Inte
 		} `graphql:"transferIssue(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.TransferIssueInput{
 			IssueID:      issueID,
 			RepositoryID: destinationRepoID,

--- a/pkg/cmd/issue/transfer/transfer_test.go
+++ b/pkg/cmd/issue/transfer/transfer_test.go
@@ -181,7 +181,7 @@ func Test_transferRunSuccessfulIssueTransfer(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation IssueTransfer\b`),
-		httpmock.GraphQLMutation(`{"data":{"transferIssue":{"issue":{"url":"https://github.com/OWNER1/REPO1/issues/1"}}}}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{"data":{"transferIssue":{"issue":{"url":"https://github.com/OWNER1/REPO1/issues/1"}}}}`, func(input map[string]any) {
 			assert.Equal(t, input["issueId"], "THE-ID")
 			assert.Equal(t, input["repositoryId"], "dest-id")
 		}))

--- a/pkg/cmd/issue/unpin/unpin.go
+++ b/pkg/cmd/issue/unpin/unpin.go
@@ -122,7 +122,7 @@ func unpinIssue(httpClient *http.Client, repo ghrepo.Interface, issue *api.Issue
 		} `graphql:"unpinIssue(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.UnpinIssueInput{
 			IssueID: issue.ID,
 		},

--- a/pkg/cmd/issue/unpin/unpin_test.go
+++ b/pkg/cmd/issue/unpin/unpin_test.go
@@ -42,7 +42,7 @@ func TestUnpinRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation IssueUnpin\b`),
 					httpmock.GraphQLMutation(`{"id": "ISSUE-ID"}`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, inputs["issueId"], "ISSUE-ID")
 						},
 					),

--- a/pkg/cmd/issue/view/http.go
+++ b/pkg/cmd/issue/view/http.go
@@ -24,7 +24,7 @@ func preloadIssueComments(client *http.Client, repo ghrepo.Interface, issue *api
 		return nil
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id":        githubv4.ID(issue.ID),
 		"endCursor": githubv4.String(issue.Comments.PageInfo.EndCursor),
 	}
@@ -66,7 +66,7 @@ func preloadClosedByPullRequestsReferences(client *http.Client, repo ghrepo.Inte
 		} `graphql:"node(id: $id)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id":        githubv4.ID(issue.ID),
 		"endCursor": githubv4.String(issue.ClosedByPullRequestsReferences.PageInfo.EndCursor),
 	}

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -931,10 +931,10 @@ func TestIssueView_json_IssueType(t *testing.T) {
 	output, err := runCommand(httpReg, false, `123 --json issueType`)
 	require.NoError(t, err)
 
-	var data map[string]interface{}
+	var data map[string]any
 	require.NoError(t, json.Unmarshal(output.OutBuf.Bytes(), &data))
 
-	issueType, ok := data["issueType"].(map[string]interface{})
+	issueType, ok := data["issueType"].(map[string]any)
 	require.True(t, ok, "issueType should be an object")
 	assert.Equal(t, "IT_1", issueType["id"])
 	assert.Equal(t, "Bug", issueType["name"])
@@ -954,11 +954,11 @@ func TestIssueView_json_ParentSubIssues(t *testing.T) {
 	output, err := runCommand(httpReg, false, `123 --json parent,subIssues,subIssuesSummary`)
 	require.NoError(t, err)
 
-	var data map[string]interface{}
+	var data map[string]any
 	require.NoError(t, json.Unmarshal(output.OutBuf.Bytes(), &data))
 
 	// Parent
-	parent, ok := data["parent"].(map[string]interface{})
+	parent, ok := data["parent"].(map[string]any)
 	require.True(t, ok, "parent should be an object")
 	assert.Equal(t, float64(100), parent["number"])
 	assert.Equal(t, "Epic: Authentication overhaul", parent["title"])
@@ -966,26 +966,26 @@ func TestIssueView_json_ParentSubIssues(t *testing.T) {
 	assert.Equal(t, "OPEN", parent["state"])
 
 	// Sub-issues
-	subIssuesObj, ok := data["subIssues"].(map[string]interface{})
+	subIssuesObj, ok := data["subIssues"].(map[string]any)
 	require.True(t, ok, "subIssues should be an object")
 	assert.Equal(t, float64(2), subIssuesObj["totalCount"])
 
-	subIssues, ok := subIssuesObj["nodes"].([]interface{})
+	subIssues, ok := subIssuesObj["nodes"].([]any)
 	require.True(t, ok, "subIssues.nodes should be an array")
 	require.Len(t, subIssues, 2)
 
-	sub0 := subIssues[0].(map[string]interface{})
+	sub0 := subIssues[0].(map[string]any)
 	assert.Equal(t, float64(101), sub0["number"])
 	assert.Equal(t, "Design auth module", sub0["title"])
 	assert.Equal(t, "CLOSED", sub0["state"])
 
-	sub1 := subIssues[1].(map[string]interface{})
+	sub1 := subIssues[1].(map[string]any)
 	assert.Equal(t, float64(102), sub1["number"])
 	assert.Equal(t, "Token refresh logic", sub1["title"])
 	assert.Equal(t, "OPEN", sub1["state"])
 
 	// Sub-issues summary
-	summary, ok := data["subIssuesSummary"].(map[string]interface{})
+	summary, ok := data["subIssuesSummary"].(map[string]any)
 	require.True(t, ok, "subIssuesSummary should be an object")
 	assert.Equal(t, float64(2), summary["total"])
 	assert.Equal(t, float64(1), summary["completed"])
@@ -1004,34 +1004,34 @@ func TestIssueView_json_BlockedByBlocking(t *testing.T) {
 	output, err := runCommand(httpReg, false, `123 --json blockedBy,blocking`)
 	require.NoError(t, err)
 
-	var data map[string]interface{}
+	var data map[string]any
 	require.NoError(t, json.Unmarshal(output.OutBuf.Bytes(), &data))
 
 	// Blocked by
-	blockedByObj, ok := data["blockedBy"].(map[string]interface{})
+	blockedByObj, ok := data["blockedBy"].(map[string]any)
 	require.True(t, ok, "blockedBy should be an object")
 	assert.Equal(t, float64(1), blockedByObj["totalCount"])
 
-	blockedBy, ok := blockedByObj["nodes"].([]interface{})
+	blockedBy, ok := blockedByObj["nodes"].([]any)
 	require.True(t, ok, "blockedBy.nodes should be an array")
 	require.Len(t, blockedBy, 1)
 
-	blocked0 := blockedBy[0].(map[string]interface{})
+	blocked0 := blockedBy[0].(map[string]any)
 	assert.Equal(t, float64(200), blocked0["number"])
 	assert.Equal(t, "API rate limiting", blocked0["title"])
 	assert.Equal(t, "https://github.com/OWNER/REPO/issues/200", blocked0["url"])
 	assert.Equal(t, "OPEN", blocked0["state"])
 
 	// Blocking
-	blockingObj, ok := data["blocking"].(map[string]interface{})
+	blockingObj, ok := data["blocking"].(map[string]any)
 	require.True(t, ok, "blocking should be an object")
 	assert.Equal(t, float64(1), blockingObj["totalCount"])
 
-	blocking, ok := blockingObj["nodes"].([]interface{})
+	blocking, ok := blockingObj["nodes"].([]any)
 	require.True(t, ok, "blocking.nodes should be an array")
 	require.Len(t, blocking, 1)
 
-	blocking0 := blocking[0].(map[string]interface{})
+	blocking0 := blocking[0].(map[string]any)
 	assert.Equal(t, float64(300), blocking0["number"])
 	assert.Equal(t, "Release v2.0", blocking0["title"])
 	assert.Equal(t, "https://github.com/OWNER/REPO/issues/300", blocking0["url"])

--- a/pkg/cmd/label/clone.go
+++ b/pkg/cmd/label/clone.go
@@ -120,7 +120,7 @@ func cloneLabels(client *http.Client, destination ghrepo.Interface, opts *cloneO
 	toCreate := make(chan createOptions)
 
 	wg, ctx := errgroup.WithContext(context.Background())
-	for i := 0; i < workers; i++ {
+	for range workers {
 		wg.Go(func() error {
 			for {
 				select {

--- a/pkg/cmd/label/clone_test.go
+++ b/pkg/cmd/label/clone_test.go
@@ -119,11 +119,11 @@ func TestCloneRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(s string, m map[string]interface{}) {
-						expected := map[string]interface{}{
+					}`, func(s string, m map[string]any) {
+						expected := map[string]any{
 							"owner": "cli",
 							"repo":  "cli",
-							"orderBy": map[string]interface{}{
+							"orderBy": map[string]any{
 								"direction": "ASC",
 								"field":     "CREATED_AT",
 							},
@@ -497,7 +497,7 @@ func TestCloneRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(s string, m map[string]interface{}) {
+					}`, func(s string, m map[string]any) {
 						assert.Equal(t, "cli", m["owner"])
 						assert.Equal(t, "cli", m["repo"])
 						assert.Equal(t, float64(100), m["limit"].(float64))
@@ -524,7 +524,7 @@ func TestCloneRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(s string, m map[string]interface{}) {
+					}`, func(s string, m map[string]any) {
 						assert.Equal(t, "cli", m["owner"])
 						assert.Equal(t, "cli", m["repo"])
 						assert.Equal(t, float64(100), m["limit"].(float64))

--- a/pkg/cmd/label/http.go
+++ b/pkg/cmd/label/http.go
@@ -88,7 +88,7 @@ func listLabels(client *http.Client, repo ghrepo.Interface, opts listQueryOption
 		}
 	}`
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":   repo.RepoOwner(),
 		"repo":    repo.RepoName(),
 		"orderBy": opts.OrderBy(),

--- a/pkg/cmd/label/list_test.go
+++ b/pkg/cmd/label/list_test.go
@@ -338,11 +338,11 @@ func TestListRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(s string, m map[string]interface{}) {
+					}`, func(s string, m map[string]any) {
 						assert.Equal(t, "OWNER", m["owner"])
 						assert.Equal(t, "REPO", m["repo"])
 						assert.Equal(t, float64(30), m["limit"].(float64))
-						assert.Equal(t, map[string]interface{}{"direction": "ASC", "field": "NAME"}, m["orderBy"])
+						assert.Equal(t, map[string]any{"direction": "ASC", "field": "NAME"}, m["orderBy"])
 					}),
 				)
 			},

--- a/pkg/cmd/label/shared.go
+++ b/pkg/cmd/label/shared.go
@@ -28,6 +28,6 @@ type label struct {
 	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
-func (l *label) ExportData(fields []string) map[string]interface{} {
+func (l *label) ExportData(fields []string) map[string]any {
 	return cmdutil.StructExportData(l, fields)
 }

--- a/pkg/cmd/org/list/http.go
+++ b/pkg/cmd/org/list/http.go
@@ -57,7 +57,7 @@ func listOrgs(httpClient *http.Client, hostname string, limit int) (*Organizatio
 	listResult := OrganizationList{}
 	listResult.User = user
 	pageLimit := min(limit, 100)
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"user": user,
 	}
 

--- a/pkg/cmd/org/list/http.go
+++ b/pkg/cmd/org/list/http.go
@@ -89,10 +89,3 @@ loop:
 
 	return &listResult, nil
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/pkg/cmd/org/list/http_test.go
+++ b/pkg/cmd/org/list/http_test.go
@@ -30,8 +30,8 @@ func Test_listOrgs(t *testing.T) {
 					httpmock.StringResponse(`{"data": {"viewer": {"login": "octocat"}}}`))
 				reg.Register(
 					httpmock.GraphQL(`query OrganizationList\b`),
-					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
-						want := map[string]interface{}{
+					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]any) {
+						want := map[string]any{
 							"user":  "octocat",
 							"limit": float64(30),
 						}
@@ -52,8 +52,8 @@ func Test_listOrgs(t *testing.T) {
 					httpmock.StringResponse(`{"data": {"viewer": {"login": "octocat"}}}`))
 				r.Register(
 					httpmock.GraphQL(`query OrganizationList\b`),
-					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
-						want := map[string]interface{}{
+					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]any) {
+						want := map[string]any{
 							"user":  "octocat",
 							"limit": float64(1),
 						}

--- a/pkg/cmd/pr/checks/aggregate.go
+++ b/pkg/cmd/pr/checks/aggregate.go
@@ -29,7 +29,7 @@ type checkCounts struct {
 	Canceled int
 }
 
-func (ch *check) ExportData(fields []string) map[string]interface{} {
+func (ch *check) ExportData(fields []string) map[string]any {
 	return cmdutil.StructExportData(ch, fields)
 }
 

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -270,7 +270,7 @@ func populateStatusChecks(client *http.Client, repo ghrepo.Interface, pr *api.Pu
 		}
 	}`, api.RequiredStatusCheckRollupGraphQL("$id", "$endCursor", includeEvent))
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id": pr.ID,
 	}
 

--- a/pkg/cmd/pr/close/close_test.go
+++ b/pkg/cmd/pr/close/close_test.go
@@ -115,7 +115,7 @@ func TestPrClose(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestClose\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "THE-ID")
 			}),
 	)
@@ -152,7 +152,7 @@ func TestPrClose_deleteBranch_sameRepo(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestClose\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "THE-ID")
 			}),
 	)
@@ -186,7 +186,7 @@ func TestPrClose_deleteBranch_crossRepo(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestClose\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "THE-ID")
 			}),
 	)
@@ -218,7 +218,7 @@ func TestPrClose_deleteBranch_sameBranch(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestClose\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "THE-ID")
 			}),
 	)
@@ -253,7 +253,7 @@ func TestPrClose_deleteBranch_notInGitRepo(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestClose\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "THE-ID")
 			}),
 	)
@@ -290,7 +290,7 @@ func TestPrClose_withComment(t *testing.T) {
 		{ "data": { "addComment": { "commentEdge": { "node": {
 			"url": "https://github.com/OWNER/REPO/issues/123#issuecomment-456"
 		} } } } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, "THE-ID", inputs["subjectId"])
 				assert.Equal(t, "closing comment", inputs["body"])
 			}),
@@ -298,7 +298,7 @@ func TestPrClose_withComment(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestClose\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "THE-ID")
 			}),
 	)

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -882,7 +882,7 @@ func mockCommentCreate(t *testing.T, reg *httpmock.Registry, wantBody string) {
 		{ "data": { "addComment": { "commentEdge": { "node": {
 			"url": "https://github.com/OWNER/REPO/pull/123#issuecomment-456"
 		} } } } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, wantBody, inputs["body"])
 			}),
 	)
@@ -895,7 +895,7 @@ func mockCommentUpdate(t *testing.T, reg *httpmock.Registry, wantBody string) {
 		{ "data": { "updateIssueComment": { "issueComment": {
 			"url": "https://github.com/OWNER/REPO/pull/123#issuecomment-111"
 		} } } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, "id1", inputs["id"])
 				assert.Equal(t, wantBody, inputs["body"])
 			}),
@@ -907,7 +907,7 @@ func mockCommentDelete(t *testing.T, reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation CommentDelete\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "deleteIssueComment": {} } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, "id1", inputs["id"])
 			},
 		),

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -1095,7 +1095,7 @@ func getRemotes(opts *CreateOptions) (ghContext.Remotes, error) {
 func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataState, projectV1Support gh.ProjectsV1Support, uploader *attachments.Uploader) error {
 	client := ctx.Client
 
-	params := map[string]interface{}{
+	params := map[string]any{
 		"title":               state.Title,
 		"body":                state.Body,
 		"draft":               state.Draft,
@@ -1155,7 +1155,7 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 	return uploadErr
 }
 
-func renderPullRequestPlain(w io.Writer, params map[string]interface{}, state *shared.IssueMetadataState) error {
+func renderPullRequestPlain(w io.Writer, params map[string]any, state *shared.IssueMetadataState) error {
 	fmt.Fprint(w, "Would have created a Pull Request with:\n")
 	fmt.Fprintf(w, "title:\t%s\n", params["title"])
 	fmt.Fprintf(w, "draft:\t%t\n", params["draft"])
@@ -1184,7 +1184,7 @@ func renderPullRequestPlain(w io.Writer, params map[string]interface{}, state *s
 	return nil
 }
 
-func renderPullRequestTTY(io *iostreams.IOStreams, params map[string]interface{}, state *shared.IssueMetadataState) error {
+func renderPullRequestTTY(io *iostreams.IOStreams, params map[string]any, state *shared.IssueMetadataState) error {
 	cs := io.ColorScheme()
 	out := io.Out
 

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -426,7 +426,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createPullRequest": { "pullRequest": {
 							"URL": "https://github.com/OWNER/REPO/pull/12"
 						} } } }`,
-						func(input map[string]interface{}) {
+						func(input map[string]any) {
 							assert.Equal(t, "REPOID", input["repositoryId"])
 							assert.Equal(t, "my title", input["title"])
 							assert.Equal(t, "my body", input["body"])
@@ -573,7 +573,7 @@ func Test_createRun(t *testing.T) {
 					httpmock.GraphQLMutation(`
 							{ "data": { "createPullRequest": { "pullRequest": {
 								"URL": "https://github.com/OWNER/REPO/pull/12"
-							} } } }`, func(input map[string]interface{}) {
+							} } } }`, func(input map[string]any) {
 						assert.Equal(t, "REPOID", input["repositoryId"].(string))
 						assert.Equal(t, "my title", input["title"].(string))
 						assert.Equal(t, "my body", input["body"].(string))
@@ -620,7 +620,7 @@ func Test_createRun(t *testing.T) {
 					httpmock.GraphQLMutation(`
 							{ "data": { "createPullRequest": { "pullRequest": {
 								"URL": "https://github.com/OWNER/REPO/pull/12"
-							} } } }`, func(input map[string]interface{}) {
+							} } } }`, func(input map[string]any) {
 						assert.Equal(t, "REPOID", input["repositoryId"].(string))
 						assert.Equal(t, "my title", input["title"].(string))
 						assert.Equal(t, "my body", input["body"].(string))
@@ -670,7 +670,7 @@ func Test_createRun(t *testing.T) {
 								"id": "PullRequest#1",
 								"URL": "https://github.com/OWNER/REPO/pull/12"
 							} } } }
-							`, func(input map[string]interface{}) {
+							`, func(input map[string]any) {
 						assert.Equal(t, "REPOID", input["repositoryId"].(string))
 						assert.Equal(t, "my title", input["title"].(string))
 						assert.Equal(t, "my body", input["body"].(string))
@@ -684,7 +684,7 @@ func Test_createRun(t *testing.T) {
 							{ "data": { "add_000": { "item": {
 								"id": "1"
 							} } } }
-							`, func(mutations string, inputs map[string]interface{}) {
+							`, func(mutations string, inputs map[string]any) {
 						variables, err := json.Marshal(inputs)
 						assert.NoError(t, err)
 						expectedMutations := "mutation UpdateProjectV2Items($input_000: AddProjectV2ItemByIdInput!) {add_000: addProjectV2ItemById(input: $input_000) { item { id } }}"
@@ -732,7 +732,7 @@ func Test_createRun(t *testing.T) {
 							{ "data": { "createPullRequest": { "pullRequest": {
 								"URL": "https://github.com/OWNER/REPO/pull/12"
 							} } } }
-							`, func(input map[string]interface{}) {
+							`, func(input map[string]any) {
 						assert.Equal(t, false, input["maintainerCanModify"].(bool))
 						assert.Equal(t, "REPOID", input["repositoryId"].(string))
 						assert.Equal(t, "my title", input["title"].(string))
@@ -780,7 +780,7 @@ func Test_createRun(t *testing.T) {
 							{ "node_id": "NODEID",
 							  "name": "REPO",
 							  "owner": {"login": "monalisa"}
-							}`, func(payload map[string]interface{}) {
+							}`, func(payload map[string]any) {
 						assert.Equal(t, true, payload["default_branch_only"])
 					}))
 				reg.Register(
@@ -788,7 +788,7 @@ func Test_createRun(t *testing.T) {
 					httpmock.GraphQLMutation(`
 							{ "data": { "createPullRequest": { "pullRequest": {
 								"URL": "https://github.com/OWNER/REPO/pull/12"
-							}}}}`, func(input map[string]interface{}) {
+							}}}}`, func(input map[string]any) {
 						assert.Equal(t, "REPOID", input["repositoryId"].(string))
 						assert.Equal(t, "master", input["baseRefName"].(string))
 						assert.Equal(t, "monalisa:feature", input["headRefName"].(string))
@@ -850,7 +850,7 @@ func Test_createRun(t *testing.T) {
 					httpmock.GraphQLMutation(`
 							{ "data": { "createPullRequest": { "pullRequest": {
 								"URL": "https://github.com/OWNER/REPO/pull/12"
-							} } } }`, func(input map[string]interface{}) {
+							} } } }`, func(input map[string]any) {
 						assert.Equal(t, "REPOID", input["repositoryId"].(string))
 						assert.Equal(t, "master", input["baseRefName"].(string))
 						assert.Equal(t, "monalisa:feature", input["headRefName"].(string))
@@ -882,7 +882,7 @@ func Test_createRun(t *testing.T) {
 			{ "data": { "createPullRequest": { "pullRequest": {
 				"URL": "https://github.com/OWNER/REPO/pull/12"
 			} } } }
-			`, func(input map[string]interface{}) {
+			`, func(input map[string]any) {
 						assert.Equal(t, "REPOID", input["repositoryId"].(string))
 						assert.Equal(t, "master", input["baseRefName"].(string))
 						assert.Equal(t, "my-feat2", input["headRefName"].(string))
@@ -929,7 +929,7 @@ func Test_createRun(t *testing.T) {
 				{ "data": { "createPullRequest": { "pullRequest": {
 					"URL": "https://github.com/OWNER/REPO/pull/12"
 				} } } }
-				`, func(input map[string]interface{}) {
+				`, func(input map[string]any) {
 						assert.Equal(t, "my title", input["title"].(string))
 						assert.Equal(t, "- **commit 1**\n- **commit 0**\n\nthis is a bug", input["body"].(string))
 					}))
@@ -1006,7 +1006,7 @@ func Test_createRun(t *testing.T) {
 						"id": "NEWPULLID",
 						"URL": "https://github.com/OWNER/REPO/pull/12"
 					} } } }
-				`, func(inputs map[string]interface{}) {
+				`, func(inputs map[string]any) {
 						assert.Equal(t, "TITLE", inputs["title"])
 						assert.Equal(t, "BODY", inputs["body"])
 						if v, ok := inputs["assigneeIds"]; ok {
@@ -1022,22 +1022,22 @@ func Test_createRun(t *testing.T) {
 					{ "data": { "updatePullRequest": {
 						"clientMutationId": ""
 					} } }
-				`, func(inputs map[string]interface{}) {
+				`, func(inputs map[string]any) {
 						assert.Equal(t, "NEWPULLID", inputs["pullRequestId"])
 						if _, ok := inputs["assigneeIds"]; ok {
 							t.Error("did not expect assigneeIds in updatePullRequest when ApiActorsSupported is true")
 						}
-						assert.Equal(t, []interface{}{"BUGID", "TODOID"}, inputs["labelIds"])
-						assert.Equal(t, []interface{}{"ROADMAPID"}, inputs["projectIds"])
+						assert.Equal(t, []any{"BUGID", "TODOID"}, inputs["labelIds"])
+						assert.Equal(t, []any{"ROADMAPID"}, inputs["projectIds"])
 						assert.Equal(t, "BIGONEID", inputs["milestoneId"])
 					}))
 				reg.Register(
 					httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }
-				`, func(inputs map[string]interface{}) {
+				`, func(inputs map[string]any) {
 						assert.Equal(t, "NEWPULLID", inputs["assignableId"])
-						assert.Equal(t, []interface{}{"monalisa"}, inputs["actorLogins"])
+						assert.Equal(t, []any{"monalisa"}, inputs["actorLogins"])
 					}))
 				reg.Register(
 					httpmock.GraphQL(`mutation RequestReviewsByLogin\b`),
@@ -1045,10 +1045,10 @@ func Test_createRun(t *testing.T) {
 					{ "data": { "requestReviewsByLogin": {
 						"clientMutationId": ""
 					} } }
-				`, func(inputs map[string]interface{}) {
+				`, func(inputs map[string]any) {
 						assert.Equal(t, "NEWPULLID", inputs["pullRequestId"])
-						assert.Equal(t, []interface{}{"hubot", "monalisa"}, inputs["userLogins"])
-						assert.Equal(t, []interface{}{"OWNER/core", "OWNER/robots"}, inputs["teamSlugs"])
+						assert.Equal(t, []any{"hubot", "monalisa"}, inputs["userLogins"])
+						assert.Equal(t, []any{"OWNER/core", "OWNER/robots"}, inputs["teamSlugs"])
 						assert.Equal(t, true, inputs["union"])
 					}))
 			},
@@ -1161,7 +1161,7 @@ func Test_createRun(t *testing.T) {
 			{ "data": { "createPullRequest": { "pullRequest": {
 				"URL": "https://github.com/OWNER/REPO/pull/12"
 			} } } }
-			`, func(input map[string]interface{}) {
+			`, func(input map[string]any) {
 						assert.Equal(t, true, input["draft"].(bool))
 					}))
 			},
@@ -1214,8 +1214,8 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "requestReviews": {
 							"clientMutationId": ""
 						} } }
-					`, func(inputs map[string]interface{}) {
-						assert.Equal(t, []interface{}{"JILLID"}, inputs["userIds"])
+					`, func(inputs map[string]any) {
+						assert.Equal(t, []any{"JILLID"}, inputs["userIds"])
 					}))
 				reg.Register(
 					httpmock.GraphQL(`mutation PullRequestCreate\b`),
@@ -1223,7 +1223,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createPullRequest": { "pullRequest": {
 							"URL": "https://github.com/OWNER/REPO/pull/12"
 						} } } }
-					`, func(input map[string]interface{}) {
+					`, func(input map[string]any) {
 						assert.Equal(t, "recovered title", input["title"].(string))
 						assert.Equal(t, "recovered body", input["body"].(string))
 					}))
@@ -1353,7 +1353,7 @@ func Test_createRun(t *testing.T) {
 							} } }
 						}
 						`,
-						func(input map[string]interface{}) {
+						func(input map[string]any) {
 							assert.Equal(t, "first commit of pr", input["title"], "pr title should be first commit message")
 							assert.Equal(t, "first commit description", input["body"], "pr body should be first commit description")
 						},
@@ -1389,7 +1389,7 @@ func Test_createRun(t *testing.T) {
 							} } }
 						}
 						`,
-						func(input map[string]interface{}) {
+						func(input map[string]any) {
 							assert.Equal(t, "first commit of pr", input["title"], "pr title should be first commit message")
 							assert.Equal(t, "first commit description", input["body"], "pr body should be first commit description")
 						},
@@ -1425,7 +1425,7 @@ func Test_createRun(t *testing.T) {
 							} } }
 						}
 						`,
-						func(input map[string]interface{}) {
+						func(input map[string]any) {
 							assert.Equal(t, "feature", input["title"], "pr title should be branch name")
 							assert.Equal(t, "- **first commit of pr**\n  first commit with super long description, with super long description, with super long description, with super long description.\n\n- **second commit of pr**\n  second commit description", input["body"], "pr body should be commits msg+body")
 						},
@@ -1446,7 +1446,7 @@ func Test_createRun(t *testing.T) {
 							"URL": "https://github.com/OWNER/REPO/pull/12"
 							} } }
 						}
-				`, func(inputs map[string]interface{}) {
+				`, func(inputs map[string]any) {
 						assert.Equal(t, "title", inputs["title"])
 						assert.Equal(t, "body", inputs["body"])
 					}))
@@ -1499,7 +1499,7 @@ func Test_createRun(t *testing.T) {
 							{ "data": { "createPullRequest": { "pullRequest": {
 								"URL": "https://github.com/OWNER/REPO/pull/12"
 							} } } }
-							`, func(input map[string]interface{}) {
+							`, func(input map[string]any) {
 						assert.Equal(t, "REPOID", input["repositoryId"].(string))
 						assert.Equal(t, "my title", input["title"].(string))
 						assert.Equal(t, "my body", input["body"].(string))
@@ -1530,7 +1530,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createPullRequest": { "pullRequest": {
 							"URL": "https://github.com/OWNER/REPO/pull/12"
 						} } } }`,
-						func(input map[string]interface{}) {
+						func(input map[string]any) {
 							assert.Equal(t, "REPOID", input["repositoryId"])
 							assert.Equal(t, "my title", input["title"])
 							assert.Equal(t, "my body", input["body"])
@@ -1567,17 +1567,17 @@ func Test_createRun(t *testing.T) {
 							"URL": "https://github.com/OWNER/REPO/pull/12",
 							"id": "NEWPULLID"
 						} } } }`,
-						func(input map[string]interface{}) {}))
+						func(input map[string]any) {}))
 				reg.Register(
 					httpmock.GraphQL(`mutation RequestReviewsByLogin\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "requestReviewsByLogin": {
 						"clientMutationId": ""
 					} } }
-				`, func(inputs map[string]interface{}) {
+				`, func(inputs map[string]any) {
 						assert.Equal(t, "NEWPULLID", inputs["pullRequestId"])
-						assert.Equal(t, []interface{}{"hubot", "monalisa"}, inputs["userLogins"])
-						assert.Equal(t, []interface{}{"org/core", "org/robots"}, inputs["teamSlugs"])
+						assert.Equal(t, []any{"hubot", "monalisa"}, inputs["userLogins"])
+						assert.Equal(t, []any{"org/core", "org/robots"}, inputs["teamSlugs"])
 						assert.Equal(t, true, inputs["union"])
 					}))
 			},
@@ -1603,17 +1603,17 @@ func Test_createRun(t *testing.T) {
 							"URL": "https://github.com/OWNER/REPO/pull/12",
 							"id": "NEWPULLID"
 						} } } }`,
-						func(input map[string]interface{}) {}))
+						func(input map[string]any) {}))
 				reg.Register(
 					httpmock.GraphQL(`mutation RequestReviewsByLogin\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "requestReviewsByLogin": {
 						"clientMutationId": ""
 					} } }
-				`, func(inputs map[string]interface{}) {
+				`, func(inputs map[string]any) {
 						assert.Equal(t, "NEWPULLID", inputs["pullRequestId"])
-						assert.Equal(t, []interface{}{"hubot"}, inputs["userLogins"])
-						assert.Equal(t, []interface{}{"copilot-pull-request-reviewer[bot]"}, inputs["botLogins"])
+						assert.Equal(t, []any{"hubot"}, inputs["userLogins"])
+						assert.Equal(t, []any{"copilot-pull-request-reviewer[bot]"}, inputs["botLogins"])
 						assert.Equal(t, true, inputs["union"])
 					}))
 			},
@@ -1667,7 +1667,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createPullRequest": { "pullRequest": {
 							"URL": "https://github.com/OWNER/REPO/pull/12"
 						} } } }`,
-						func(input map[string]interface{}) {}))
+						func(input map[string]any) {}))
 			},
 			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
 			expectedErrOut: "\nCreating pull request for feature into master in OWNER/REPO\n\n",
@@ -1731,7 +1731,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createPullRequest": { "pullRequest": {
 							"URL": "https://github.com/OWNER/REPO/pull/12"
 						} } } }`,
-						func(input map[string]interface{}) {}))
+						func(input map[string]any) {}))
 			},
 			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
 			expectedErrOut: "\nCreating pull request for feature into master in OWNER/REPO\n\n",
@@ -1756,7 +1756,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createPullRequest": { "pullRequest": {
 							"URL": "https://github.com/OWNER/REPO/pull/12"
 						} } } }`,
-						func(input map[string]interface{}) {
+						func(input map[string]any) {
 							assert.Equal(t, "before ![the shot](https://github.com/user-attachments/assets/ASSET) after", input["body"])
 						}))
 			},
@@ -1797,7 +1797,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createPullRequest": { "pullRequest": {
 							"URL": "https://acme.ghe.com/OWNER/REPO/pull/12"
 						} } } }`,
-						func(input map[string]interface{}) {
+						func(input map[string]any) {
 							assert.Equal(t, "my body\n\n![shot](https://acme.ghe.com/user-attachments/assets/ASSET)", input["body"])
 						}))
 			},
@@ -1850,7 +1850,7 @@ func Test_createRun(t *testing.T) {
 						{ "data": { "createPullRequest": { "pullRequest": {
 							"URL": "https://github.com/OWNER/REPO/pull/12"
 						} } } }`,
-						func(input map[string]interface{}) {
+						func(input map[string]any) {
 							assert.Equal(t, "my body\n\n![good](https://github.com/user-attachments/assets/ASSET)", input["body"])
 						}))
 			},
@@ -2284,7 +2284,7 @@ func Test_createRun_GHES(t *testing.T) {
 							"URL": "https://github.com/OWNER/REPO/pull/12",
 							"id": "NEWPULLID"
 						} } } }`,
-						func(input map[string]interface{}) {}))
+						func(input map[string]any) {}))
 				reg.Register(
 					httpmock.GraphQL(`query RepositoryAssignableUsers\b`),
 					httpmock.StringResponse(`
@@ -2318,10 +2318,10 @@ func Test_createRun_GHES(t *testing.T) {
 					{ "data": { "requestReviews": {
 						"clientMutationId": ""
 					} } }
-				`, func(inputs map[string]interface{}) {
+				`, func(inputs map[string]any) {
 						assert.Equal(t, "NEWPULLID", inputs["pullRequestId"])
-						assert.Equal(t, []interface{}{"HUBOTID", "MONAID"}, inputs["userIds"])
-						assert.Equal(t, []interface{}{"COREID", "ROBOTID"}, inputs["teamIds"])
+						assert.Equal(t, []any{"HUBOTID", "MONAID"}, inputs["userIds"])
+						assert.Equal(t, []any{"COREID", "ROBOTID"}, inputs["teamIds"])
 						assert.Equal(t, true, inputs["union"])
 					}))
 			},
@@ -2347,7 +2347,7 @@ func Test_createRun_GHES(t *testing.T) {
 							"URL": "https://github.com/OWNER/REPO/pull/12",
 							"id": "NEWPULLID"
 						} } } }`,
-						func(input map[string]interface{}) {}))
+						func(input map[string]any) {}))
 				reg.Register(
 					httpmock.GraphQL(`query RepositoryAssignableUsers\b`),
 					httpmock.StringResponse(`
@@ -2374,10 +2374,10 @@ func Test_createRun_GHES(t *testing.T) {
 					{ "data": { "requestReviews": {
 						"clientMutationId": ""
 					} } }
-				`, func(inputs map[string]interface{}) {
+				`, func(inputs map[string]any) {
 						assert.Equal(t, "NEWPULLID", inputs["pullRequestId"])
-						assert.Equal(t, []interface{}{"HUBOTID", "MONAID"}, inputs["userIds"])
-						assert.NotEqual(t, []interface{}{"COREID", "ROBOTID"}, inputs["teamIds"])
+						assert.Equal(t, []any{"HUBOTID", "MONAID"}, inputs["userIds"])
+						assert.NotEqual(t, []any{"COREID", "ROBOTID"}, inputs["teamIds"])
 						assert.Equal(t, true, inputs["union"])
 					}))
 			},
@@ -2482,7 +2482,7 @@ func Test_createRun_GHES(t *testing.T) {
 							"URL": "https://github.com/OWNER/REPO/pull/12"
 						} } } }
 						`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							assert.Equal(t, "TITLE", inputs["title"])
 							assert.Equal(t, "BODY", inputs["body"])
 							if v, ok := inputs["assigneeIds"]; ok {
@@ -2498,10 +2498,10 @@ func Test_createRun_GHES(t *testing.T) {
 					{ "data": { "requestReviews": {
 						"clientMutationId": ""
 					} } }
-				`, func(inputs map[string]interface{}) {
+				`, func(inputs map[string]any) {
 						assert.Equal(t, "NEWPULLID", inputs["pullRequestId"])
-						assert.Equal(t, []interface{}{"COREID"}, inputs["teamIds"])
-						assert.Equal(t, []interface{}{"MONAID"}, inputs["userIds"])
+						assert.Equal(t, []any{"COREID"}, inputs["teamIds"])
+						assert.Equal(t, []any{"MONAID"}, inputs["userIds"])
 						assert.Equal(t, true, inputs["union"])
 					}))
 			},
@@ -2626,7 +2626,7 @@ func TestRemoteGuessing(t *testing.T) {
 		httpmock.GraphQLMutation(`
 				{ "data": { "createPullRequest": { "pullRequest": {
 					"URL": "https://github.com/OWNER/REPO/pull/12"
-				} } } }`, func(input map[string]interface{}) {
+				} } } }`, func(input map[string]any) {
 			assert.Equal(t, "REPOID", input["repositoryId"].(string))
 			assert.Equal(t, "master", input["baseRefName"].(string))
 			assert.Equal(t, "OTHEROWNER:feature", input["headRefName"].(string))

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -655,11 +655,11 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation RequestReviewsByLogin\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "requestReviewsByLogin": { "clientMutationId": "" } } }`,
-						func(inputs map[string]interface{}) {
+						func(inputs map[string]any) {
 							// Verify that empty slices are sent to properly clear all reviewer types
-							require.Equal(t, []interface{}{}, inputs["userLogins"], "userLogins should be an empty slice")
-							require.Equal(t, []interface{}{}, inputs["botLogins"], "botLogins should be an empty slice")
-							require.Equal(t, []interface{}{}, inputs["teamSlugs"], "teamSlugs should be an empty slice")
+							require.Equal(t, []any{}, inputs["userLogins"], "userLogins should be an empty slice")
+							require.Equal(t, []any{}, inputs["botLogins"], "botLogins should be an empty slice")
+							require.Equal(t, []any{}, inputs["teamSlugs"], "teamSlugs should be an empty slice")
 							require.Equal(t, false, inputs["union"], "union should be false for replace mode")
 						}),
 				)
@@ -981,8 +981,8 @@ func Test_editRun(t *testing.T) {
 					httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
 					httpmock.GraphQLMutation(`
 					{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }`,
-						func(inputs map[string]interface{}) {
-							require.Subset(t, inputs["actorLogins"], []interface{}{"hubot", "monalisa"})
+						func(inputs map[string]any) {
+							require.Subset(t, inputs["actorLogins"], []any{"hubot", "monalisa"})
 						}),
 				)
 			},
@@ -1854,7 +1854,7 @@ func mockPullRequestUpdate(reg *httpmock.Registry) {
 func mockPullRequestUpdateWithBody(t *testing.T, reg *httpmock.Registry, wantBody string) {
 	reg.Register(
 		httpmock.GraphQL(`mutation PullRequestUpdate\b`),
-		httpmock.GraphQLMutation(`{}`, func(inputs map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(inputs map[string]any) {
 			assert.Equal(t, wantBody, inputs["body"])
 		}),
 	)
@@ -1865,7 +1865,7 @@ func mockPullRequestUpdateWithBody(t *testing.T, reg *httpmock.Registry, wantBod
 func mockPullRequestUpdateWithoutBody(t *testing.T, reg *httpmock.Registry, wantTitle string) {
 	reg.Register(
 		httpmock.GraphQL(`mutation PullRequestUpdate\b`),
-		httpmock.GraphQLMutation(`{}`, func(inputs map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(inputs map[string]any) {
 			assert.Equal(t, wantTitle, inputs["title"])
 			assert.NotContains(t, inputs, "body")
 		}),
@@ -1877,7 +1877,7 @@ func mockPullRequestUpdateApiActors(reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }`,
-			func(inputs map[string]interface{}) {}),
+			func(inputs map[string]any) {}),
 	)
 }
 
@@ -1900,7 +1900,7 @@ func mockRequestReviewsByLogin(reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation RequestReviewsByLogin\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "requestReviewsByLogin": { "clientMutationId": "" } } }`,
-			func(inputs map[string]interface{}) {}),
+			func(inputs map[string]any) {}),
 	)
 }
 
@@ -1909,13 +1909,13 @@ func mockPullRequestUpdateLabels(reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation LabelAdd\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "addLabelsToLabelable": { "__typename": "" } } }`,
-			func(inputs map[string]interface{}) {}),
+			func(inputs map[string]any) {}),
 	)
 	reg.Register(
 		httpmock.GraphQL(`mutation LabelRemove\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "removeLabelsFromLabelable": { "__typename": "" } } }`,
-			func(inputs map[string]interface{}) {}),
+			func(inputs map[string]any) {}),
 	)
 }
 
@@ -1924,7 +1924,7 @@ func mockProjectV2ItemUpdate(reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation UpdateProjectV2Items\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "add_000": { "item": { "id": "1" } }, "delete_001": { "item": { "id": "2" } } } }`,
-			func(inputs map[string]interface{}) {}),
+			func(inputs map[string]any) {}),
 	)
 }
 

--- a/pkg/cmd/pr/list/http.go
+++ b/pkg/cmd/pr/list/http.go
@@ -70,7 +70,7 @@ func searchPullRequests(httpClient *http.Client, detector fd.Detector, repo ghre
 			}
 		}`
 
-	variables := map[string]interface{}{}
+	variables := map[string]any{}
 
 	filters.Repo = ghrepo.FullName(repo)
 	filters.Entity = "pr"

--- a/pkg/cmd/pr/list/http.go
+++ b/pkg/cmd/pr/list/http.go
@@ -128,10 +128,3 @@ loop:
 
 	return &res, nil
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/pkg/cmd/pr/list/http_test.go
+++ b/pkg/cmd/pr/list/http_test.go
@@ -37,11 +37,11 @@ func Test_ListPullRequests(t *testing.T) {
 			httpStub: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.GraphQL(`query PullRequestList\b`),
-					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
-						want := map[string]interface{}{
+					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]any) {
+						want := map[string]any{
 							"owner": "OWNER",
 							"repo":  "REPO",
-							"state": []interface{}{"OPEN"},
+							"state": []any{"OPEN"},
 							"limit": float64(30),
 						}
 						if !reflect.DeepEqual(vars, want) {
@@ -62,11 +62,11 @@ func Test_ListPullRequests(t *testing.T) {
 			httpStub: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.GraphQL(`query PullRequestList\b`),
-					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
-						want := map[string]interface{}{
+					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]any) {
+						want := map[string]any{
 							"owner": "OWNER",
 							"repo":  "REPO",
-							"state": []interface{}{"CLOSED", "MERGED"},
+							"state": []any{"CLOSED", "MERGED"},
 							"limit": float64(30),
 						}
 						if !reflect.DeepEqual(vars, want) {
@@ -91,8 +91,8 @@ func Test_ListPullRequests(t *testing.T) {
 			httpStub: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.GraphQL(`query PullRequestSearch\b`),
-					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
-						want := map[string]interface{}{
+					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]any) {
+						want := map[string]any{
 							"q":     `label:"one world" label:hello repo:OWNER/REPO state:open type:pr`,
 							"type":  "ISSUE_ADVANCED",
 							"limit": float64(30),
@@ -119,8 +119,8 @@ func Test_ListPullRequests(t *testing.T) {
 			httpStub: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.GraphQL(`query PullRequestSearch\b`),
-					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
-						want := map[string]interface{}{
+					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]any) {
+						want := map[string]any{
 							"q":     "author:monalisa repo:OWNER/REPO state:open type:pr",
 							"type":  "ISSUE_ADVANCED",
 							"limit": float64(30),
@@ -147,8 +147,8 @@ func Test_ListPullRequests(t *testing.T) {
 			httpStub: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.GraphQL(`query PullRequestSearch\b`),
-					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
-						want := map[string]interface{}{
+					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]any) {
+						want := map[string]any{
 							"q":     "( one world in:title ) repo:OWNER/REPO state:open type:pr",
 							"type":  "ISSUE_ADVANCED",
 							"limit": float64(30),
@@ -209,7 +209,7 @@ func TestSearchPullRequestsAndAdvancedSearch(t *testing.T) {
 
 			reg.Register(
 				httpmock.GraphQL(`query PullRequestSearch\b`),
-				httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
+				httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]any) {
 					assert.Equal(t, tt.wantSearchType, vars["type"])
 
 					// Since no repeated usage of special search qualifiers is possible

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -122,8 +122,8 @@ func TestPRList_filtering(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`query PullRequestList\b`),
-		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
-			assert.Equal(t, []interface{}{"OPEN", "CLOSED", "MERGED"}, params["state"].([]interface{}))
+		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]any) {
+			assert.Equal(t, []any{"OPEN", "CLOSED", "MERGED"}, params["state"].([]any))
 		}))
 
 	output, err := runCommand(http, nil, true, `-s all`)
@@ -160,8 +160,8 @@ func TestPRList_filteringClosed(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`query PullRequestList\b`),
-		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
-			assert.Equal(t, []interface{}{"CLOSED", "MERGED"}, params["state"].([]interface{}))
+		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]any) {
+			assert.Equal(t, []any{"CLOSED", "MERGED"}, params["state"].([]any))
 		}))
 
 	_, err := runCommand(http, nil, true, `-s closed`)
@@ -174,8 +174,8 @@ func TestPRList_filteringHeadBranch(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`query PullRequestList\b`),
-		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
-			assert.Equal(t, interface{}("bug-fix"), params["headBranch"])
+		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]any) {
+			assert.Equal(t, any("bug-fix"), params["headBranch"])
 		}))
 
 	_, err := runCommand(http, nil, true, `-H bug-fix`)
@@ -188,7 +188,7 @@ func TestPRList_filteringAssignee(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`query PullRequestSearch\b`),
-		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
+		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]any) {
 			assert.Equal(t, `assignee:hubot base:develop is:merged label:"needs tests" repo:OWNER/REPO type:pr`, params["q"].(string))
 		}))
 
@@ -223,7 +223,7 @@ func TestPRList_filteringDraft(t *testing.T) {
 
 			http.Register(
 				httpmock.GraphQL(`query PullRequestSearch\b`),
-				httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
+				httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]any) {
 					assert.Equal(t, test.expectedQuery, params["q"].(string))
 				}))
 
@@ -270,7 +270,7 @@ func TestPRList_filteringAuthor(t *testing.T) {
 
 			http.Register(
 				httpmock.GraphQL(`query PullRequestSearch\b`),
-				httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
+				httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]any) {
 					assert.Equal(t, test.expectedQuery, params["q"].(string))
 				}))
 
@@ -366,12 +366,12 @@ func TestPRList_withProjectItems(t *testing.T) {
 				}
 			  }
 			}
-		  }`, func(_ string, params map[string]interface{}) {
-			require.Equal(t, map[string]interface{}{
+		  }`, func(_ string, params map[string]any) {
+			require.Equal(t, map[string]any{
 				"owner": "OWNER",
 				"repo":  "REPO",
 				"limit": float64(30),
-				"state": []interface{}{"OPEN"},
+				"state": []any{"OPEN"},
 			}, params)
 		}))
 
@@ -438,8 +438,8 @@ func TestPRList_Search_withProjectItems(t *testing.T) {
 				]
 			  }
 			}
-		  }`, func(_ string, params map[string]interface{}) {
-			require.Equal(t, map[string]interface{}{
+		  }`, func(_ string, params map[string]any) {
+			require.Equal(t, map[string]any{
 				"limit": float64(30),
 				"q":     "( just used to force the search API branch ) repo:OWNER/REPO state:open type:pr",
 				"type":  "ISSUE_ADVANCED",

--- a/pkg/cmd/pr/merge/http.go
+++ b/pkg/cmd/pr/merge/http.go
@@ -79,7 +79,7 @@ func mergePullRequest(client *http.Client, payload mergePayload) error {
 		input.ExpectedHeadOid = &expectedHeadOid
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": input,
 	}
 
@@ -110,7 +110,7 @@ func disableAutoMerge(client *http.Client, repo ghrepo.Interface, prID string) e
 		} `graphql:"disablePullRequestAutoMerge(input: {pullRequestId: $prID})"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"prID": githubv4.ID(prID),
 	}
 
@@ -138,7 +138,7 @@ func getMergeText(client *http.Client, repo ghrepo.Interface, prID string, merge
 		} `graphql:"node(id: $prID)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"prID":   githubv4.ID(prID),
 		"method": method,
 	}

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -551,12 +551,12 @@ func (m *mergeContext) shouldAddToMergeQueue() bool {
 	return m.mergeQueueRequired && !m.opts.UseAdmin
 }
 
-func (m *mergeContext) warnf(format string, args ...interface{}) error {
+func (m *mergeContext) warnf(format string, args ...any) error {
 	_, err := fmt.Fprintf(m.opts.IO.ErrOut, format, args...)
 	return err
 }
 
-func (m *mergeContext) infof(format string, args ...interface{}) error {
+func (m *mergeContext) infof(format string, args ...any) error {
 	if !m.isTerminal {
 		return nil
 	}

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -330,7 +330,7 @@ func TestPrMerge(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -436,7 +436,7 @@ func TestPrMerge_nontty(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -474,7 +474,7 @@ func TestPrMerge_editMessage_nontty(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.Equal(t, "mytitle", input["commitHeadline"].(string))
@@ -513,7 +513,7 @@ func TestPrMerge_withRepoFlag(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -552,7 +552,7 @@ func TestPrMerge_withMatchCommitHeadFlag(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, 3, len(input))
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
@@ -593,7 +593,7 @@ func TestPrMerge_withAuthorFlag(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.Equal(t, "octocat@github.com", input["authorEmail"].(string))
@@ -637,7 +637,7 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -736,7 +736,7 @@ func TestPrMerge_deleteBranch_apiError(t *testing.T) {
 
 			http.Register(
 				httpmock.GraphQL(`mutation PullRequestMerge\b`),
-				httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+				httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 					assert.Equal(t, "PR_10", input["pullRequestId"].(string))
 					assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 					assert.NotContains(t, input, "commitHeadline")
@@ -812,7 +812,7 @@ func TestPrMerge_deleteBranch_nonDefault(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -866,7 +866,7 @@ func TestPrMerge_deleteBranch_onlyLocally(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -915,7 +915,7 @@ func TestPrMerge_deleteBranch_checkoutNewBranch(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -967,7 +967,7 @@ func TestPrMerge_deleteNonCurrentBranch(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -1015,7 +1015,7 @@ func Test_nonDivergingPullRequest(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -1055,7 +1055,7 @@ func Test_divergingPullRequestWarning(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -1096,7 +1096,7 @@ func Test_pullRequestWithoutCommits(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -1135,7 +1135,7 @@ func TestPrMerge_rebase(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "REBASE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -1176,7 +1176,7 @@ func TestPrMerge_squash(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "SQUASH", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -1384,7 +1384,7 @@ func TestPRMergeTTY(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -1453,7 +1453,7 @@ func TestPRMergeTTY_withDeleteBranch(t *testing.T) {
 		} } }`))
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -1533,7 +1533,7 @@ func TestPRMergeTTY_squashEditCommitMsgAndSubject(t *testing.T) {
 		} } }`))
 	tr.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "SQUASH", input["mergeMethod"].(string))
 			assert.Equal(t, "DEFAULT HEADLINE TEXT", input["commitHeadline"].(string))
@@ -1698,7 +1698,7 @@ func TestMergeRun_autoMerge(t *testing.T) {
 	defer tr.Verify(t)
 	tr.Register(
 		httpmock.GraphQL(`mutation PullRequestAutoMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "SQUASH", input["mergeMethod"].(string))
 		}))
@@ -1735,7 +1735,7 @@ func TestMergeRun_autoMerge_directMerge(t *testing.T) {
 	defer tr.Verify(t)
 	tr.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -1773,8 +1773,8 @@ func TestMergeRun_disableAutoMerge(t *testing.T) {
 	defer tr.Verify(t)
 	tr.Register(
 		httpmock.GraphQL(`mutation PullRequestAutoMergeDisable\b`),
-		httpmock.GraphQLQuery(`{}`, func(s string, m map[string]interface{}) {
-			assert.Equal(t, map[string]interface{}{"prID": "THE-ID"}, m)
+		httpmock.GraphQLQuery(`{}`, func(s string, m map[string]any) {
+			assert.Equal(t, map[string]any{"prID": "THE-ID"}, m)
 		}))
 
 	_, cmdTeardown := run.Stub()
@@ -1850,7 +1850,7 @@ func TestPrAddToMergeQueueWithMergeMethod(t *testing.T) {
 	)
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestAutoMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 		}),
@@ -1889,7 +1889,7 @@ func TestPrAddToMergeQueueClean(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestAutoMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 		}),
@@ -1929,7 +1929,7 @@ func TestPrAddToMergeQueueBlocked(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestAutoMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 		}),
@@ -1977,7 +1977,7 @@ func TestPrAddToMergeQueueAdmin(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -2036,7 +2036,7 @@ func TestPrAddToMergeQueueAdminWithMergeStrategy(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
@@ -2304,7 +2304,7 @@ func TestPrMerge_deleteBranch_worktrees(t *testing.T) {
 
 			http.Register(
 				httpmock.GraphQL(`mutation PullRequestMerge\b`),
-				httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+				httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 					assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 					assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 				}))
@@ -2363,7 +2363,7 @@ func TestPrMerge_deleteBranch_noWorktreeConflict(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 		}))

--- a/pkg/cmd/pr/ready/ready_test.go
+++ b/pkg/cmd/pr/ready/ready_test.go
@@ -134,7 +134,7 @@ func TestPRReady(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestReadyForReview\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "THE-ID")
 			}),
 	)
@@ -176,7 +176,7 @@ func TestPRReadyUndo(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation ConvertPullRequestToDraft\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "THE-ID")
 			}),
 	)

--- a/pkg/cmd/pr/reopen/reopen_test.go
+++ b/pkg/cmd/pr/reopen/reopen_test.go
@@ -63,7 +63,7 @@ func TestPRReopen(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestReopen\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "THE-ID")
 			}),
 	)
@@ -125,7 +125,7 @@ func TestPRReopen_withComment(t *testing.T) {
 		{ "data": { "addComment": { "commentEdge": { "node": {
 			"url": "https://github.com/OWNER/REPO/issues/123#issuecomment-456"
 		} } } } }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, "THE-ID", inputs["subjectId"])
 				assert.Equal(t, "reopening comment", inputs["body"])
 			}),
@@ -133,7 +133,7 @@ func TestPRReopen_withComment(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestReopen\b`),
 		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "THE-ID")
 			}),
 	)

--- a/pkg/cmd/pr/revert/revert.go
+++ b/pkg/cmd/pr/revert/revert.go
@@ -106,17 +106,17 @@ func revertRun(opts *RevertOptions) error {
 
 	params := githubv4.RevertPullRequestInput{
 		PullRequestID: pr.ID,
-		Draft:         githubv4.NewBoolean(githubv4.Boolean(opts.IsDraft)),
+		Draft:         new(githubv4.Boolean(opts.IsDraft)),
 	}
 	// Only set the Body field when opts.BodySet is true to avoid overriding
 	// GitHub's default revert body generation.
 	if opts.BodySet {
-		params.Body = githubv4.NewString(githubv4.String(opts.Body))
+		params.Body = new(githubv4.String(opts.Body))
 	}
 	// Only set the Title field when opts.Title is not empty to avoid overriding
 	// GitHub's default revert title generation.
 	if opts.Title != "" {
-		params.Title = githubv4.NewString(githubv4.String(opts.Title))
+		params.Title = new(githubv4.String(opts.Title))
 	}
 
 	revertPR, err := api.PullRequestRevert(apiClient, baseRepo, params)

--- a/pkg/cmd/pr/revert/revert_test.go
+++ b/pkg/cmd/pr/revert/revert_test.go
@@ -109,7 +109,7 @@ func TestPRRevert_acceptedIdentifierFormats(t *testing.T) {
                "URL": "https://github.com/OWNER/REPO/pull/456"
             } } } }
 			`,
-					func(inputs map[string]interface{}) {
+					func(inputs map[string]any) {
 						assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
 					}),
 			)
@@ -165,7 +165,7 @@ func TestPRRevert_withTitleAndBody(t *testing.T) {
                "URL": "https://github.com/OWNER/REPO/pull/456"
             } } } }
 			`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
 				assert.Equal(t, inputs["title"], "Revert PR title")
 				assert.Equal(t, inputs["body"], "Revert PR body")
@@ -202,7 +202,7 @@ func TestPRRevert_withDraft(t *testing.T) {
                "URL": "https://github.com/OWNER/REPO/pull/456"
             } } } }
 			`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
 				assert.Equal(t, inputs["draft"], true)
 			}),
@@ -233,7 +233,7 @@ func TestPRRevert_APIFailure(t *testing.T) {
 			{ "errors": [{
               "message": "Authorization error"
             }]}`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
 			}),
 	)
@@ -267,7 +267,7 @@ func TestPRRevert_multipleInvocations(t *testing.T) {
                "URL": "https://github.com/OWNER/REPO/pull/456"
             } } } }
 			`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
 			}),
 	)
@@ -297,7 +297,7 @@ func TestPRRevert_multipleInvocations(t *testing.T) {
                "URL": "https://github.com/OWNER/REPO/pull/456"
             } } } }
 			`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
 			}),
 	)

--- a/pkg/cmd/pr/review/review_test.go
+++ b/pkg/cmd/pr/review/review_test.go
@@ -240,8 +240,8 @@ func TestPRReview(t *testing.T) {
 			http.Register(
 				httpmock.GraphQL(`mutation PullRequestReviewAdd\b`),
 				httpmock.GraphQLMutation(`{"data": {} }`,
-					func(inputs map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					func(inputs map[string]any) {
+						assert.Equal(t, map[string]any{
 							"pullRequestId": "THE-ID",
 							"event":         tt.wantEvent,
 							"body":          tt.wantBody,
@@ -266,7 +266,7 @@ func TestPRReview_interactive(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestReviewAdd\b`),
 		httpmock.GraphQLMutation(`{"data": {} }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["event"], "APPROVE")
 				assert.Equal(t, inputs["body"], "cool story")
 			}),
@@ -313,7 +313,7 @@ func TestPRReview_interactive_blank_approve(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestReviewAdd\b`),
 		httpmock.GraphQLMutation(`{"data": {} }`,
-			func(inputs map[string]interface{}) {
+			func(inputs map[string]any) {
 				assert.Equal(t, inputs["event"], "APPROVE")
 				assert.Equal(t, inputs["body"], "")
 			}),

--- a/pkg/cmd/pr/shared/commentable_test.go
+++ b/pkg/cmd/pr/shared/commentable_test.go
@@ -423,7 +423,7 @@ func TestCommentableRunUploadsAndWritesBodies(t *testing.T) {
 				}
 				reg.Register(
 					httpmock.GraphQL(tt.wantQuery),
-					httpmock.GraphQLMutation(response, func(inputs map[string]interface{}) {
+					httpmock.GraphQLMutation(response, func(inputs map[string]any) {
 						gotBody, _ = inputs["body"].(string)
 					}),
 				)

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
@@ -432,11 +433,8 @@ func EditFieldsSurvey(p EditPrompter, editable *Editable, editorCommand string) 
 		}
 		for _, prev := range editable.Labels.Default {
 			var found bool
-			for _, selected := range editable.Labels.Add {
-				if prev == selected {
-					found = true
-					break
-				}
+			if slices.Contains(editable.Labels.Add, prev) {
+				found = true
 			}
 			if !found {
 				editable.Labels.Remove = append(editable.Labels.Remove, prev)
@@ -479,12 +477,7 @@ func EditFieldsSurvey(p EditPrompter, editable *Editable, editorCommand string) 
 
 func FieldsToEditSurvey(p EditPrompter, editable *Editable) error {
 	contains := func(s []string, str string) bool {
-		for _, v := range s {
-			if v == str {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(s, str)
 	}
 
 	opts := []string{"Title", "Body"}

--- a/pkg/cmd/pr/shared/editable_http.go
+++ b/pkg/cmd/pr/shared/editable_http.go
@@ -161,7 +161,7 @@ func addLabels(httpClient *http.Client, id string, repo ghrepo.Interface, labels
 		} `graphql:"addLabelsToLabelable(input: $input)"`
 	}
 
-	variables := map[string]interface{}{"input": params}
+	variables := map[string]any{"input": params}
 	gql := api.NewClientFromHTTP(httpClient)
 	return gql.Mutate(repo.RepoHost(), "LabelAdd", &mutation, variables)
 }
@@ -178,7 +178,7 @@ func removeLabels(httpClient *http.Client, id string, repo ghrepo.Interface, lab
 		} `graphql:"removeLabelsFromLabelable(input: $input)"`
 	}
 
-	variables := map[string]interface{}{"input": params}
+	variables := map[string]any{"input": params}
 	gql := api.NewClientFromHTTP(httpClient)
 	return gql.Mutate(repo.RepoHost(), "LabelRemove", &mutation, variables)
 }
@@ -189,7 +189,7 @@ func updateIssue(httpClient *http.Client, repo ghrepo.Interface, params githubv4
 			Typename string `graphql:"__typename"`
 		} `graphql:"updateIssue(input: $input)"`
 	}
-	variables := map[string]interface{}{"input": params}
+	variables := map[string]any{"input": params}
 	gql := api.NewClientFromHTTP(httpClient)
 	return gql.Mutate(repo.RepoHost(), "IssueUpdate", &mutation, variables)
 }
@@ -200,7 +200,7 @@ func updatePullRequest(httpClient *http.Client, repo ghrepo.Interface, params gi
 			Typename string `graphql:"__typename"`
 		} `graphql:"updatePullRequest(input: $input)"`
 	}
-	variables := map[string]interface{}{"input": params}
+	variables := map[string]any{"input": params}
 	gql := api.NewClientFromHTTP(httpClient)
 	err := gql.Mutate(repo.RepoHost(), "PullRequestUpdate", &mutation, variables)
 	return err

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -367,7 +367,7 @@ func findByNumber(httpClient *http.Client, repo ghrepo.Interface, number int, fi
 		}
 	}`, api.PullRequestGraphQL(fields))
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     repo.RepoOwner(),
 		"repo":      repo.RepoName(),
 		"pr_number": number,
@@ -410,7 +410,7 @@ func findForRefs(httpClient *http.Client, prRefs PRFindRefs, stateFilters, field
 		}
 	}`, api.PullRequestGraphQL(fieldSet.ToSlice()))
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":       prRefs.BaseRepo().RepoOwner(),
 		"repo":        prRefs.BaseRepo().RepoName(),
 		"headRefName": prRefs.UnqualifiedHeadRef(),
@@ -454,7 +454,7 @@ func preloadPrReviews(httpClient *http.Client, repo ghrepo.Interface, pr *api.Pu
 		} `graphql:"node(id: $id)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id":        githubv4.ID(pr.ID),
 		"endCursor": githubv4.String(pr.Reviews.PageInfo.EndCursor),
 	}
@@ -494,7 +494,7 @@ func preloadPrComments(client *http.Client, repo ghrepo.Interface, pr *api.PullR
 		} `graphql:"node(id: $id)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id":        githubv4.ID(pr.ID),
 		"endCursor": githubv4.String(pr.Comments.PageInfo.EndCursor),
 	}
@@ -534,7 +534,7 @@ func preloadPrClosingIssuesReferences(client *http.Client, repo ghrepo.Interface
 		} `graphql:"node(id: $id)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id":        githubv4.ID(pr.ID),
 		"endCursor": githubv4.String(pr.ClosingIssuesReferences.PageInfo.EndCursor),
 	}
@@ -584,7 +584,7 @@ func preloadPrChecks(client *http.Client, repo ghrepo.Interface, pr *api.PullReq
 		}
 	}`, api.StatusCheckRollupGraphQLWithoutCountByState("$endCursor"))
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id": pr.ID,
 	}
 

--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -803,7 +803,7 @@ func TestFind(t *testing.T) {
 		                  }
 		                }
 		              }`,
-						func(query string, inputs map[string]interface{}) {
+						func(query string, inputs map[string]any) {
 							require.Equal(t, float64(13), inputs["number"])
 							require.Equal(t, "OWNER", inputs["owner"])
 							require.Equal(t, "REPO", inputs["name"])

--- a/pkg/cmd/pr/shared/lister.go
+++ b/pkg/cmd/pr/shared/lister.go
@@ -82,7 +82,7 @@ func (l *lister) List(opts ListOptions) (*api.PullRequestAndTotalCount, error) {
 		}`
 
 	pageLimit := min(limit, 100)
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": opts.BaseRepo.RepoOwner(),
 		"repo":  opts.BaseRepo.RepoName(),
 	}

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -56,7 +56,7 @@ func ValidURL(urlStr string) bool {
 	return len(urlStr) < 8192
 }
 
-func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, params map[string]interface{}, tb *IssueMetadataState, projectV1Support gh.ProjectsV1Support) error {
+func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, params map[string]any, tb *IssueMetadataState, projectV1Support gh.ProjectsV1Support) error {
 	if !tb.HasMetadata() {
 		return nil
 	}

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -156,12 +156,7 @@ type RepoMetadataFetcher interface {
 
 func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher RepoMetadataFetcher, state *IssueMetadataState, projectsV1Support gh.ProjectsV1Support, reviewerSearchFunc func(string) prompter.MultiSelectSearchResult, assigneeSearchFunc func(string) prompter.MultiSelectSearchResult) error {
 	isChosen := func(m string) bool {
-		for _, c := range state.Metadata {
-			if m == c {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(state.Metadata, m)
 	}
 
 	allowReviewers := state.Type == PRMetadata

--- a/pkg/cmd/pr/shared/templates.go
+++ b/pkg/cmd/pr/shared/templates.go
@@ -65,7 +65,7 @@ func listIssueTemplates(httpClient *http.Client, repo ghrepo.Interface) ([]Templ
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": githubv4.String(repo.RepoOwner()),
 		"name":  githubv4.String(repo.RepoName()),
 	}
@@ -93,7 +93,7 @@ func listPullRequestTemplates(httpClient *http.Client, repo ghrepo.Interface) ([
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner": githubv4.String(repo.RepoOwner()),
 		"name":  githubv4.String(repo.RepoName()),
 	}

--- a/pkg/cmd/pr/status/http.go
+++ b/pkg/cmd/pr/status/http.go
@@ -136,7 +136,7 @@ func pullRequestStatus(httpClient *http.Client, repo ghrepo.Interface, options r
 		branchWithoutOwner = currentPRHeadRef[idx+1:]
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"viewerQuery":   viewerQuery,
 		"reviewerQuery": reviewerQuery,
 		"owner":         repo.RepoOwner(),

--- a/pkg/cmd/pr/status/http.go
+++ b/pkg/cmd/pr/status/http.go
@@ -132,8 +132,8 @@ func pullRequestStatus(httpClient *http.Client, repo ghrepo.Interface, options r
 
 	currentPRHeadRef := options.HeadRef
 	branchWithoutOwner := currentPRHeadRef
-	if idx := strings.Index(currentPRHeadRef, ":"); idx >= 0 {
-		branchWithoutOwner = currentPRHeadRef[idx+1:]
+	if _, after, ok := strings.Cut(currentPRHeadRef, ":"); ok {
+		branchWithoutOwner = after
 	}
 
 	variables := map[string]any{

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -165,7 +165,7 @@ func statusRun(opts *StatusOptions) error {
 	defer opts.IO.StopPager()
 
 	if opts.Exporter != nil {
-		data := map[string]interface{}{
+		data := map[string]any{
 			"currentBranch": nil,
 			"createdBy":     prPayload.ViewerCreated.PullRequests,
 			"needsReview":   prPayload.ReviewRequested.PullRequests,

--- a/pkg/cmd/pr/update-branch/update_branch_test.go
+++ b/pkg/cmd/pr/update-branch/update_branch_test.go
@@ -148,7 +148,7 @@ func Test_updateBranchRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(_ string, inputs map[string]interface{}) {
+					}`, func(_ string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["pullRequestNumber"])
 						assert.Equal(t, "head-repository-owner:head-ref-name", inputs["headRef"])
 					}))
@@ -185,7 +185,7 @@ func Test_updateBranchRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(_ string, inputs map[string]interface{}) {
+					}`, func(_ string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["pullRequestNumber"])
 						assert.Equal(t, "head-ref-name", inputs["headRef"])
 					}))
@@ -230,7 +230,7 @@ func Test_updateBranchRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(_ string, inputs map[string]interface{}) {
+					}`, func(_ string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["pullRequestNumber"])
 						assert.Equal(t, "head-repository-owner:head-ref-name", inputs["headRef"])
 					}))
@@ -242,7 +242,7 @@ func Test_updateBranchRun(t *testing.T) {
 								"pullRequest": {}
 							}
 						}
-					}`, func(inputs map[string]interface{}) {
+					}`, func(inputs map[string]any) {
 						assert.Equal(t, "123", inputs["pullRequestId"])
 						assert.Equal(t, "head-ref-oid", inputs["expectedHeadOid"])
 						assert.Equal(t, "MERGE", inputs["updateMethod"])
@@ -273,7 +273,7 @@ func Test_updateBranchRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(_ string, inputs map[string]interface{}) {
+					}`, func(_ string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["pullRequestNumber"])
 						assert.Equal(t, "head-repository-owner:head-ref-name", inputs["headRef"])
 					}))
@@ -285,7 +285,7 @@ func Test_updateBranchRun(t *testing.T) {
 								"pullRequest": {}
 							}
 						}
-					}`, func(inputs map[string]interface{}) {
+					}`, func(inputs map[string]any) {
 						assert.Equal(t, "123", inputs["pullRequestId"])
 						assert.Equal(t, "head-ref-oid", inputs["expectedHeadOid"])
 						assert.Equal(t, "REBASE", inputs["updateMethod"])
@@ -308,7 +308,7 @@ func Test_updateBranchRun(t *testing.T) {
 								"message": "some error"
 							}
 						]
-					}`, func(_ string, inputs map[string]interface{}) {
+					}`, func(_ string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["pullRequestNumber"])
 						assert.Equal(t, "head-repository-owner:head-ref-name", inputs["headRef"])
 					}))
@@ -337,7 +337,7 @@ func Test_updateBranchRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(_ string, inputs map[string]interface{}) {
+					}`, func(_ string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["pullRequestNumber"])
 						assert.Equal(t, "head-repository-owner:head-ref-name", inputs["headRef"])
 					}))
@@ -350,7 +350,7 @@ func Test_updateBranchRun(t *testing.T) {
 								"message": "merge conflict between base and head (updatePullRequestBranch)"
 							}
 						]
-					}`, func(inputs map[string]interface{}) {
+					}`, func(inputs map[string]any) {
 						assert.Equal(t, "123", inputs["pullRequestId"])
 						assert.Equal(t, "head-ref-oid", inputs["expectedHeadOid"])
 						assert.Equal(t, "MERGE", inputs["updateMethod"])
@@ -381,7 +381,7 @@ func Test_updateBranchRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(_ string, inputs map[string]interface{}) {
+					}`, func(_ string, inputs map[string]any) {
 						assert.Equal(t, float64(123), inputs["pullRequestNumber"])
 						assert.Equal(t, "head-repository-owner:head-ref-name", inputs["headRef"])
 					}))
@@ -394,7 +394,7 @@ func Test_updateBranchRun(t *testing.T) {
 								"message": "some error"
 							}
 						]
-					}`, func(inputs map[string]interface{}) {
+					}`, func(inputs map[string]any) {
 						assert.Equal(t, "123", inputs["pullRequestId"])
 						assert.Equal(t, "head-ref-oid", inputs["expectedHeadOid"])
 						assert.Equal(t, "MERGE", inputs["updateMethod"])

--- a/pkg/cmd/project/close/close.go
+++ b/pkg/cmd/project/close/close.go
@@ -114,7 +114,7 @@ func closeArgs(config closeConfig) (*updateProjectMutation, map[string]any) {
 	return &updateProjectMutation{}, map[string]any{
 		"input": githubv4.UpdateProjectV2Input{
 			ProjectID: githubv4.ID(config.opts.projectID),
-			Closed:    githubv4.NewBoolean(githubv4.Boolean(closed)),
+			Closed:    new(githubv4.Boolean(closed)),
 		},
 		"firstItems":  githubv4.Int(0),
 		"afterItems":  (*githubv4.String)(nil),

--- a/pkg/cmd/project/close/close.go
+++ b/pkg/cmd/project/close/close.go
@@ -109,9 +109,9 @@ func runClose(config closeConfig) error {
 	return printResults(config, query.UpdateProjectV2.ProjectV2)
 }
 
-func closeArgs(config closeConfig) (*updateProjectMutation, map[string]interface{}) {
+func closeArgs(config closeConfig) (*updateProjectMutation, map[string]any) {
 	closed := !config.opts.reopen
-	return &updateProjectMutation{}, map[string]interface{}{
+	return &updateProjectMutation{}, map[string]any{
 		"input": githubv4.UpdateProjectV2Input{
 			ProjectID: githubv4.ID(config.opts.projectID),
 			Closed:    githubv4.NewBoolean(githubv4.Boolean(closed)),

--- a/pkg/cmd/project/close/close_test.go
+++ b/pkg/cmd/project/close/close_test.go
@@ -96,21 +96,21 @@ func TestRunClose_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -121,9 +121,9 @@ func TestRunClose_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -133,9 +133,9 @@ func TestRunClose_User(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -148,10 +148,10 @@ func TestRunClose_User(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","closed":true}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -192,21 +192,21 @@ func TestRunClose_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -217,9 +217,9 @@ func TestRunClose_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -229,9 +229,9 @@ func TestRunClose_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -244,10 +244,10 @@ func TestRunClose_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","closed":true}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -283,13 +283,13 @@ func TestRunClose_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -299,9 +299,9 @@ func TestRunClose_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -310,9 +310,9 @@ func TestRunClose_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -325,10 +325,10 @@ func TestRunClose_Me(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","closed":true}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -364,21 +364,21 @@ func TestRunClose_Reopen(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -389,9 +389,9 @@ func TestRunClose_Reopen(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -401,9 +401,9 @@ func TestRunClose_Reopen(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -416,10 +416,10 @@ func TestRunClose_Reopen(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","closed":false}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -461,21 +461,21 @@ func TestRunClose_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -486,9 +486,9 @@ func TestRunClose_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -498,9 +498,9 @@ func TestRunClose_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -513,14 +513,14 @@ func TestRunClose_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","closed":true}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"number": 1,
 						"title":  "a title",
 						"url":    "http://a-url.com",
-						"owner": map[string]interface{}{
+						"owner": map[string]any{
 							"__typename": "User",
 							"login":      "monalisa",
 						},

--- a/pkg/cmd/project/copy/copy.go
+++ b/pkg/cmd/project/copy/copy.go
@@ -119,8 +119,8 @@ func runCopy(config copyConfig) error {
 	return printResults(config, query.CopyProjectV2.ProjectV2)
 }
 
-func copyArgs(config copyConfig) (*copyProjectMutation, map[string]interface{}) {
-	return &copyProjectMutation{}, map[string]interface{}{
+func copyArgs(config copyConfig) (*copyProjectMutation, map[string]any) {
+	return &copyProjectMutation{}, map[string]any{
 		"input": githubv4.CopyProjectV2Input{
 			OwnerID:            githubv4.ID(config.opts.ownerID),
 			ProjectID:          githubv4.ID(config.opts.projectID),

--- a/pkg/cmd/project/copy/copy.go
+++ b/pkg/cmd/project/copy/copy.go
@@ -125,7 +125,7 @@ func copyArgs(config copyConfig) (*copyProjectMutation, map[string]any) {
 			OwnerID:            githubv4.ID(config.opts.ownerID),
 			ProjectID:          githubv4.ID(config.opts.projectID),
 			Title:              githubv4.String(config.opts.title),
-			IncludeDraftIssues: githubv4.NewBoolean(githubv4.Boolean(config.opts.includeDraftIssues)),
+			IncludeDraftIssues: new(githubv4.Boolean(config.opts.includeDraftIssues)),
 		},
 		"firstItems":  githubv4.Int(0),
 		"afterItems":  (*githubv4.String)(nil),

--- a/pkg/cmd/project/copy/copy_test.go
+++ b/pkg/cmd/project/copy/copy_test.go
@@ -120,9 +120,9 @@ func TestRunCopy_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -132,9 +132,9 @@ func TestRunCopy_User(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -146,22 +146,22 @@ func TestRunCopy_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id":    "an ID",
 					"login": "monalisa",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -172,22 +172,22 @@ func TestRunCopy_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id":    "an ID",
 					"login": "monalisa",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -199,10 +199,10 @@ func TestRunCopy_User(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"copyProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"copyProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -242,9 +242,9 @@ func TestRunCopy_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -254,9 +254,9 @@ func TestRunCopy_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -267,22 +267,22 @@ func TestRunCopy_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id":    "an ID",
 					"login": "github",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -293,22 +293,22 @@ func TestRunCopy_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id":    "an ID",
 					"login": "github",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -320,10 +320,10 @@ func TestRunCopy_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"copyProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"copyProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -363,9 +363,9 @@ func TestRunCopy_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -374,9 +374,9 @@ func TestRunCopy_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -388,13 +388,13 @@ func TestRunCopy_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id":    "an ID",
 					"login": "me",
 				},
@@ -405,13 +405,13 @@ func TestRunCopy_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id":    "an ID",
 					"login": "me",
 				},
@@ -422,10 +422,10 @@ func TestRunCopy_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"copyProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"copyProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -468,9 +468,9 @@ func TestRunCopy_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -480,9 +480,9 @@ func TestRunCopy_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -494,22 +494,22 @@ func TestRunCopy_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id":    "an ID",
 					"login": "monalisa",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -520,22 +520,22 @@ func TestRunCopy_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id":    "an ID",
 					"login": "monalisa",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -547,10 +547,10 @@ func TestRunCopy_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"copyProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"copyProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"number": 1,
 						"title":  "a title",
 						"url":    "http://a-url.com",

--- a/pkg/cmd/project/create/create.go
+++ b/pkg/cmd/project/create/create.go
@@ -91,8 +91,8 @@ func runCreate(config createConfig) error {
 	return printResults(config, query.CreateProjectV2.ProjectV2)
 }
 
-func createArgs(config createConfig) (*createProjectMutation, map[string]interface{}) {
-	return &createProjectMutation{}, map[string]interface{}{
+func createArgs(config createConfig) (*createProjectMutation, map[string]any) {
+	return &createProjectMutation{}, map[string]any{
 		"input": githubv4.CreateProjectV2Input{
 			OwnerID: githubv4.ID(config.opts.ownerID),
 			Title:   githubv4.String(config.opts.title),

--- a/pkg/cmd/project/create/create_test.go
+++ b/pkg/cmd/project/create/create_test.go
@@ -87,22 +87,22 @@ func TestRunCreate_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id":    "an ID",
 					"login": "monalisa",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -114,10 +114,10 @@ func TestRunCreate_User(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"ownerId":"an ID","title":"a title"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -156,22 +156,22 @@ func TestRunCreate_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id":    "an ID",
 					"login": "github",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -182,10 +182,10 @@ func TestRunCreate_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"ownerId":"an ID","title":"a title"}}}`).Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -224,13 +224,13 @@ func TestRunCreate_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id":    "an ID",
 					"login": "me",
 				},
@@ -241,10 +241,10 @@ func TestRunCreate_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"ownerId":"an ID","title":"a title"}}}`).Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -284,22 +284,22 @@ func TestRunCreate_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id":    "an ID",
 					"login": "monalisa",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -311,10 +311,10 @@ func TestRunCreate_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"ownerId":"an ID","title":"a title"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"number": 1,
 						"title":  "a title",
 						"url":    "http://a-url.com",

--- a/pkg/cmd/project/delete/delete.go
+++ b/pkg/cmd/project/delete/delete.go
@@ -103,8 +103,8 @@ func runDelete(config deleteConfig) error {
 
 }
 
-func deleteItemArgs(config deleteConfig) (*deleteProjectMutation, map[string]interface{}) {
-	return &deleteProjectMutation{}, map[string]interface{}{
+func deleteItemArgs(config deleteConfig) (*deleteProjectMutation, map[string]any) {
+	return &deleteProjectMutation{}, map[string]any{
 		"input": githubv4.DeleteProjectV2Input{
 			ProjectID: githubv4.ID(config.opts.projectID),
 		},

--- a/pkg/cmd/project/delete/delete_test.go
+++ b/pkg/cmd/project/delete/delete_test.go
@@ -89,21 +89,21 @@ func TestRunDelete_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -114,9 +114,9 @@ func TestRunDelete_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -126,10 +126,10 @@ func TestRunDelete_User(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -141,10 +141,10 @@ func TestRunDelete_User(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"deleteProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"deleteProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"id":     "project ID",
 						"number": 1,
 					},
@@ -181,21 +181,21 @@ func TestRunDelete_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -206,9 +206,9 @@ func TestRunDelete_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -218,10 +218,10 @@ func TestRunDelete_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -233,10 +233,10 @@ func TestRunDelete_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"deleteProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"deleteProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"id":     "project ID",
 						"number": 1,
 					},
@@ -273,13 +273,13 @@ func TestRunDelete_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -289,9 +289,9 @@ func TestRunDelete_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -300,10 +300,10 @@ func TestRunDelete_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -315,10 +315,10 @@ func TestRunDelete_Me(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"deleteProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"deleteProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"id":     "project ID",
 						"number": 1,
 					},
@@ -355,21 +355,21 @@ func TestRunDelete_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -380,9 +380,9 @@ func TestRunDelete_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -392,10 +392,10 @@ func TestRunDelete_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -407,10 +407,10 @@ func TestRunDelete_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"deleteProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"deleteProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"id":     "project ID",
 						"number": 1,
 					},

--- a/pkg/cmd/project/edit/edit.go
+++ b/pkg/cmd/project/edit/edit.go
@@ -116,7 +116,7 @@ func runEdit(config editConfig) error {
 	return printResults(config, query.UpdateProjectV2.ProjectV2)
 }
 
-func editArgs(config editConfig) (*updateProjectMutation, map[string]interface{}) {
+func editArgs(config editConfig) (*updateProjectMutation, map[string]any) {
 	variables := githubv4.UpdateProjectV2Input{ProjectID: githubv4.ID(config.opts.projectID)}
 	if config.opts.title != "" {
 		variables.Title = githubv4.NewString(githubv4.String(config.opts.title))
@@ -135,7 +135,7 @@ func editArgs(config editConfig) (*updateProjectMutation, map[string]interface{}
 		}
 	}
 
-	return &updateProjectMutation{}, map[string]interface{}{
+	return &updateProjectMutation{}, map[string]any{
 		"input":       variables,
 		"firstItems":  githubv4.Int(0),
 		"afterItems":  (*githubv4.String)(nil),

--- a/pkg/cmd/project/edit/edit.go
+++ b/pkg/cmd/project/edit/edit.go
@@ -119,13 +119,13 @@ func runEdit(config editConfig) error {
 func editArgs(config editConfig) (*updateProjectMutation, map[string]any) {
 	variables := githubv4.UpdateProjectV2Input{ProjectID: githubv4.ID(config.opts.projectID)}
 	if config.opts.title != "" {
-		variables.Title = githubv4.NewString(githubv4.String(config.opts.title))
+		variables.Title = new(githubv4.String(config.opts.title))
 	}
 	if config.opts.shortDescription != "" {
-		variables.ShortDescription = githubv4.NewString(githubv4.String(config.opts.shortDescription))
+		variables.ShortDescription = new(githubv4.String(config.opts.shortDescription))
 	}
 	if config.opts.readme != "" {
-		variables.Readme = githubv4.NewString(githubv4.String(config.opts.readme))
+		variables.Readme = new(githubv4.String(config.opts.readme))
 	}
 	if config.opts.visibility != "" {
 		if config.opts.visibility == projectVisibilityPublic {

--- a/pkg/cmd/project/edit/edit_test.go
+++ b/pkg/cmd/project/edit/edit_test.go
@@ -138,21 +138,21 @@ func TestRunUpdate_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -163,9 +163,9 @@ func TestRunUpdate_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -175,9 +175,9 @@ func TestRunUpdate_User(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -190,10 +190,10 @@ func TestRunUpdate_User(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -236,21 +236,21 @@ func TestRunUpdate_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -261,9 +261,9 @@ func TestRunUpdate_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -273,9 +273,9 @@ func TestRunUpdate_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -288,10 +288,10 @@ func TestRunUpdate_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -333,13 +333,13 @@ func TestRunUpdate_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -350,9 +350,9 @@ func TestRunUpdate_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -361,9 +361,9 @@ func TestRunUpdate_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -376,10 +376,10 @@ func TestRunUpdate_Me(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":false}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -422,21 +422,21 @@ func TestRunUpdate_OmitParams(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -447,9 +447,9 @@ func TestRunUpdate_OmitParams(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -459,9 +459,9 @@ func TestRunUpdate_OmitParams(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -474,10 +474,10 @@ func TestRunUpdate_OmitParams(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","title":"another title"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"title": "a title",
 						"url":   "http://a-url.com",
 						"owner": map[string]string{
@@ -518,21 +518,21 @@ func TestRunUpdate_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -543,9 +543,9 @@ func TestRunUpdate_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -555,9 +555,9 @@ func TestRunUpdate_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id": "an ID",
 					},
@@ -570,10 +570,10 @@ func TestRunUpdate_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2": map[string]any{
+					"projectV2": map[string]any{
 						"number": 1,
 						"title":  "a title",
 						"url":    "http://a-url.com",

--- a/pkg/cmd/project/field-create/field_create.go
+++ b/pkg/cmd/project/field-create/field_create.go
@@ -119,7 +119,7 @@ func runCreateField(config createFieldConfig) error {
 	return printResults(config, query.CreateProjectV2Field.Field)
 }
 
-func createFieldArgs(config createFieldConfig) (*createProjectV2FieldMutation, map[string]interface{}) {
+func createFieldArgs(config createFieldConfig) (*createProjectV2FieldMutation, map[string]any) {
 	input := githubv4.CreateProjectV2FieldInput{
 		ProjectID: githubv4.ID(config.opts.projectID),
 		DataType:  githubv4.ProjectV2CustomFieldType(config.opts.dataType),
@@ -137,7 +137,7 @@ func createFieldArgs(config createFieldConfig) (*createProjectV2FieldMutation, m
 		input.SingleSelectOptions = &opts
 	}
 
-	return &createProjectV2FieldMutation{}, map[string]interface{}{
+	return &createProjectV2FieldMutation{}, map[string]any{
 		"input": input,
 	}
 }

--- a/pkg/cmd/project/field-create/field_create_test.go
+++ b/pkg/cmd/project/field-create/field_create_test.go
@@ -124,21 +124,21 @@ func TestRunCreateField_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -149,9 +149,9 @@ func TestRunCreateField_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -161,10 +161,10 @@ func TestRunCreateField_User(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -176,10 +176,10 @@ func TestRunCreateField_User(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateField.*","variables":{"input":{"projectId":"an ID","dataType":"TEXT","name":"a name"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2Field": map[string]interface{}{
-					"projectV2Field": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2Field": map[string]any{
+					"projectV2Field": map[string]any{
 						"id": "Field ID",
 					},
 				},
@@ -217,21 +217,21 @@ func TestRunCreateField_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -242,9 +242,9 @@ func TestRunCreateField_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -254,10 +254,10 @@ func TestRunCreateField_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -269,10 +269,10 @@ func TestRunCreateField_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateField.*","variables":{"input":{"projectId":"an ID","dataType":"TEXT","name":"a name"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2Field": map[string]interface{}{
-					"projectV2Field": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2Field": map[string]any{
+					"projectV2Field": map[string]any{
 						"id": "Field ID",
 					},
 				},
@@ -309,13 +309,13 @@ func TestRunCreateField_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -325,9 +325,9 @@ func TestRunCreateField_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -336,10 +336,10 @@ func TestRunCreateField_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -351,10 +351,10 @@ func TestRunCreateField_Me(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateField.*","variables":{"input":{"projectId":"an ID","dataType":"TEXT","name":"a name"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2Field": map[string]interface{}{
-					"projectV2Field": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2Field": map[string]any{
+					"projectV2Field": map[string]any{
 						"id": "Field ID",
 					},
 				},
@@ -391,13 +391,13 @@ func TestRunCreateField_TEXT(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -407,9 +407,9 @@ func TestRunCreateField_TEXT(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -418,10 +418,10 @@ func TestRunCreateField_TEXT(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -433,10 +433,10 @@ func TestRunCreateField_TEXT(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateField.*","variables":{"input":{"projectId":"an ID","dataType":"TEXT","name":"a name"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2Field": map[string]interface{}{
-					"projectV2Field": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2Field": map[string]any{
+					"projectV2Field": map[string]any{
 						"id": "Field ID",
 					},
 				},
@@ -473,13 +473,13 @@ func TestRunCreateField_DATE(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -489,9 +489,9 @@ func TestRunCreateField_DATE(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -500,10 +500,10 @@ func TestRunCreateField_DATE(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -515,10 +515,10 @@ func TestRunCreateField_DATE(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateField.*","variables":{"input":{"projectId":"an ID","dataType":"DATE","name":"a name"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2Field": map[string]interface{}{
-					"projectV2Field": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2Field": map[string]any{
+					"projectV2Field": map[string]any{
 						"id": "Field ID",
 					},
 				},
@@ -555,13 +555,13 @@ func TestRunCreateField_NUMBER(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -571,9 +571,9 @@ func TestRunCreateField_NUMBER(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -582,10 +582,10 @@ func TestRunCreateField_NUMBER(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -597,10 +597,10 @@ func TestRunCreateField_NUMBER(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateField.*","variables":{"input":{"projectId":"an ID","dataType":"NUMBER","name":"a name"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2Field": map[string]interface{}{
-					"projectV2Field": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2Field": map[string]any{
+					"projectV2Field": map[string]any{
 						"id": "Field ID",
 					},
 				},
@@ -638,21 +638,21 @@ func TestRunCreateField_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -663,9 +663,9 @@ func TestRunCreateField_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -675,10 +675,10 @@ func TestRunCreateField_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -690,10 +690,10 @@ func TestRunCreateField_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateField.*","variables":{"input":{"projectId":"an ID","dataType":"TEXT","name":"a name"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"createProjectV2Field": map[string]interface{}{
-					"projectV2Field": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createProjectV2Field": map[string]any{
+					"projectV2Field": map[string]any{
 						"__typename": "ProjectV2Field",
 						"id":         "Field ID",
 						"name":       "a name",

--- a/pkg/cmd/project/field-delete/field_delete.go
+++ b/pkg/cmd/project/field-delete/field_delete.go
@@ -76,8 +76,8 @@ func runDeleteField(config deleteFieldConfig) error {
 	return printResults(config, query.DeleteProjectV2Field.Field)
 }
 
-func deleteFieldArgs(config deleteFieldConfig) (*deleteProjectV2FieldMutation, map[string]interface{}) {
-	return &deleteProjectV2FieldMutation{}, map[string]interface{}{
+func deleteFieldArgs(config deleteFieldConfig) (*deleteProjectV2FieldMutation, map[string]any) {
+	return &deleteProjectV2FieldMutation{}, map[string]any{
 		"input": githubv4.DeleteProjectV2FieldInput{
 			FieldID: githubv4.ID(config.opts.fieldID),
 		},

--- a/pkg/cmd/project/field-delete/field_delete_test.go
+++ b/pkg/cmd/project/field-delete/field_delete_test.go
@@ -85,10 +85,10 @@ func TestRunDeleteField(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation DeleteField.*","variables":{"input":{"fieldId":"an ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"deleteProjectV2Field": map[string]interface{}{
-					"projectV2Field": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"deleteProjectV2Field": map[string]any{
+					"projectV2Field": map[string]any{
 						"id": "Field ID",
 					},
 				},
@@ -124,10 +124,10 @@ func TestRunDeleteField_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation DeleteField.*","variables":{"input":{"fieldId":"an ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"deleteProjectV2Field": map[string]interface{}{
-					"projectV2Field": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"deleteProjectV2Field": map[string]any{
+					"projectV2Field": map[string]any{
 						"__typename": "ProjectV2Field",
 						"id":         "Field ID",
 						"name":       "a name",

--- a/pkg/cmd/project/field-list/field_list_test.go
+++ b/pkg/cmd/project/field-list/field_list_test.go
@@ -96,21 +96,21 @@ func TestRunList_User_tty(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -120,9 +120,9 @@ func TestRunList_User_tty(t *testing.T) {
 	// list project fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  queries.LimitMax,
@@ -132,12 +132,12 @@ func TestRunList_User_tty(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2Field",
 									"name":       "FieldTitle",
@@ -191,21 +191,21 @@ func TestRunList_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -215,9 +215,9 @@ func TestRunList_User(t *testing.T) {
 	// list project fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  queries.LimitMax,
@@ -227,12 +227,12 @@ func TestRunList_User(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2Field",
 									"name":       "FieldTitle",
@@ -283,21 +283,21 @@ func TestRunList_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -307,9 +307,9 @@ func TestRunList_Org(t *testing.T) {
 	// list project fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  queries.LimitMax,
@@ -319,12 +319,12 @@ func TestRunList_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2Field",
 									"name":       "FieldTitle",
@@ -375,13 +375,13 @@ func TestRunList_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -390,9 +390,9 @@ func TestRunList_Me(t *testing.T) {
 	// list project fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  queries.LimitMax,
 				"afterItems":  nil,
@@ -401,12 +401,12 @@ func TestRunList_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2Field",
 									"name":       "FieldTitle",
@@ -457,13 +457,13 @@ func TestRunList_Empty(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -472,9 +472,9 @@ func TestRunList_Empty(t *testing.T) {
 	// list project fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  queries.LimitMax,
 				"afterItems":  nil,
@@ -483,11 +483,11 @@ func TestRunList_Empty(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
 							"nodes": nil,
 						},
 					},
@@ -522,21 +522,21 @@ func TestRunList_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -546,9 +546,9 @@ func TestRunList_JSON(t *testing.T) {
 	// list project fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  queries.LimitMax,
@@ -558,12 +558,12 @@ func TestRunList_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2Field",
 									"name":       "FieldTitle",

--- a/pkg/cmd/project/item-add/item_add.go
+++ b/pkg/cmd/project/item-add/item_add.go
@@ -114,8 +114,8 @@ func runAddItem(config addItemConfig) error {
 
 }
 
-func addItemArgs(config addItemConfig) (*addProjectItemMutation, map[string]interface{}) {
-	return &addProjectItemMutation{}, map[string]interface{}{
+func addItemArgs(config addItemConfig) (*addProjectItemMutation, map[string]any) {
+	return &addProjectItemMutation{}, map[string]any{
 		"input": githubv4.AddProjectV2ItemByIdInput{
 			ProjectID: githubv4.ID(config.opts.projectID),
 			ContentID: githubv4.ID(config.opts.itemID),

--- a/pkg/cmd/project/item-add/item_add_test.go
+++ b/pkg/cmd/project/item-add/item_add_test.go
@@ -106,21 +106,21 @@ func setupRunAddItemUserMocks() {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -131,9 +131,9 @@ func setupRunAddItemUserMocks() {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -143,10 +143,10 @@ func setupRunAddItemUserMocks() {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -157,16 +157,16 @@ func setupRunAddItemUserMocks() {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query GetIssueOrPullRequest.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"url": "https://github.com/cli/go-gh/issues/1",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"resource": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"resource": map[string]any{
 					"id":         "item ID",
 					"__typename": "Issue",
 				},
@@ -178,10 +178,10 @@ func setupRunAddItemUserMocks() {
 		Post("/graphql").
 		BodyString(`{"query":"mutation AddItem.*","variables":{"input":{"projectId":"an ID","contentId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"addProjectV2ItemById": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"addProjectV2ItemById": map[string]any{
+					"item": map[string]any{
 						"id": "project item ID",
 					},
 				},
@@ -240,21 +240,21 @@ func TestRunAddItem_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -265,9 +265,9 @@ func TestRunAddItem_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -277,10 +277,10 @@ func TestRunAddItem_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -291,16 +291,16 @@ func TestRunAddItem_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query GetIssueOrPullRequest.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"url": "https://github.com/cli/go-gh/issues/1",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"resource": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"resource": map[string]any{
 					"id":         "item ID",
 					"__typename": "Issue",
 				},
@@ -312,10 +312,10 @@ func TestRunAddItem_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation AddItem.*","variables":{"input":{"projectId":"an ID","contentId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"addProjectV2ItemById": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"addProjectV2ItemById": map[string]any{
+					"item": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -351,13 +351,13 @@ func TestRunAddItem_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -367,9 +367,9 @@ func TestRunAddItem_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -378,10 +378,10 @@ func TestRunAddItem_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -392,16 +392,16 @@ func TestRunAddItem_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query GetIssueOrPullRequest.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"url": "https://github.com/cli/go-gh/pull/1",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"resource": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"resource": map[string]any{
 					"id":         "item ID",
 					"__typename": "PullRequest",
 				},
@@ -413,10 +413,10 @@ func TestRunAddItem_Me(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation AddItem.*","variables":{"input":{"projectId":"an ID","contentId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"addProjectV2ItemById": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"addProjectV2ItemById": map[string]any{
+					"item": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -453,21 +453,21 @@ func TestRunAddItem_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -478,9 +478,9 @@ func TestRunAddItem_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -490,10 +490,10 @@ func TestRunAddItem_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -504,16 +504,16 @@ func TestRunAddItem_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query GetIssueOrPullRequest.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"url": "https://github.com/cli/go-gh/issues/1",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"resource": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"resource": map[string]any{
 					"id":         "item ID",
 					"__typename": "Issue",
 				},
@@ -525,12 +525,12 @@ func TestRunAddItem_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation AddItem.*","variables":{"input":{"projectId":"an ID","contentId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"addProjectV2ItemById": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"addProjectV2ItemById": map[string]any{
+					"item": map[string]any{
 						"id": "item ID",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Issue",
 							"title":      "a title",
 						},

--- a/pkg/cmd/project/item-archive/item_archive.go
+++ b/pkg/cmd/project/item-archive/item_archive.go
@@ -127,8 +127,8 @@ func runArchiveItem(config archiveItemConfig) error {
 	return printResults(config, query.ArchiveProjectItem.ProjectV2Item)
 }
 
-func archiveItemArgs(config archiveItemConfig) (*archiveProjectItemMutation, map[string]interface{}) {
-	return &archiveProjectItemMutation{}, map[string]interface{}{
+func archiveItemArgs(config archiveItemConfig) (*archiveProjectItemMutation, map[string]any) {
+	return &archiveProjectItemMutation{}, map[string]any{
 		"input": githubv4.ArchiveProjectV2ItemInput{
 			ProjectID: githubv4.ID(config.opts.projectID),
 			ItemID:    githubv4.ID(config.opts.itemID),
@@ -136,8 +136,8 @@ func archiveItemArgs(config archiveItemConfig) (*archiveProjectItemMutation, map
 	}
 }
 
-func unarchiveItemArgs(config archiveItemConfig, itemID string) (*unarchiveProjectItemMutation, map[string]interface{}) {
-	return &unarchiveProjectItemMutation{}, map[string]interface{}{
+func unarchiveItemArgs(config archiveItemConfig, itemID string) (*unarchiveProjectItemMutation, map[string]any) {
+	return &unarchiveProjectItemMutation{}, map[string]any{
 		"input": githubv4.UnarchiveProjectV2ItemInput{
 			ProjectID: githubv4.ID(config.opts.projectID),
 			ItemID:    githubv4.ID(itemID),

--- a/pkg/cmd/project/item-archive/item_archive_test.go
+++ b/pkg/cmd/project/item-archive/item_archive_test.go
@@ -117,21 +117,21 @@ func TestRunArchive_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -142,9 +142,9 @@ func TestRunArchive_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -154,10 +154,10 @@ func TestRunArchive_User(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -169,10 +169,10 @@ func TestRunArchive_User(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation ArchiveProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"archiveProjectV2Item": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"archiveProjectV2Item": map[string]any{
+					"item": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -208,21 +208,21 @@ func TestRunArchive_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -233,9 +233,9 @@ func TestRunArchive_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -245,10 +245,10 @@ func TestRunArchive_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -260,10 +260,10 @@ func TestRunArchive_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation ArchiveProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"archiveProjectV2Item": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"archiveProjectV2Item": map[string]any{
+					"item": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -299,13 +299,13 @@ func TestRunArchive_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -315,9 +315,9 @@ func TestRunArchive_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -326,10 +326,10 @@ func TestRunArchive_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -341,10 +341,10 @@ func TestRunArchive_Me(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation ArchiveProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"archiveProjectV2Item": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"archiveProjectV2Item": map[string]any{
+					"item": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -380,21 +380,21 @@ func TestRunArchive_User_Undo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -405,9 +405,9 @@ func TestRunArchive_User_Undo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -417,10 +417,10 @@ func TestRunArchive_User_Undo(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -432,10 +432,10 @@ func TestRunArchive_User_Undo(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UnarchiveProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"unarchiveProjectV2Item": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"unarchiveProjectV2Item": map[string]any{
+					"item": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -471,21 +471,21 @@ func TestRunArchive_Org_Undo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -496,9 +496,9 @@ func TestRunArchive_Org_Undo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -508,10 +508,10 @@ func TestRunArchive_Org_Undo(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -523,10 +523,10 @@ func TestRunArchive_Org_Undo(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UnarchiveProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"unarchiveProjectV2Item": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"unarchiveProjectV2Item": map[string]any{
+					"item": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -563,13 +563,13 @@ func TestRunArchive_Me_Undo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -579,9 +579,9 @@ func TestRunArchive_Me_Undo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -590,10 +590,10 @@ func TestRunArchive_Me_Undo(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -605,10 +605,10 @@ func TestRunArchive_Me_Undo(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UnarchiveProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"unarchiveProjectV2Item": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"unarchiveProjectV2Item": map[string]any{
+					"item": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -645,21 +645,21 @@ func TestRunArchive_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -670,9 +670,9 @@ func TestRunArchive_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -682,10 +682,10 @@ func TestRunArchive_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -697,12 +697,12 @@ func TestRunArchive_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation ArchiveProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"archiveProjectV2Item": map[string]interface{}{
-					"item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"archiveProjectV2Item": map[string]any{
+					"item": map[string]any{
 						"id": "item ID",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Issue",
 							"title":      "a title",
 						},

--- a/pkg/cmd/project/item-create/item_create.go
+++ b/pkg/cmd/project/item-create/item_create.go
@@ -112,7 +112,7 @@ func runCreateItem(config createItemConfig) error {
 func createDraftIssueArgs(config createItemConfig) (*createProjectDraftItemMutation, map[string]any) {
 	return &createProjectDraftItemMutation{}, map[string]any{
 		"input": githubv4.AddProjectV2DraftIssueInput{
-			Body:      githubv4.NewString(githubv4.String(config.opts.body)),
+			Body:      new(githubv4.String(config.opts.body)),
 			ProjectID: githubv4.ID(config.opts.projectID),
 			Title:     githubv4.String(config.opts.title),
 		},

--- a/pkg/cmd/project/item-create/item_create.go
+++ b/pkg/cmd/project/item-create/item_create.go
@@ -109,8 +109,8 @@ func runCreateItem(config createItemConfig) error {
 	return printResults(config, query.CreateProjectDraftItem.ProjectV2Item)
 }
 
-func createDraftIssueArgs(config createItemConfig) (*createProjectDraftItemMutation, map[string]interface{}) {
-	return &createProjectDraftItemMutation{}, map[string]interface{}{
+func createDraftIssueArgs(config createItemConfig) (*createProjectDraftItemMutation, map[string]any) {
+	return &createProjectDraftItemMutation{}, map[string]any{
 		"input": githubv4.AddProjectV2DraftIssueInput{
 			Body:      githubv4.NewString(githubv4.String(config.opts.body)),
 			ProjectID: githubv4.ID(config.opts.projectID),

--- a/pkg/cmd/project/item-create/item_create_test.go
+++ b/pkg/cmd/project/item-create/item_create_test.go
@@ -115,21 +115,21 @@ func TestRunCreateItem_Draft_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -140,9 +140,9 @@ func TestRunCreateItem_Draft_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -152,10 +152,10 @@ func TestRunCreateItem_Draft_User(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -167,10 +167,10 @@ func TestRunCreateItem_Draft_User(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateDraftItem.*","variables":{"input":{"projectId":"an ID","title":"a title","body":""}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"addProjectV2DraftIssue": map[string]interface{}{
-					"projectItem": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"addProjectV2DraftIssue": map[string]any{
+					"projectItem": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -206,21 +206,21 @@ func TestRunCreateItem_Draft_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -231,9 +231,9 @@ func TestRunCreateItem_Draft_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -243,10 +243,10 @@ func TestRunCreateItem_Draft_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -258,10 +258,10 @@ func TestRunCreateItem_Draft_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateDraftItem.*","variables":{"input":{"projectId":"an ID","title":"a title","body":""}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"addProjectV2DraftIssue": map[string]interface{}{
-					"projectItem": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"addProjectV2DraftIssue": map[string]any{
+					"projectItem": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -297,13 +297,13 @@ func TestRunCreateItem_Draft_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -313,9 +313,9 @@ func TestRunCreateItem_Draft_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -324,10 +324,10 @@ func TestRunCreateItem_Draft_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -339,10 +339,10 @@ func TestRunCreateItem_Draft_Me(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateDraftItem.*","variables":{"input":{"projectId":"an ID","title":"a title","body":"a body"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"addProjectV2DraftIssue": map[string]interface{}{
-					"projectItem": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"addProjectV2DraftIssue": map[string]any{
+					"projectItem": map[string]any{
 						"id": "item ID",
 					},
 				},
@@ -379,21 +379,21 @@ func TestRunCreateItem_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -404,9 +404,9 @@ func TestRunCreateItem_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -416,10 +416,10 @@ func TestRunCreateItem_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -431,12 +431,12 @@ func TestRunCreateItem_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation CreateDraftItem.*","variables":{"input":{"projectId":"an ID","title":"a title","body":""}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"addProjectV2DraftIssue": map[string]interface{}{
-					"projectItem": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"addProjectV2DraftIssue": map[string]any{
+					"projectItem": map[string]any{
 						"id": "item ID",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Draft",
 							"title":      "a title",
 						},

--- a/pkg/cmd/project/item-delete/item_delete.go
+++ b/pkg/cmd/project/item-delete/item_delete.go
@@ -107,8 +107,8 @@ func runDeleteItem(config deleteItemConfig) error {
 
 }
 
-func deleteItemArgs(config deleteItemConfig) (*deleteProjectItemMutation, map[string]interface{}) {
-	return &deleteProjectItemMutation{}, map[string]interface{}{
+func deleteItemArgs(config deleteItemConfig) (*deleteProjectItemMutation, map[string]any) {
+	return &deleteProjectItemMutation{}, map[string]any{
 		"input": githubv4.DeleteProjectV2ItemInput{
 			ProjectID: githubv4.ID(config.opts.projectID),
 			ItemID:    githubv4.ID(config.opts.itemID),
@@ -126,7 +126,7 @@ func printResults(config deleteItemConfig) error {
 }
 
 func printJSON(config deleteItemConfig, id githubv4.ID) error {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"id": id,
 	}
 	return config.opts.exporter.Write(config.io, m)

--- a/pkg/cmd/project/item-delete/item_delete_test.go
+++ b/pkg/cmd/project/item-delete/item_delete_test.go
@@ -107,21 +107,21 @@ func TestRunDelete_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -132,9 +132,9 @@ func TestRunDelete_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -144,10 +144,10 @@ func TestRunDelete_User(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -159,9 +159,9 @@ func TestRunDelete_User(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation DeleteProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"deleteProjectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"deleteProjectV2Item": map[string]any{
 					"deletedItemId": "item ID",
 				},
 			},
@@ -196,21 +196,21 @@ func TestRunDelete_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -221,9 +221,9 @@ func TestRunDelete_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -233,10 +233,10 @@ func TestRunDelete_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -248,9 +248,9 @@ func TestRunDelete_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation DeleteProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"deleteProjectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"deleteProjectV2Item": map[string]any{
 					"deletedItemId": "item ID",
 				},
 			},
@@ -285,13 +285,13 @@ func TestRunDelete_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -301,9 +301,9 @@ func TestRunDelete_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"number":      1,
 				"firstItems":  0,
 				"afterItems":  nil,
@@ -312,10 +312,10 @@ func TestRunDelete_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -327,9 +327,9 @@ func TestRunDelete_Me(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation DeleteProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"deleteProjectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"deleteProjectV2Item": map[string]any{
 					"deletedItemId": "item ID",
 				},
 			},
@@ -364,21 +364,21 @@ func TestRunDelete_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -389,9 +389,9 @@ func TestRunDelete_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -401,10 +401,10 @@ func TestRunDelete_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -416,9 +416,9 @@ func TestRunDelete_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation DeleteProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"deleteProjectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"deleteProjectV2Item": map[string]any{
 					"deletedItemId": "item ID",
 				},
 			},

--- a/pkg/cmd/project/item-edit/item_edit.go
+++ b/pkg/cmd/project/item-edit/item_edit.go
@@ -345,17 +345,17 @@ func buildEditDraftIssue(config editItemConfig, currentDraftIssue *queries.Draft
 	}
 
 	if config.opts.titleChanged {
-		input.Title = githubv4.NewString(githubv4.String(config.opts.title))
+		input.Title = new(githubv4.String(config.opts.title))
 	} else if currentDraftIssue != nil {
 		// Preserve existing if title is not provided
-		input.Title = githubv4.NewString(githubv4.String(currentDraftIssue.Title))
+		input.Title = new(githubv4.String(currentDraftIssue.Title))
 	}
 
 	if config.opts.bodyChanged {
-		input.Body = githubv4.NewString(githubv4.String(config.opts.body))
+		input.Body = new(githubv4.String(config.opts.body))
 	} else if currentDraftIssue != nil {
 		// Preserve existing if body is not provided
-		input.Body = githubv4.NewString(githubv4.String(currentDraftIssue.Body))
+		input.Body = new(githubv4.String(currentDraftIssue.Body))
 	}
 
 	return &EditProjectDraftIssue{}, map[string]any{
@@ -367,23 +367,23 @@ func buildUpdateItem(config editItemConfig, date time.Time) (*UpdateProjectV2Fie
 	var value githubv4.ProjectV2FieldValue
 	if config.opts.text != "" {
 		value = githubv4.ProjectV2FieldValue{
-			Text: githubv4.NewString(githubv4.String(config.opts.text)),
+			Text: new(githubv4.String(config.opts.text)),
 		}
 	} else if config.opts.numberChanged {
 		value = githubv4.ProjectV2FieldValue{
-			Number: githubv4.NewFloat(githubv4.Float(config.opts.number)),
+			Number: new(githubv4.Float(config.opts.number)),
 		}
 	} else if config.opts.date != "" {
 		value = githubv4.ProjectV2FieldValue{
-			Date: githubv4.NewDate(githubv4.Date{Time: date}),
+			Date: new(githubv4.Date{Time: date}),
 		}
 	} else if config.opts.singleSelectOptionID != "" {
 		value = githubv4.ProjectV2FieldValue{
-			SingleSelectOptionID: githubv4.NewString(githubv4.String(config.opts.singleSelectOptionID)),
+			SingleSelectOptionID: new(githubv4.String(config.opts.singleSelectOptionID)),
 		}
 	} else if config.opts.iterationID != "" {
 		value = githubv4.ProjectV2FieldValue{
-			IterationID: githubv4.NewString(githubv4.String(config.opts.iterationID)),
+			IterationID: new(githubv4.String(config.opts.iterationID)),
 		}
 	}
 

--- a/pkg/cmd/project/item-edit/item_edit.go
+++ b/pkg/cmd/project/item-edit/item_edit.go
@@ -327,7 +327,7 @@ func resolveItemEditNames(config editItemConfig) (editItemConfig, error) {
 
 func fetchDraftIssueByID(config editItemConfig, draftIssueID string) (*queries.DraftIssue, error) {
 	var query DraftIssueQuery
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id": githubv4.ID(draftIssueID),
 	}
 
@@ -339,7 +339,7 @@ func fetchDraftIssueByID(config editItemConfig, draftIssueID string) (*queries.D
 	return &query.DraftIssueNode.DraftIssue, nil
 }
 
-func buildEditDraftIssue(config editItemConfig, currentDraftIssue *queries.DraftIssue) (*EditProjectDraftIssue, map[string]interface{}) {
+func buildEditDraftIssue(config editItemConfig, currentDraftIssue *queries.DraftIssue) (*EditProjectDraftIssue, map[string]any) {
 	input := githubv4.UpdateProjectV2DraftIssueInput{
 		DraftIssueID: githubv4.ID(config.opts.itemID),
 	}
@@ -358,12 +358,12 @@ func buildEditDraftIssue(config editItemConfig, currentDraftIssue *queries.Draft
 		input.Body = githubv4.NewString(githubv4.String(currentDraftIssue.Body))
 	}
 
-	return &EditProjectDraftIssue{}, map[string]interface{}{
+	return &EditProjectDraftIssue{}, map[string]any{
 		"input": input,
 	}
 }
 
-func buildUpdateItem(config editItemConfig, date time.Time) (*UpdateProjectV2FieldValue, map[string]interface{}) {
+func buildUpdateItem(config editItemConfig, date time.Time) (*UpdateProjectV2FieldValue, map[string]any) {
 	var value githubv4.ProjectV2FieldValue
 	if config.opts.text != "" {
 		value = githubv4.ProjectV2FieldValue{
@@ -387,7 +387,7 @@ func buildUpdateItem(config editItemConfig, date time.Time) (*UpdateProjectV2Fie
 		}
 	}
 
-	return &UpdateProjectV2FieldValue{}, map[string]interface{}{
+	return &UpdateProjectV2FieldValue{}, map[string]any{
 		"input": githubv4.UpdateProjectV2ItemFieldValueInput{
 			ProjectID: githubv4.ID(config.opts.projectID),
 			ItemID:    githubv4.ID(config.opts.itemID),
@@ -397,8 +397,8 @@ func buildUpdateItem(config editItemConfig, date time.Time) (*UpdateProjectV2Fie
 	}
 }
 
-func buildClearItem(config editItemConfig) (*ClearProjectV2FieldValue, map[string]interface{}) {
-	return &ClearProjectV2FieldValue{}, map[string]interface{}{
+func buildClearItem(config editItemConfig) (*ClearProjectV2FieldValue, map[string]any) {
+	return &ClearProjectV2FieldValue{}, map[string]any{
 		"input": githubv4.ClearProjectV2ItemFieldValueInput{
 			ProjectID: githubv4.ID(config.opts.projectID),
 			ItemID:    githubv4.ID(config.opts.itemID),

--- a/pkg/cmd/project/item-edit/item_edit_test.go
+++ b/pkg/cmd/project/item-edit/item_edit_test.go
@@ -255,10 +255,10 @@ func TestRunItemEdit_Draft(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation EditDraftIssueItem.*","variables":{"input":{"draftIssueId":"DI_item_id","title":"a title","body":"a new body"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2DraftIssue": map[string]interface{}{
-					"draftIssue": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2DraftIssue": map[string]any{
+					"draftIssue": map[string]any{
 						"title": "a title",
 						"body":  "a new body",
 					},
@@ -298,9 +298,9 @@ func TestRunItemEdit_DraftTitleOnly(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"query DraftIssueByID.*","variables":{"id":"DI_item_id"}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"node": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"node": map[string]any{
 					"id":    "DI_item_id",
 					"title": "existing title",
 					"body":  "existing body",
@@ -312,10 +312,10 @@ func TestRunItemEdit_DraftTitleOnly(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation EditDraftIssueItem.*","variables":{"input":{"draftIssueId":"DI_item_id","title":"new title","body":"existing body"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2DraftIssue": map[string]interface{}{
-					"draftIssue": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2DraftIssue": map[string]any{
+					"draftIssue": map[string]any{
 						"title": "new title",
 						"body":  "existing body",
 					},
@@ -354,9 +354,9 @@ func TestRunItemEdit_DraftBodyOnly(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"query DraftIssueByID.*","variables":{"id":"DI_item_id"}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"node": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"node": map[string]any{
 					"id":    "DI_item_id",
 					"title": "existing title",
 					"body":  "existing body",
@@ -368,10 +368,10 @@ func TestRunItemEdit_DraftBodyOnly(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation EditDraftIssueItem.*","variables":{"input":{"draftIssueId":"DI_item_id","title":"existing title","body":"new body"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2DraftIssue": map[string]interface{}{
-					"draftIssue": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2DraftIssue": map[string]any{
+					"draftIssue": map[string]any{
 						"title": "existing title",
 						"body":  "new body",
 					},
@@ -410,8 +410,8 @@ func TestRunItemEdit_DraftFetchError(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"query DraftIssueByID.*","variables":{"id":"DI_item_id"}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"errors": []map[string]interface{}{
+		JSON(map[string]any{
+			"errors": []map[string]any{
 				{
 					"type":    "NOT_FOUND",
 					"message": "Could not resolve to a node with the global id of 'DI_item_id' (node)",
@@ -448,16 +448,16 @@ func TestRunItemEdit_Text(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"text":"item text"}}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2ItemFieldValue": map[string]interface{}{
-					"projectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2ItemFieldValue": map[string]any{
+					"projectV2Item": map[string]any{
 						"ID": "item_id",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"body":   "body",
 							"title":  "title",
 							"number": 1,
-							"repository": map[string]interface{}{
+							"repository": map[string]any{
 								"nameWithOwner": "my-repo",
 							},
 						},
@@ -494,17 +494,17 @@ func TestRunItemEdit_Number(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"number":123.45}}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2ItemFieldValue": map[string]interface{}{
-					"projectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2ItemFieldValue": map[string]any{
+					"projectV2Item": map[string]any{
 						"ID": "item_id",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Issue",
 							"body":       "body",
 							"title":      "title",
 							"number":     1,
-							"repository": map[string]interface{}{
+							"repository": map[string]any{
 								"nameWithOwner": "my-repo",
 							},
 						},
@@ -547,17 +547,17 @@ func TestRunItemEdit_NumberZero(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"number":0}}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2ItemFieldValue": map[string]interface{}{
-					"projectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2ItemFieldValue": map[string]any{
+					"projectV2Item": map[string]any{
 						"ID": "item_id",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Issue",
 							"body":       "body",
 							"title":      "title",
 							"number":     1,
-							"repository": map[string]interface{}{
+							"repository": map[string]any{
 								"nameWithOwner": "my-repo",
 							},
 						},
@@ -600,17 +600,17 @@ func TestRunItemEdit_Date(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"date":"2023-01-01T00:00:00Z"}}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2ItemFieldValue": map[string]interface{}{
-					"projectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2ItemFieldValue": map[string]any{
+					"projectV2Item": map[string]any{
 						"ID": "item_id",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Issue",
 							"body":       "body",
 							"title":      "title",
 							"number":     1,
-							"repository": map[string]interface{}{
+							"repository": map[string]any{
 								"nameWithOwner": "my-repo",
 							},
 						},
@@ -647,17 +647,17 @@ func TestRunItemEdit_SingleSelect(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"singleSelectOptionId":"option_id"}}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2ItemFieldValue": map[string]interface{}{
-					"projectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2ItemFieldValue": map[string]any{
+					"projectV2Item": map[string]any{
 						"ID": "item_id",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Issue",
 							"body":       "body",
 							"title":      "title",
 							"number":     1,
-							"repository": map[string]interface{}{
+							"repository": map[string]any{
 								"nameWithOwner": "my-repo",
 							},
 						},
@@ -694,17 +694,17 @@ func TestRunItemEdit_Iteration(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"iterationId":"option_id"}}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2ItemFieldValue": map[string]interface{}{
-					"projectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2ItemFieldValue": map[string]any{
+					"projectV2Item": map[string]any{
 						"ID": "item_id",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Issue",
 							"body":       "body",
 							"title":      "title",
 							"number":     1,
-							"repository": map[string]interface{}{
+							"repository": map[string]any{
 								"nameWithOwner": "my-repo",
 							},
 						},
@@ -786,17 +786,17 @@ func TestRunItemEdit_Clear(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation ClearItemFieldValue.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"clearProjectV2ItemFieldValue": map[string]interface{}{
-					"projectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"clearProjectV2ItemFieldValue": map[string]any{
+					"projectV2Item": map[string]any{
 						"ID": "item_id",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Issue",
 							"body":       "body",
 							"title":      "title",
 							"number":     1,
-							"repository": map[string]interface{}{
+							"repository": map[string]any{
 								"nameWithOwner": "my-repo",
 							},
 						},
@@ -835,10 +835,10 @@ func TestRunItemEdit_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation EditDraftIssueItem.*","variables":{"input":{"draftIssueId":"DI_item_id","title":"a title","body":"a new body"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2DraftIssue": map[string]interface{}{
-					"draftIssue": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2DraftIssue": map[string]any{
+					"draftIssue": map[string]any{
 						"id":    "DI_item_id",
 						"title": "a title",
 						"body":  "a new body",
@@ -877,21 +877,21 @@ func TestRunItemEdit_ByName_SingleSelect(t *testing.T) {
 	// resolve owner
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "user ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -901,9 +901,9 @@ func TestRunItemEdit_ByName_SingleSelect(t *testing.T) {
 	// resolve project + fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  queries.LimitMax,
@@ -913,19 +913,19 @@ func TestRunItemEdit_ByName_SingleSelect(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "project ID",
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"id":         "status ID",
 									"name":       "Status",
 									"dataType":   "SINGLE_SELECT",
-									"options": []map[string]interface{}{
+									"options": []map[string]any{
 										{"id": "opt_todo", "name": "Todo"},
 										{"id": "opt_done", "name": "Done"},
 									},
@@ -940,21 +940,21 @@ func TestRunItemEdit_ByName_SingleSelect(t *testing.T) {
 	// resolve item by URL
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query GetProjectItemByURL.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"url":        "https://github.com/monalisa/repo/issues/1",
 				"firstItems": queries.LimitMax,
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"resource": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"resource": map[string]any{
 					"__typename": "Issue",
-					"projectItems": map[string]interface{}{
-						"nodes": []map[string]interface{}{
-							{"id": "item ID", "project": map[string]interface{}{"id": "project ID"}},
+					"projectItems": map[string]any{
+						"nodes": []map[string]any{
+							{"id": "item ID", "project": map[string]any{"id": "project ID"}},
 						},
 					},
 				},
@@ -966,12 +966,12 @@ func TestRunItemEdit_ByName_SingleSelect(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project ID","itemId":"item ID","fieldId":"status ID","value":{"singleSelectOptionId":"opt_done"}}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2ItemFieldValue": map[string]interface{}{
-					"projectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2ItemFieldValue": map[string]any{
+					"projectV2Item": map[string]any{
 						"id": "item ID",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Issue",
 							"title":      "an issue",
 						},
@@ -1011,14 +1011,14 @@ func TestRunItemEdit_ByName_SingleSelect(t *testing.T) {
 func TestRunItemEdit_ByName_ValueDispatch(t *testing.T) {
 	tests := []struct {
 		name         string
-		fieldNode    map[string]interface{}
+		fieldNode    map[string]any
 		value        string
 		mutationBody string // expected mutation body; empty when no write should happen
 		wantErr      string // expected error; empty for happy paths
 	}{
 		{
 			name: "text field",
-			fieldNode: map[string]interface{}{
+			fieldNode: map[string]any{
 				"__typename": "ProjectV2Field",
 				"id":         "text ID",
 				"name":       "Text",
@@ -1029,7 +1029,7 @@ func TestRunItemEdit_ByName_ValueDispatch(t *testing.T) {
 		},
 		{
 			name: "number field",
-			fieldNode: map[string]interface{}{
+			fieldNode: map[string]any{
 				"__typename": "ProjectV2Field",
 				"id":         "number ID",
 				"name":       "Estimate",
@@ -1040,7 +1040,7 @@ func TestRunItemEdit_ByName_ValueDispatch(t *testing.T) {
 		},
 		{
 			name: "date field",
-			fieldNode: map[string]interface{}{
+			fieldNode: map[string]any{
 				"__typename": "ProjectV2Field",
 				"id":         "date ID",
 				"name":       "Due",
@@ -1051,7 +1051,7 @@ func TestRunItemEdit_ByName_ValueDispatch(t *testing.T) {
 		},
 		{
 			name: "invalid number value",
-			fieldNode: map[string]interface{}{
+			fieldNode: map[string]any{
 				"__typename": "ProjectV2Field",
 				"id":         "number ID",
 				"name":       "Estimate",
@@ -1062,7 +1062,7 @@ func TestRunItemEdit_ByName_ValueDispatch(t *testing.T) {
 		},
 		{
 			name: "iteration field rejected",
-			fieldNode: map[string]interface{}{
+			fieldNode: map[string]any{
 				"__typename": "ProjectV2IterationField",
 				"id":         "iteration ID",
 				"name":       "Sprint",
@@ -1080,21 +1080,21 @@ func TestRunItemEdit_ByName_ValueDispatch(t *testing.T) {
 			// resolve owner
 			gock.New("https://api.github.com").
 				Post("/graphql").
-				JSON(map[string]interface{}{
+				JSON(map[string]any{
 					"query": "query UserOrgOwner.*",
-					"variables": map[string]interface{}{
+					"variables": map[string]any{
 						"login": "monalisa",
 					},
 				}).
 				Reply(200).
-				JSON(map[string]interface{}{
-					"data": map[string]interface{}{
-						"user": map[string]interface{}{
+				JSON(map[string]any{
+					"data": map[string]any{
+						"user": map[string]any{
 							"id": "user ID",
 						},
 					},
-					"errors": []interface{}{
-						map[string]interface{}{
+					"errors": []any{
+						map[string]any{
 							"type": "NOT_FOUND",
 							"path": []string{"organization"},
 						},
@@ -1104,9 +1104,9 @@ func TestRunItemEdit_ByName_ValueDispatch(t *testing.T) {
 			// resolve project + fields
 			gock.New("https://api.github.com").
 				Post("/graphql").
-				JSON(map[string]interface{}{
+				JSON(map[string]any{
 					"query": "query UserProject.*",
-					"variables": map[string]interface{}{
+					"variables": map[string]any{
 						"login":       "monalisa",
 						"number":      1,
 						"firstItems":  queries.LimitMax,
@@ -1116,13 +1116,13 @@ func TestRunItemEdit_ByName_ValueDispatch(t *testing.T) {
 					},
 				}).
 				Reply(200).
-				JSON(map[string]interface{}{
-					"data": map[string]interface{}{
-						"user": map[string]interface{}{
-							"projectV2": map[string]interface{}{
+				JSON(map[string]any{
+					"data": map[string]any{
+						"user": map[string]any{
+							"projectV2": map[string]any{
 								"id": "project ID",
-								"fields": map[string]interface{}{
-									"nodes": []map[string]interface{}{tt.fieldNode},
+								"fields": map[string]any{
+									"nodes": []map[string]any{tt.fieldNode},
 								},
 							},
 						},
@@ -1132,21 +1132,21 @@ func TestRunItemEdit_ByName_ValueDispatch(t *testing.T) {
 			// resolve item by URL
 			gock.New("https://api.github.com").
 				Post("/graphql").
-				JSON(map[string]interface{}{
+				JSON(map[string]any{
 					"query": "query GetProjectItemByURL.*",
-					"variables": map[string]interface{}{
+					"variables": map[string]any{
 						"url":        "https://github.com/monalisa/repo/issues/1",
 						"firstItems": queries.LimitMax,
 					},
 				}).
 				Reply(200).
-				JSON(map[string]interface{}{
-					"data": map[string]interface{}{
-						"resource": map[string]interface{}{
+				JSON(map[string]any{
+					"data": map[string]any{
+						"resource": map[string]any{
 							"__typename": "Issue",
-							"projectItems": map[string]interface{}{
-								"nodes": []map[string]interface{}{
-									{"id": "item ID", "project": map[string]interface{}{"id": "project ID"}},
+							"projectItems": map[string]any{
+								"nodes": []map[string]any{
+									{"id": "item ID", "project": map[string]any{"id": "project ID"}},
 								},
 							},
 						},
@@ -1158,12 +1158,12 @@ func TestRunItemEdit_ByName_ValueDispatch(t *testing.T) {
 					Post("/graphql").
 					BodyString(tt.mutationBody).
 					Reply(200).
-					JSON(map[string]interface{}{
-						"data": map[string]interface{}{
-							"updateProjectV2ItemFieldValue": map[string]interface{}{
-								"projectV2Item": map[string]interface{}{
+					JSON(map[string]any{
+						"data": map[string]any{
+							"updateProjectV2ItemFieldValue": map[string]any{
+								"projectV2Item": map[string]any{
 									"id": "item ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 									},
@@ -1210,21 +1210,21 @@ func TestRunItemEdit_ByName_CaseInsensitive(t *testing.T) {
 	// resolve owner
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "user ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -1234,9 +1234,9 @@ func TestRunItemEdit_ByName_CaseInsensitive(t *testing.T) {
 	// resolve project + fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  queries.LimitMax,
@@ -1246,19 +1246,19 @@ func TestRunItemEdit_ByName_CaseInsensitive(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "project ID",
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"id":         "status ID",
 									"name":       "Status",
 									"dataType":   "SINGLE_SELECT",
-									"options": []map[string]interface{}{
+									"options": []map[string]any{
 										{"id": "opt_todo", "name": "Todo"},
 										{"id": "opt_inprog", "name": "In Progress"},
 									},
@@ -1273,21 +1273,21 @@ func TestRunItemEdit_ByName_CaseInsensitive(t *testing.T) {
 	// resolve item by URL
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query GetProjectItemByURL.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"url":        "https://github.com/monalisa/repo/issues/1",
 				"firstItems": queries.LimitMax,
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"resource": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"resource": map[string]any{
 					"__typename": "Issue",
-					"projectItems": map[string]interface{}{
-						"nodes": []map[string]interface{}{
-							{"id": "item ID", "project": map[string]interface{}{"id": "project ID"}},
+					"projectItems": map[string]any{
+						"nodes": []map[string]any{
+							{"id": "item ID", "project": map[string]any{"id": "project ID"}},
 						},
 					},
 				},
@@ -1299,12 +1299,12 @@ func TestRunItemEdit_ByName_CaseInsensitive(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project ID","itemId":"item ID","fieldId":"status ID","value":{"singleSelectOptionId":"opt_inprog"}}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"updateProjectV2ItemFieldValue": map[string]interface{}{
-					"projectV2Item": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"updateProjectV2ItemFieldValue": map[string]any{
+					"projectV2Item": map[string]any{
 						"id": "item ID",
-						"content": map[string]interface{}{
+						"content": map[string]any{
 							"__typename": "Issue",
 							"title":      "an issue",
 						},
@@ -1342,21 +1342,21 @@ func TestRunItemEdit_ByName_FieldNotFound(t *testing.T) {
 
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "user ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -1365,9 +1365,9 @@ func TestRunItemEdit_ByName_FieldNotFound(t *testing.T) {
 
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  queries.LimitMax,
@@ -1377,13 +1377,13 @@ func TestRunItemEdit_ByName_FieldNotFound(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "project ID",
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2Field",
 									"id":         "title ID",
@@ -1429,21 +1429,21 @@ func TestRunItemEdit_ByName_WrongFieldType(t *testing.T) {
 	// resolve owner
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "user ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -1454,9 +1454,9 @@ func TestRunItemEdit_ByName_WrongFieldType(t *testing.T) {
 	// updateProjectV2ItemFieldValue does not support with --value.
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  queries.LimitMax,
@@ -1466,13 +1466,13 @@ func TestRunItemEdit_ByName_WrongFieldType(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
 						"id": "project ID",
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2Field",
 									"id":         "title ID",
@@ -1490,21 +1490,21 @@ func TestRunItemEdit_ByName_WrongFieldType(t *testing.T) {
 	// mutation should follow.
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query GetProjectItemByURL.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"url":        "https://github.com/monalisa/repo/issues/1",
 				"firstItems": queries.LimitMax,
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"resource": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"resource": map[string]any{
 					"__typename": "Issue",
-					"projectItems": map[string]interface{}{
-						"nodes": []map[string]interface{}{
-							{"id": "item ID", "project": map[string]interface{}{"id": "project ID"}},
+					"projectItems": map[string]any{
+						"nodes": []map[string]any{
+							{"id": "item ID", "project": map[string]any{"id": "project ID"}},
 						},
 					},
 				},

--- a/pkg/cmd/project/item-list/item_list_test.go
+++ b/pkg/cmd/project/item-list/item_list_test.go
@@ -143,21 +143,21 @@ func TestRunList_User_tty(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -167,9 +167,9 @@ func TestRunList_User_tty(t *testing.T) {
 	// list project items
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProjectWithItems.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"firstItems":  queries.LimitDefault,
 				"afterItems":  nil,
 				"firstFields": queries.LimitMax,
@@ -179,15 +179,15 @@ func TestRunList_User_tty(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 										"number":     1,
@@ -198,7 +198,7 @@ func TestRunList_User_tty(t *testing.T) {
 								},
 								{
 									"id": "pull request ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "PullRequest",
 										"title":      "a pull request",
 										"number":     2,
@@ -209,7 +209,7 @@ func TestRunList_User_tty(t *testing.T) {
 								},
 								{
 									"id": "draft issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"id":         "draft issue ID",
 										"title":      "draft issue",
 										"__typename": "DraftIssue",
@@ -253,21 +253,21 @@ func TestRunList_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -277,9 +277,9 @@ func TestRunList_User(t *testing.T) {
 	// list project items
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProjectWithItems.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"firstItems":  queries.LimitDefault,
 				"afterItems":  nil,
 				"firstFields": queries.LimitMax,
@@ -289,15 +289,15 @@ func TestRunList_User(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 										"number":     1,
@@ -308,7 +308,7 @@ func TestRunList_User(t *testing.T) {
 								},
 								{
 									"id": "pull request ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "PullRequest",
 										"title":      "a pull request",
 										"number":     2,
@@ -319,7 +319,7 @@ func TestRunList_User(t *testing.T) {
 								},
 								{
 									"id": "draft issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"id":         "draft issue ID",
 										"title":      "draft issue",
 										"__typename": "DraftIssue",
@@ -360,21 +360,21 @@ func TestRunList_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -384,9 +384,9 @@ func TestRunList_Org(t *testing.T) {
 	// list project items
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProjectWithItems.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"firstItems":  queries.LimitDefault,
 				"afterItems":  nil,
 				"firstFields": queries.LimitMax,
@@ -396,15 +396,15 @@ func TestRunList_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 										"number":     1,
@@ -415,7 +415,7 @@ func TestRunList_Org(t *testing.T) {
 								},
 								{
 									"id": "pull request ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "PullRequest",
 										"title":      "a pull request",
 										"number":     2,
@@ -426,7 +426,7 @@ func TestRunList_Org(t *testing.T) {
 								},
 								{
 									"id": "draft issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"id":         "draft issue ID",
 										"title":      "draft issue",
 										"__typename": "DraftIssue",
@@ -467,13 +467,13 @@ func TestRunList_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -482,9 +482,9 @@ func TestRunList_Me(t *testing.T) {
 	// list project items
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerProjectWithItems.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"firstItems":  queries.LimitDefault,
 				"afterItems":  nil,
 				"firstFields": queries.LimitMax,
@@ -493,15 +493,15 @@ func TestRunList_Me(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
+					"projectV2": map[string]any{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 										"number":     1,
@@ -512,7 +512,7 @@ func TestRunList_Me(t *testing.T) {
 								},
 								{
 									"id": "pull request ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "PullRequest",
 										"title":      "a pull request",
 										"number":     2,
@@ -523,7 +523,7 @@ func TestRunList_Me(t *testing.T) {
 								},
 								{
 									"id": "draft issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"id":         "draft issue ID",
 										"title":      "draft issue",
 										"__typename": "DraftIssue",
@@ -564,21 +564,21 @@ func TestRunList_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -588,9 +588,9 @@ func TestRunList_JSON(t *testing.T) {
 	// list project items
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProjectWithItems.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"firstItems":  queries.LimitDefault,
 				"afterItems":  nil,
 				"firstFields": queries.LimitMax,
@@ -600,15 +600,15 @@ func TestRunList_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 										"number":     1,
@@ -619,7 +619,7 @@ func TestRunList_JSON(t *testing.T) {
 								},
 								{
 									"id": "pull request ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "PullRequest",
 										"title":      "a pull request",
 										"number":     2,
@@ -630,7 +630,7 @@ func TestRunList_JSON(t *testing.T) {
 								},
 								{
 									"id": "draft issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"id":         "draft issue ID",
 										"title":      "draft issue",
 										"__typename": "DraftIssue",
@@ -672,21 +672,21 @@ func TestRunList_WithQuery(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -696,9 +696,9 @@ func TestRunList_WithQuery(t *testing.T) {
 	// list project items with query
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProjectWithItems.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"firstItems":  queries.LimitDefault,
 				"afterItems":  nil,
 				"firstFields": queries.LimitMax,
@@ -709,15 +709,15 @@ func TestRunList_WithQuery(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 										"number":     1,
@@ -778,21 +778,21 @@ func TestRunList_FieldColumn(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -803,12 +803,12 @@ func TestRunList_FieldColumn(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"id":         "status ID",
@@ -835,11 +835,11 @@ func TestRunList_FieldColumn(t *testing.T) {
 								},
 							},
 						},
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 										"number":     1,
@@ -847,12 +847,12 @@ func TestRunList_FieldColumn(t *testing.T) {
 											"nameWithOwner": "cli/go-gh",
 										},
 									},
-									"fieldValues": map[string]interface{}{
-										"nodes": []map[string]interface{}{
+									"fieldValues": map[string]any{
+										"nodes": []map[string]any{
 											{
 												"__typename": "ProjectV2ItemFieldSingleSelectValue",
 												"name":       "In Progress",
-												"field": map[string]interface{}{
+												"field": map[string]any{
 													"__typename": "ProjectV2SingleSelectField",
 													"id":         "status ID",
 												},
@@ -860,20 +860,20 @@ func TestRunList_FieldColumn(t *testing.T) {
 											{
 												"__typename": "ProjectV2ItemFieldNumberValue",
 												"number":     5,
-												"field": map[string]interface{}{
+												"field": map[string]any{
 													"__typename": "ProjectV2Field",
 													"id":         "est ID",
 												},
 											},
 											{
 												"__typename": "ProjectV2ItemFieldLabelValue",
-												"labels": map[string]interface{}{
-													"nodes": []map[string]interface{}{
+												"labels": map[string]any{
+													"nodes": []map[string]any{
 														{"name": "bug"},
 														{"name": "p1"},
 													},
 												},
-												"field": map[string]interface{}{
+												"field": map[string]any{
 													"__typename": "ProjectV2Field",
 													"id":         "tags ID",
 												},
@@ -881,7 +881,7 @@ func TestRunList_FieldColumn(t *testing.T) {
 											{
 												"__typename": "ProjectV2ItemFieldIterationValue",
 												"title":      "S1",
-												"field": map[string]interface{}{
+												"field": map[string]any{
 													"__typename": "ProjectV2IterationField",
 													"id":         "iter ID",
 												},
@@ -924,21 +924,21 @@ func TestRunList_FieldColumn_UnknownName(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -948,12 +948,12 @@ func TestRunList_FieldColumn_UnknownName(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"id":         "status ID",
@@ -962,11 +962,11 @@ func TestRunList_FieldColumn_UnknownName(t *testing.T) {
 								},
 							},
 						},
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 										"number":     1,
@@ -1007,21 +1007,21 @@ func TestRunList_FieldColumn_UnknownID(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -1031,12 +1031,12 @@ func TestRunList_FieldColumn_UnknownID(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"id":         "status ID",
@@ -1045,11 +1045,11 @@ func TestRunList_FieldColumn_UnknownID(t *testing.T) {
 								},
 							},
 						},
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 										"number":     1,
@@ -1091,21 +1091,21 @@ func TestRunList_FieldColumn_PaginatesFields(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -1117,17 +1117,17 @@ func TestRunList_FieldColumn_PaginatesFields(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
 							"totalCount": 2,
-							"pageInfo": map[string]interface{}{
+							"pageInfo": map[string]any{
 								"hasNextPage": true,
 								"endCursor":   "STATUSCURSOR",
 							},
-							"nodes": []map[string]interface{}{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"id":         "status ID",
@@ -1136,11 +1136,11 @@ func TestRunList_FieldColumn_PaginatesFields(t *testing.T) {
 								},
 							},
 						},
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
-									"content": map[string]interface{}{
+									"content": map[string]any{
 										"__typename": "Issue",
 										"title":      "an issue",
 										"number":     1,
@@ -1148,12 +1148,12 @@ func TestRunList_FieldColumn_PaginatesFields(t *testing.T) {
 											"nameWithOwner": "cli/go-gh",
 										},
 									},
-									"fieldValues": map[string]interface{}{
-										"nodes": []map[string]interface{}{
+									"fieldValues": map[string]any{
+										"nodes": []map[string]any{
 											{
 												"__typename": "ProjectV2ItemFieldSingleSelectValue",
 												"name":       "High",
-												"field": map[string]interface{}{
+												"field": map[string]any{
 													"__typename": "ProjectV2SingleSelectField",
 													"id":         "priority ID",
 												},
@@ -1172,17 +1172,17 @@ func TestRunList_FieldColumn_PaginatesFields(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
 							"totalCount": 2,
-							"pageInfo": map[string]interface{}{
+							"pageInfo": map[string]any{
 								"hasNextPage": false,
 								"endCursor":   "PRIORITYCURSOR",
 							},
-							"nodes": []map[string]interface{}{
+							"nodes": []map[string]any{
 								{
 									"__typename": "ProjectV2SingleSelectField",
 									"id":         "status ID",
@@ -1197,8 +1197,8 @@ func TestRunList_FieldColumn_PaginatesFields(t *testing.T) {
 								},
 							},
 						},
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{},
+						"items": map[string]any{
+							"nodes": []map[string]any{},
 						},
 					},
 				},

--- a/pkg/cmd/project/link/link_test.go
+++ b/pkg/cmd/project/link/link_test.go
@@ -191,22 +191,22 @@ func TestRunLink_Repo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id":    "an ID",
 					"login": "monalisa",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -217,9 +217,9 @@ func TestRunLink_Repo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -229,9 +229,9 @@ func TestRunLink_Repo(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id":    "project-ID",
 						"title": "first-project",
@@ -244,13 +244,13 @@ func TestRunLink_Repo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "mutation LinkProjectV2ToRepository.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"linkProjectV2ToRepository": map[string]interface{}{},
+		JSON(map[string]any{
+			"data": map[string]any{
+				"linkProjectV2ToRepository": map[string]any{},
 			},
 		})
 
@@ -259,9 +259,9 @@ func TestRunLink_Repo(t *testing.T) {
 		Post("/graphql").
 		BodyString(`.*query RepositoryInfo.*`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"repository": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
 					"id": "repo-ID",
 				},
 			},
@@ -301,22 +301,22 @@ func TestRunLink_Team(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "monalisa-org",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id":    "an ID",
 					"login": "monalisa-org",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -327,9 +327,9 @@ func TestRunLink_Team(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa-org",
 				"number":      1,
 				"firstItems":  0,
@@ -339,9 +339,9 @@ func TestRunLink_Team(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id":    "project-ID",
 						"title": "first-project",
@@ -354,13 +354,13 @@ func TestRunLink_Team(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "mutation LinkProjectV2ToTeam.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"linkProjectV2ToTeam": map[string]interface{}{},
+		JSON(map[string]any{
+			"data": map[string]any{
+				"linkProjectV2ToTeam": map[string]any{},
 			},
 		})
 
@@ -369,10 +369,10 @@ func TestRunLink_Team(t *testing.T) {
 		Post("/graphql").
 		BodyString(`.*query OrganizationTeam.*`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"team": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"team": map[string]any{
 						"id": "team-ID",
 					},
 				},

--- a/pkg/cmd/project/list/list_test.go
+++ b/pkg/cmd/project/list/list_test.go
@@ -99,21 +99,21 @@ func TestRunListTTY(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -123,13 +123,13 @@ func TestRunListTTY(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"login": "monalisa",
-					"projectsV2": map[string]interface{}{
-						"nodes": []interface{}{
-							map[string]interface{}{
+					"projectsV2": map[string]any{
+						"nodes": []any{
+							map[string]any{
 								"title":            "Project 1",
 								"shortDescription": "Short description 1",
 								"url":              "url1",
@@ -137,7 +137,7 @@ func TestRunListTTY(t *testing.T) {
 								"ID":               "id-1",
 								"number":           1,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"title":            "Project 2",
 								"shortDescription": "",
 								"url":              "url2",
@@ -178,21 +178,21 @@ func TestRunList(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -202,13 +202,13 @@ func TestRunList(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"login": "monalisa",
-					"projectsV2": map[string]interface{}{
-						"nodes": []interface{}{
-							map[string]interface{}{
+					"projectsV2": map[string]any{
+						"nodes": []any{
+							map[string]any{
 								"title":            "Project 1",
 								"shortDescription": "Short description 1",
 								"url":              "url1",
@@ -216,7 +216,7 @@ func TestRunList(t *testing.T) {
 								"ID":               "id-1",
 								"number":           1,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"title":            "Project 2",
 								"shortDescription": "",
 								"url":              "url2",
@@ -256,21 +256,21 @@ func TestRunList_tty(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -280,13 +280,13 @@ func TestRunList_tty(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"login": "monalisa",
-					"projectsV2": map[string]interface{}{
-						"nodes": []interface{}{
-							map[string]interface{}{
+					"projectsV2": map[string]any{
+						"nodes": []any{
+							map[string]any{
 								"title":            "Project 1",
 								"shortDescription": "Short description 1",
 								"url":              "url1",
@@ -294,7 +294,7 @@ func TestRunList_tty(t *testing.T) {
 								"ID":               "id-1",
 								"number":           1,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"title":            "Project 2",
 								"shortDescription": "",
 								"url":              "url2",
@@ -337,13 +337,13 @@ func TestRunList_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -352,13 +352,13 @@ func TestRunList_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"login": "monalisa",
-					"projectsV2": map[string]interface{}{
-						"nodes": []interface{}{
-							map[string]interface{}{
+					"projectsV2": map[string]any{
+						"nodes": []any{
+							map[string]any{
 								"title":            "Project 1",
 								"shortDescription": "Short description 1",
 								"url":              "url1",
@@ -366,7 +366,7 @@ func TestRunList_Me(t *testing.T) {
 								"ID":               "id-1",
 								"number":           1,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"title":            "Project 2",
 								"shortDescription": "",
 								"url":              "url2",
@@ -407,13 +407,13 @@ func TestRunListViewer(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -422,13 +422,13 @@ func TestRunListViewer(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"login": "monalisa",
-					"projectsV2": map[string]interface{}{
-						"nodes": []interface{}{
-							map[string]interface{}{
+					"projectsV2": map[string]any{
+						"nodes": []any{
+							map[string]any{
 								"title":            "Project 1",
 								"shortDescription": "Short description 1",
 								"url":              "url1",
@@ -436,7 +436,7 @@ func TestRunListViewer(t *testing.T) {
 								"ID":               "id-1",
 								"number":           1,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"title":            "Project 2",
 								"shortDescription": "",
 								"url":              "url2",
@@ -475,21 +475,21 @@ func TestRunListOrg(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -499,13 +499,13 @@ func TestRunListOrg(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"login": "monalisa",
-					"projectsV2": map[string]interface{}{
-						"nodes": []interface{}{
-							map[string]interface{}{
+					"projectsV2": map[string]any{
+						"nodes": []any{
+							map[string]any{
 								"title":            "Project 1",
 								"shortDescription": "Short description 1",
 								"url":              "url1",
@@ -513,7 +513,7 @@ func TestRunListOrg(t *testing.T) {
 								"ID":               "id-1",
 								"number":           1,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"title":            "Project 2",
 								"shortDescription": "",
 								"url":              "url2",
@@ -554,13 +554,13 @@ func TestRunListEmpty(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query Viewer.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id":    "an ID",
 					"login": "theviewer",
 				},
@@ -570,12 +570,12 @@ func TestRunListEmpty(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"login": "monalisa",
-					"projectsV2": map[string]interface{}{
-						"nodes": []interface{}{},
+					"projectsV2": map[string]any{
+						"nodes": []any{},
 					},
 				},
 			},
@@ -603,21 +603,21 @@ func TestRunListWithClosed(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -627,13 +627,13 @@ func TestRunListWithClosed(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"login": "monalisa",
-					"projectsV2": map[string]interface{}{
-						"nodes": []interface{}{
-							map[string]interface{}{
+					"projectsV2": map[string]any{
+						"nodes": []any{
+							map[string]any{
 								"title":            "Project 1",
 								"shortDescription": "Short description 1",
 								"url":              "url1",
@@ -641,7 +641,7 @@ func TestRunListWithClosed(t *testing.T) {
 								"ID":               "id-1",
 								"number":           1,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"title":            "Project 2",
 								"shortDescription": "",
 								"url":              "url2",
@@ -682,21 +682,21 @@ func TestRunListWeb_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -729,21 +729,21 @@ func TestRunListWeb_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -777,13 +777,13 @@ func TestRunListWeb_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query Viewer.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id":    "an ID",
 					"login": "theviewer",
 				},
@@ -817,13 +817,13 @@ func TestRunListWeb_Empty(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query Viewer.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id":    "an ID",
 					"login": "theviewer",
 				},
@@ -856,13 +856,13 @@ func TestRunListWeb_Closed(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query Viewer.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id":    "an ID",
 					"login": "theviewer",
 				},
@@ -895,21 +895,21 @@ func TestRunList_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -919,13 +919,13 @@ func TestRunList_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"login": "monalisa",
-					"projectsV2": map[string]interface{}{
-						"nodes": []interface{}{
-							map[string]interface{}{
+					"projectsV2": map[string]any{
+						"nodes": []any{
+							map[string]any{
 								"title":            "Project 1",
 								"shortDescription": "Short description 1",
 								"url":              "url1",
@@ -933,7 +933,7 @@ func TestRunList_JSON(t *testing.T) {
 								"ID":               "id-1",
 								"number":           1,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"title":            "Project 2",
 								"shortDescription": "",
 								"url":              "url2",

--- a/pkg/cmd/project/mark-template/mark_template.go
+++ b/pkg/cmd/project/mark-template/mark_template.go
@@ -126,8 +126,8 @@ func runMarkTemplate(config markTemplateConfig) error {
 	return printResults(config, query.TemplateProject.Project)
 }
 
-func markTemplateArgs(config markTemplateConfig) (*markProjectTemplateMutation, map[string]interface{}) {
-	return &markProjectTemplateMutation{}, map[string]interface{}{
+func markTemplateArgs(config markTemplateConfig) (*markProjectTemplateMutation, map[string]any) {
+	return &markProjectTemplateMutation{}, map[string]any{
 		"input": githubv4.MarkProjectV2AsTemplateInput{
 			ProjectID: githubv4.ID(config.opts.projectID),
 		},
@@ -138,8 +138,8 @@ func markTemplateArgs(config markTemplateConfig) (*markProjectTemplateMutation, 
 	}
 }
 
-func unmarkTemplateArgs(config markTemplateConfig) (*unmarkProjectTemplateMutation, map[string]interface{}) {
-	return &unmarkProjectTemplateMutation{}, map[string]interface{}{
+func unmarkTemplateArgs(config markTemplateConfig) (*unmarkProjectTemplateMutation, map[string]any) {
+	return &unmarkProjectTemplateMutation{}, map[string]any{
 		"input": githubv4.UnmarkProjectV2AsTemplateInput{
 			ProjectID: githubv4.ID(config.opts.projectID),
 		},

--- a/pkg/cmd/project/mark-template/mark_template_test.go
+++ b/pkg/cmd/project/mark-template/mark_template_test.go
@@ -97,21 +97,21 @@ func TestRunMarkTemplate_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -122,9 +122,9 @@ func TestRunMarkTemplate_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -134,10 +134,10 @@ func TestRunMarkTemplate_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -149,10 +149,10 @@ func TestRunMarkTemplate_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation MarkProjectTemplate.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"markProjectV2AsTemplate": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"markProjectV2AsTemplate": map[string]any{
+					"projectV2": map[string]any{
 						"id":     "project ID",
 						"number": 1,
 					},
@@ -189,21 +189,21 @@ func TestRunUnmarkTemplate_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -214,9 +214,9 @@ func TestRunUnmarkTemplate_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -226,10 +226,10 @@ func TestRunUnmarkTemplate_Org(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -241,10 +241,10 @@ func TestRunUnmarkTemplate_Org(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation UnmarkProjectTemplate.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"unmarkProjectV2AsTemplate": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"unmarkProjectV2AsTemplate": map[string]any{
+					"projectV2": map[string]any{
 						"id":     "project ID",
 						"number": 1,
 					},
@@ -282,21 +282,21 @@ func TestRunMarkTemplate_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -307,9 +307,9 @@ func TestRunMarkTemplate_JSON(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query OrgProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "github",
 				"number":      1,
 				"firstItems":  0,
@@ -319,10 +319,10 @@ func TestRunMarkTemplate_JSON(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"projectV2": map[string]any{
 						"id": "an ID",
 					},
 				},
@@ -334,13 +334,13 @@ func TestRunMarkTemplate_JSON(t *testing.T) {
 		Post("/graphql").
 		BodyString(`{"query":"mutation MarkProjectTemplate.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"markProjectV2AsTemplate": map[string]interface{}{
-					"projectV2": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"markProjectV2AsTemplate": map[string]any{
+					"projectV2": map[string]any{
 						"id":     "project ID",
 						"number": 1,
-						"owner": map[string]interface{}{
+						"owner": map[string]any{
 							"__typename": "Organization",
 							"login":      "github",
 						},

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -65,17 +65,17 @@ type hostScopedClient struct {
 	hostname string
 }
 
-func (c *hostScopedClient) Query(queryName string, query interface{}, variables map[string]interface{}) error {
+func (c *hostScopedClient) Query(queryName string, query any, variables map[string]any) error {
 	return c.Client.Query(c.hostname, queryName, query, variables)
 }
 
-func (c *hostScopedClient) Mutate(queryName string, query interface{}, variables map[string]interface{}) error {
+func (c *hostScopedClient) Mutate(queryName string, query any, variables map[string]any) error {
 	return c.Client.Mutate(c.hostname, queryName, query, variables)
 }
 
 type graphqlClient interface {
-	Query(queryName string, query interface{}, variables map[string]interface{}) error
-	Mutate(queryName string, query interface{}, variables map[string]interface{}) error
+	Query(queryName string, query any, variables map[string]any) error
+	Mutate(queryName string, query any, variables map[string]any) error
 }
 
 type Client struct {
@@ -91,7 +91,7 @@ const (
 
 // doQueryWithProgressIndicator wraps API calls with a progress indicator.
 // The query name is used in the progress indicator label.
-func (c *Client) doQueryWithProgressIndicator(name string, query interface{}, variables map[string]interface{}) error {
+func (c *Client) doQueryWithProgressIndicator(name string, query any, variables map[string]any) error {
 	c.io.StartProgressIndicatorWithLabel(fmt.Sprintf("Fetching %s", name))
 	defer c.io.StopProgressIndicator()
 	err := c.apiClient.Query(name, query, variables)
@@ -99,12 +99,12 @@ func (c *Client) doQueryWithProgressIndicator(name string, query interface{}, va
 }
 
 // TODO: un-export this since it couples the caller heavily to api.GraphQLClient
-func (c *Client) Mutate(operationName string, query interface{}, variables map[string]interface{}) error {
+func (c *Client) Mutate(operationName string, query any, variables map[string]any) error {
 	err := c.apiClient.Mutate(operationName, query, variables)
 	return handleError(err)
 }
 
-func (c *Client) Query(operationName string, query interface{}, variables map[string]interface{}) error {
+func (c *Client) Query(operationName string, query any, variables map[string]any) error {
 	err := c.apiClient.Query(operationName, query, variables)
 	return handleError(err)
 }
@@ -258,15 +258,15 @@ func newProjectFromQueryWithoutItemsQuery(source projectQueryWithoutQueryableIte
 	return project
 }
 
-func (p Project) DetailedItems() map[string]interface{} {
-	return map[string]interface{}{
+func (p Project) DetailedItems() map[string]any {
+	return map[string]any{
 		"items":      serializeProjectWithItems(&p),
 		"totalCount": p.Items.TotalCount,
 	}
 }
 
-func (p Project) ExportData(_ []string) map[string]interface{} {
-	return map[string]interface{}{
+func (p Project) ExportData(_ []string) map[string]any {
+	return map[string]any{
 		"number":           p.Number,
 		"url":              p.URL,
 		"shortDescription": p.ShortDescription,
@@ -275,13 +275,13 @@ func (p Project) ExportData(_ []string) map[string]interface{} {
 		"title":            p.Title,
 		"id":               p.ID,
 		"readme":           p.Readme,
-		"items": map[string]interface{}{
+		"items": map[string]any{
 			"totalCount": p.Items.TotalCount,
 		},
-		"fields": map[string]interface{}{
+		"fields": map[string]any{
 			"totalCount": p.Fields.TotalCount,
 		},
-		"owner": map[string]interface{}{
+		"owner": map[string]any{
 			"type":  p.OwnerType(),
 			"login": p.OwnerLogin(),
 		},
@@ -299,8 +299,8 @@ func (p Project) OwnerLogin() string {
 	return p.Owner.Organization.Login
 }
 
-func (p ProjectMutationQuery) ExportData(_ []string) map[string]interface{} {
-	return map[string]interface{}{
+func (p ProjectMutationQuery) ExportData(_ []string) map[string]any {
+	return map[string]any{
 		"number":           p.Number,
 		"url":              p.URL,
 		"shortDescription": p.ShortDescription,
@@ -309,13 +309,13 @@ func (p ProjectMutationQuery) ExportData(_ []string) map[string]interface{} {
 		"title":            p.Title,
 		"id":               p.ID,
 		"readme":           p.Readme,
-		"items": map[string]interface{}{
+		"items": map[string]any{
 			"totalCount": p.Items.TotalCount,
 		},
-		"fields": map[string]interface{}{
+		"fields": map[string]any{
 			"totalCount": p.Fields.TotalCount,
 		},
-		"owner": map[string]interface{}{
+		"owner": map[string]any{
 			"type":  p.OwnerType(),
 			"login": p.OwnerLogin(),
 		},
@@ -338,12 +338,12 @@ type Projects struct {
 	TotalCount int
 }
 
-func (p Projects) ExportData(_ []string) map[string]interface{} {
-	v := make([]map[string]interface{}, len(p.Nodes))
+func (p Projects) ExportData(_ []string) map[string]any {
+	v := make([]map[string]any, len(p.Nodes))
 	for i := range p.Nodes {
 		v[i] = p.Nodes[i].ExportData(nil)
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"projects":   v,
 		"totalCount": p.TotalCount,
 	}
@@ -489,7 +489,7 @@ func (v FieldValueNodes) DisplayValue() string {
 		value = strconv.FormatFloat(data, 'f', -1, 64)
 	case []string:
 		value = strings.Join(data, ", ")
-	case map[string]interface{}:
+	case map[string]any:
 		title, _ := data["title"].(string)
 		value = title
 	default:
@@ -511,8 +511,8 @@ type DraftIssue struct {
 	Title string
 }
 
-func (i DraftIssue) ExportData(_ []string) map[string]interface{} {
-	v := map[string]interface{}{
+func (i DraftIssue) ExportData(_ []string) map[string]any {
+	v := map[string]any{
 		"title": i.Title,
 		"body":  i.Body,
 		"type":  "DraftIssue",
@@ -534,8 +534,8 @@ type PullRequest struct {
 	}
 }
 
-func (pr PullRequest) ExportData(_ []string) map[string]interface{} {
-	return map[string]interface{}{
+func (pr PullRequest) ExportData(_ []string) map[string]any {
+	return map[string]any{
 		"type":       "PullRequest",
 		"body":       pr.Body,
 		"title":      pr.Title,
@@ -555,8 +555,8 @@ type Issue struct {
 	}
 }
 
-func (i Issue) ExportData(_ []string) map[string]interface{} {
-	return map[string]interface{}{
+func (i Issue) ExportData(_ []string) map[string]any {
+	return map[string]any{
 		"type":       "Issue",
 		"body":       i.Body,
 		"title":      i.Title,
@@ -670,8 +670,8 @@ func (p ProjectItem) URL() string {
 	return ""
 }
 
-func (p ProjectItem) ExportData(_ []string) map[string]interface{} {
-	v := map[string]interface{}{
+func (p ProjectItem) ExportData(_ []string) map[string]any {
+	v := map[string]any{
 		"id":    p.ID(),
 		"title": p.Title(),
 		"body":  p.Body(),
@@ -700,7 +700,7 @@ func (c *Client) ProjectItems(o *Owner, number int32, limit int, queryStr string
 		first = limit
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"firstItems":  githubv4.Int(first),
 		"afterItems":  (*githubv4.String)(nil),
 		"firstFields": githubv4.Int(LimitMax),
@@ -1023,8 +1023,8 @@ type SingleSelectFieldOptions struct {
 	Name string
 }
 
-func (f SingleSelectFieldOptions) ExportData(_ []string) map[string]interface{} {
-	return map[string]interface{}{
+func (f SingleSelectFieldOptions) ExportData(_ []string) map[string]any {
+	return map[string]any{
 		"id":   f.ID,
 		"name": f.Name,
 	}
@@ -1044,15 +1044,15 @@ func (p ProjectField) Options() []SingleSelectFieldOptions {
 	return nil
 }
 
-func (p ProjectField) ExportData(_ []string) map[string]interface{} {
-	v := map[string]interface{}{
+func (p ProjectField) ExportData(_ []string) map[string]any {
+	v := map[string]any{
 		"id":   p.ID(),
 		"name": p.Name(),
 		"type": p.Type(),
 	}
 	// Emulate omitempty
 	if opts := p.Options(); len(opts) != 0 {
-		options := make([]map[string]interface{}, len(opts))
+		options := make([]map[string]any, len(opts))
 		for i, opt := range opts {
 			options[i] = opt.ExportData(nil)
 		}
@@ -1067,12 +1067,12 @@ type ProjectFields struct {
 	PageInfo   PageInfo
 }
 
-func (p ProjectFields) ExportData(_ []string) map[string]interface{} {
-	fields := make([]map[string]interface{}, len(p.Nodes))
+func (p ProjectFields) ExportData(_ []string) map[string]any {
+	fields := make([]map[string]any, len(p.Nodes))
 	for i := range p.Nodes {
 		fields[i] = p.Nodes[i].ExportData(nil)
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"fields":     fields,
 		"totalCount": p.TotalCount,
 	}
@@ -1091,7 +1091,7 @@ func (c *Client) ProjectFields(o *Owner, number int32, limit int) (*Project, err
 	if limit < first {
 		first = limit
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"firstItems":  githubv4.Int(LimitMax),
 		"afterItems":  (*githubv4.String)(nil),
 		"firstFields": githubv4.Int(first),
@@ -1235,7 +1235,7 @@ const ViewerOwner OwnerType = "VIEWER"
 // ViewerLoginName returns the login name of the viewer.
 func (c *Client) ViewerLoginName() (string, error) {
 	var query viewerLogin
-	err := c.doQueryWithProgressIndicator("Viewer", &query, map[string]interface{}{})
+	err := c.doQueryWithProgressIndicator("Viewer", &query, map[string]any{})
 	if err != nil {
 		return "", err
 	}
@@ -1253,7 +1253,7 @@ func (c *Client) OwnerIDAndType(login string) (string, OwnerType, error) {
 		return query.Viewer.Id, ViewerOwner, nil
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"login": githubv4.String(login),
 	}
 	var query struct {
@@ -1306,7 +1306,7 @@ func (c *Client) IssueOrPullRequestID(rawURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"url": githubv4.URI{URL: uri},
 	}
 	var query issueOrPullRequest
@@ -1368,7 +1368,7 @@ type loginTypes struct {
 func (c *Client) userOrgLogins() ([]loginTypes, error) {
 	l := make([]loginTypes, 0)
 	var v viewerLoginOrgs
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"after": (*githubv4.String)(nil),
 	}
 
@@ -1406,7 +1406,7 @@ func (c *Client) userOrgLogins() ([]loginTypes, error) {
 // paginateOrgLogins after cursor and append them to the list of logins.
 func (c *Client) paginateOrgLogins(l []loginTypes, cursor string) ([]loginTypes, error) {
 	var v viewerLoginOrgs
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"after": githubv4.String(cursor),
 	}
 
@@ -1491,7 +1491,7 @@ func (c *Client) NewOwner(canPrompt bool, login string) (*Owner, error) {
 // set `fields“ to true to get the project's field data
 func (c *Client) NewProject(canPrompt bool, o *Owner, number int32, fields bool) (*Project, error) {
 	if number != 0 {
-		variables := map[string]interface{}{
+		variables := map[string]any{
 			"number":      githubv4.Int(number),
 			"firstItems":  githubv4.Int(0),
 			"afterItems":  (*githubv4.String)(nil),
@@ -1566,7 +1566,7 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 		first = limit
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"first":       githubv4.Int(first),
 		"after":       cursor,
 		"firstItems":  githubv4.Int(0),
@@ -1661,7 +1661,7 @@ type unlinkProjectFromTeamMutation struct {
 // LinkProjectToRepository links a project to a repository.
 func (c *Client) LinkProjectToRepository(projectID string, repoID string) error {
 	var mutation linkProjectToRepoMutation
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.LinkProjectV2ToRepositoryInput{
 			ProjectID:    githubv4.String(projectID),
 			RepositoryID: githubv4.ID(repoID),
@@ -1674,7 +1674,7 @@ func (c *Client) LinkProjectToRepository(projectID string, repoID string) error 
 // LinkProjectToTeam links a project to a team.
 func (c *Client) LinkProjectToTeam(projectID string, teamID string) error {
 	var mutation linkProjectToTeamMutation
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.LinkProjectV2ToTeamInput{
 			ProjectID: githubv4.String(projectID),
 			TeamID:    githubv4.ID(teamID),
@@ -1687,7 +1687,7 @@ func (c *Client) LinkProjectToTeam(projectID string, teamID string) error {
 // UnlinkProjectFromRepository unlinks a project from a repository.
 func (c *Client) UnlinkProjectFromRepository(projectID string, repoID string) error {
 	var mutation unlinkProjectFromRepoMutation
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.UnlinkProjectV2FromRepositoryInput{
 			ProjectID:    githubv4.String(projectID),
 			RepositoryID: githubv4.ID(repoID),
@@ -1700,7 +1700,7 @@ func (c *Client) UnlinkProjectFromRepository(projectID string, repoID string) er
 // UnlinkProjectFromTeam unlinks a project from a team.
 func (c *Client) UnlinkProjectFromTeam(projectID string, teamID string) error {
 	var mutation unlinkProjectFromTeamMutation
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.UnlinkProjectV2FromTeamInput{
 			ProjectID: githubv4.String(projectID),
 			TeamID:    githubv4.ID(teamID),
@@ -1747,12 +1747,12 @@ func requiredScopesFromServerMessage(msg string) []string {
 	return scopes
 }
 
-func projectFieldValueData(v FieldValueNodes) interface{} {
+func projectFieldValueData(v FieldValueNodes) any {
 	switch v.Type {
 	case "ProjectV2ItemFieldDateValue":
 		return v.ProjectV2ItemFieldDateValue.Date
 	case "ProjectV2ItemFieldIterationValue":
-		return map[string]interface{}{
+		return map[string]any{
 			"title":       v.ProjectV2ItemFieldIterationValue.Title,
 			"startDate":   v.ProjectV2ItemFieldIterationValue.StartDate,
 			"duration":    v.ProjectV2ItemFieldIterationValue.Duration,
@@ -1765,7 +1765,7 @@ func projectFieldValueData(v FieldValueNodes) interface{} {
 	case "ProjectV2ItemFieldTextValue":
 		return v.ProjectV2ItemFieldTextValue.Text
 	case "ProjectV2ItemFieldMilestoneValue":
-		return map[string]interface{}{
+		return map[string]any{
 			"title":       v.ProjectV2ItemFieldMilestoneValue.Milestone.Title,
 			"description": v.ProjectV2ItemFieldMilestoneValue.Milestone.Description,
 			"dueOn":       v.ProjectV2ItemFieldMilestoneValue.Milestone.DueOn,
@@ -1807,19 +1807,19 @@ func projectFieldValueData(v FieldValueNodes) interface{} {
 }
 
 // serialize creates a map from field to field values
-func serializeProjectWithItems(project *Project) []map[string]interface{} {
+func serializeProjectWithItems(project *Project) []map[string]any {
 	fields := make(map[string]string)
 
 	// make a map of fields by ID
 	for _, f := range project.Fields.Nodes {
 		fields[f.ID()] = camelCase(f.Name())
 	}
-	itemsSlice := make([]map[string]interface{}, 0)
+	itemsSlice := make([]map[string]any, 0)
 
 	// for each value, look up the name by ID
 	// and set the value to the field value
 	for _, i := range project.Items.Nodes {
-		o := make(map[string]interface{})
+		o := make(map[string]any)
 		o["id"] = i.Id
 		if projectItem := i.DetailedItem(); projectItem != nil {
 			o["content"] = projectItem.ExportData(nil)
@@ -1849,5 +1849,5 @@ func camelCase(s string) string {
 }
 
 type exportable interface {
-	ExportData([]string) map[string]interface{}
+	ExportData([]string) map[string]any
 }

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -1732,7 +1732,7 @@ func requiredScopesFromServerMessage(msg string) []string {
 		return nil
 	}
 	var scopes []string
-	for _, mm := range strings.Split(m[1], ",") {
+	for mm := range strings.SplitSeq(m[1], ",") {
 		scopes = append(scopes, strings.Trim(mm, "' "))
 	}
 	return scopes

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -695,10 +695,7 @@ func (c *Client) ProjectItems(o *Owner, number int32, limit int, queryStr string
 	}
 
 	// set first to the min of limit and LimitMax
-	first := LimitMax
-	if limit < first {
-		first = limit
-	}
+	first := min(limit, LimitMax)
 
 	variables := map[string]any{
 		"firstItems":  githubv4.Int(first),
@@ -1087,10 +1084,7 @@ func (c *Client) ProjectFields(o *Owner, number int32, limit int) (*Project, err
 	}
 
 	// set first to the min of limit and LimitMax
-	first := LimitMax
-	if limit < first {
-		first = limit
-	}
+	first := min(limit, LimitMax)
 	variables := map[string]any{
 		"firstItems":  githubv4.Int(LimitMax),
 		"afterItems":  (*githubv4.String)(nil),
@@ -1561,10 +1555,7 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 	}
 
 	// set first to the min of limit and LimitMax
-	first := LimitMax
-	if limit < first {
-		first = limit
-	}
+	first := min(limit, LimitMax)
 
 	variables := map[string]any{
 		"first":       githubv4.Int(first),

--- a/pkg/cmd/project/shared/queries/queries_test.go
+++ b/pkg/cmd/project/shared/queries/queries_test.go
@@ -53,7 +53,7 @@ func TestProjectMutationQuery_DoesNotRequireQueryVariable(t *testing.T) {
 		} `graphql:"updateProjectV2(input:$input)"`
 	}{}
 
-	err := client.Mutate("UpdateProjectV2", &mutation, map[string]interface{}{
+	err := client.Mutate("UpdateProjectV2", &mutation, map[string]any{
 		"input": githubv4.UpdateProjectV2Input{
 			ProjectID: githubv4.ID("project ID"),
 		},
@@ -72,9 +72,9 @@ func TestProjectItems_DefaultLimit(t *testing.T) {
 	// list project items
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProjectWithItems.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"firstItems":  LimitMax,
 				"afterItems":  nil,
 				"firstFields": LimitMax,
@@ -84,12 +84,12 @@ func TestProjectItems_DefaultLimit(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
 								},
@@ -125,9 +125,9 @@ func TestProjectItems_LowerLimit(t *testing.T) {
 	// list project items
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProjectWithItems.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"firstItems":  2,
 				"afterItems":  nil,
 				"firstFields": LimitMax,
@@ -137,12 +137,12 @@ func TestProjectItems_LowerLimit(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
 								},
@@ -175,9 +175,9 @@ func TestProjectItems_NoLimit(t *testing.T) {
 	// list project items
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProjectWithItems.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"firstItems":  LimitDefault,
 				"afterItems":  nil,
 				"firstFields": LimitMax,
@@ -187,12 +187,12 @@ func TestProjectItems_NoLimit(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "issue ID",
 								},
@@ -227,7 +227,7 @@ func TestProjectItems_WithQuery(t *testing.T) {
 		owner     *Owner
 		queryName string
 		dataKey   string
-		vars      map[string]interface{}
+		vars      map[string]any
 	}{
 		{
 			name: "user owner",
@@ -238,7 +238,7 @@ func TestProjectItems_WithQuery(t *testing.T) {
 			},
 			queryName: "UserProjectWithItems",
 			dataKey:   "user",
-			vars: map[string]interface{}{
+			vars: map[string]any{
 				"firstItems":  LimitMax,
 				"afterItems":  nil,
 				"firstFields": LimitMax,
@@ -257,7 +257,7 @@ func TestProjectItems_WithQuery(t *testing.T) {
 			},
 			queryName: "OrgProjectWithItems",
 			dataKey:   "organization",
-			vars: map[string]interface{}{
+			vars: map[string]any{
 				"firstItems":  LimitMax,
 				"afterItems":  nil,
 				"firstFields": LimitMax,
@@ -275,7 +275,7 @@ func TestProjectItems_WithQuery(t *testing.T) {
 			},
 			queryName: "ViewerProjectWithItems",
 			dataKey:   "viewer",
-			vars: map[string]interface{}{
+			vars: map[string]any{
 				"firstItems":  LimitMax,
 				"afterItems":  nil,
 				"firstFields": LimitMax,
@@ -293,17 +293,17 @@ func TestProjectItems_WithQuery(t *testing.T) {
 
 			gock.New("https://api.github.com").
 				Post("/graphql").
-				JSON(map[string]interface{}{
+				JSON(map[string]any{
 					"query":     "query " + tt.queryName + ".*",
 					"variables": tt.vars,
 				}).
 				Reply(200).
-				JSON(map[string]interface{}{
-					"data": map[string]interface{}{
-						tt.dataKey: map[string]interface{}{
-							"projectV2": map[string]interface{}{
-								"items": map[string]interface{}{
-									"nodes": []map[string]interface{}{
+				JSON(map[string]any{
+					"data": map[string]any{
+						tt.dataKey: map[string]any{
+							"projectV2": map[string]any{
+								"items": map[string]any{
+									"nodes": []map[string]any{
 										{
 											"id": "issue ID",
 										},
@@ -415,9 +415,9 @@ func TestProjectFields_LowerLimit(t *testing.T) {
 	// list project fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  LimitMax,
@@ -427,12 +427,12 @@ func TestProjectFields_LowerLimit(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "field ID",
 								},
@@ -465,9 +465,9 @@ func TestProjectFields_DefaultLimit(t *testing.T) {
 	// list project fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  LimitMax,
@@ -477,12 +477,12 @@ func TestProjectFields_DefaultLimit(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "field ID",
 								},
@@ -518,9 +518,9 @@ func TestProjectFields_NoLimit(t *testing.T) {
 	// list project fields
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  LimitMax,
@@ -530,12 +530,12 @@ func TestProjectFields_NoLimit(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"fields": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"fields": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "field ID",
 								},
@@ -615,9 +615,9 @@ func TestProjectItems_FieldTitle(t *testing.T) {
 	// list project items
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProjectWithItems.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"firstItems":  LimitMax,
 				"afterItems":  nil,
 				"firstFields": LimitMax,
@@ -627,16 +627,16 @@ func TestProjectItems_FieldTitle(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
-					"projectV2": map[string]interface{}{
-						"items": map[string]interface{}{
-							"nodes": []map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
+					"projectV2": map[string]any{
+						"items": map[string]any{
+							"nodes": []map[string]any{
 								{
 									"id": "draft issue ID",
-									"fieldValues": map[string]interface{}{
-										"nodes": []map[string]interface{}{
+									"fieldValues": map[string]any{
+										"nodes": []map[string]any{
 											{
 												"__typename":  "ProjectV2ItemFieldIterationValue",
 												"title":       "Iteration Title 1",
@@ -644,7 +644,7 @@ func TestProjectItems_FieldTitle(t *testing.T) {
 											},
 											{
 												"__typename": "ProjectV2ItemFieldMilestoneValue",
-												"milestone": map[string]interface{}{
+												"milestone": map[string]any{
 													"title": "Milestone Title 1",
 												},
 											},

--- a/pkg/cmd/project/shared/queries/resolve.go
+++ b/pkg/cmd/project/shared/queries/resolve.go
@@ -156,7 +156,7 @@ func (c *Client) ProjectItemIDByURL(rawURL, projectID string, projectNumber int3
 		return "", err
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"url":        githubv4.URI{URL: uri},
 		"firstItems": githubv4.Int(LimitMax),
 	}

--- a/pkg/cmd/project/shared/queries/resolve_test.go
+++ b/pkg/cmd/project/shared/queries/resolve_test.go
@@ -78,14 +78,14 @@ func TestProjectItemIDByURL(t *testing.T) {
 		gock.New("https://api.github.com").
 			Post("/graphql").
 			Reply(200).
-			JSON(map[string]interface{}{
-				"data": map[string]interface{}{
-					"resource": map[string]interface{}{
+			JSON(map[string]any{
+				"data": map[string]any{
+					"resource": map[string]any{
 						"__typename": "Issue",
-						"projectItems": map[string]interface{}{
-							"nodes": []map[string]interface{}{
-								{"id": "PVTI_other", "project": map[string]interface{}{"id": "PVT_other"}},
-								{"id": "PVTI_match", "project": map[string]interface{}{"id": "PVT_target"}},
+						"projectItems": map[string]any{
+							"nodes": []map[string]any{
+								{"id": "PVTI_other", "project": map[string]any{"id": "PVT_other"}},
+								{"id": "PVTI_match", "project": map[string]any{"id": "PVT_target"}},
 							},
 						},
 					},
@@ -103,13 +103,13 @@ func TestProjectItemIDByURL(t *testing.T) {
 		gock.New("https://api.github.com").
 			Post("/graphql").
 			Reply(200).
-			JSON(map[string]interface{}{
-				"data": map[string]interface{}{
-					"resource": map[string]interface{}{
+			JSON(map[string]any{
+				"data": map[string]any{
+					"resource": map[string]any{
 						"__typename": "Issue",
-						"projectItems": map[string]interface{}{
-							"nodes": []map[string]interface{}{
-								{"id": "PVTI_other", "project": map[string]interface{}{"id": "PVT_other"}},
+						"projectItems": map[string]any{
+							"nodes": []map[string]any{
+								{"id": "PVTI_other", "project": map[string]any{"id": "PVT_other"}},
 							},
 						},
 					},

--- a/pkg/cmd/project/unlink/unlink_test.go
+++ b/pkg/cmd/project/unlink/unlink_test.go
@@ -191,22 +191,22 @@ func TestRunUnlink_Repo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id":    "an ID",
 					"login": "monalisa",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -217,9 +217,9 @@ func TestRunUnlink_Repo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa",
 				"number":      1,
 				"firstItems":  0,
@@ -229,9 +229,9 @@ func TestRunUnlink_Repo(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id":    "project-ID",
 						"title": "first-project",
@@ -244,13 +244,13 @@ func TestRunUnlink_Repo(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "mutation UnlinkProjectV2FromRepository.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"unlinkProjectV2FromRepository": map[string]interface{}{},
+		JSON(map[string]any{
+			"data": map[string]any{
+				"unlinkProjectV2FromRepository": map[string]any{},
 			},
 		})
 
@@ -259,9 +259,9 @@ func TestRunUnlink_Repo(t *testing.T) {
 		Post("/graphql").
 		BodyString(`.*query RepositoryInfo.*`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"repository": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
 					"id": "repo-ID",
 				},
 			},
@@ -301,22 +301,22 @@ func TestRunUnlink_Team(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
 			"variables": map[string]string{
 				"login": "monalisa-org",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id":    "an ID",
 					"login": "monalisa-org",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -327,9 +327,9 @@ func TestRunUnlink_Team(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserProject.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login":       "monalisa-org",
 				"number":      1,
 				"firstItems":  0,
@@ -339,9 +339,9 @@ func TestRunUnlink_Team(t *testing.T) {
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"projectV2": map[string]string{
 						"id":    "project-ID",
 						"title": "first-project",
@@ -354,13 +354,13 @@ func TestRunUnlink_Team(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "mutation UnlinkProjectV2FromTeam.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"unlinkProjectV2FromTeam": map[string]interface{}{},
+		JSON(map[string]any{
+			"data": map[string]any{
+				"unlinkProjectV2FromTeam": map[string]any{},
 			},
 		})
 
@@ -369,10 +369,10 @@ func TestRunUnlink_Team(t *testing.T) {
 		Post("/graphql").
 		BodyString(`.*query OrganizationTeam.*`).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
-					"team": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"team": map[string]any{
 						"id": "team-ID",
 					},
 				},

--- a/pkg/cmd/project/view/view_test.go
+++ b/pkg/cmd/project/view/view_test.go
@@ -98,21 +98,21 @@ func TestRunView_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -170,13 +170,13 @@ func TestRunView_Viewer(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query ViewerOwner.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id": "an ID",
 				},
 			},
@@ -233,21 +233,21 @@ func TestRunView_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -305,21 +305,21 @@ func TestRunViewWeb_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "monalisa",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"user": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"user": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"organization"},
 				},
@@ -383,21 +383,21 @@ func TestRunViewWeb_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query UserOrgOwner.*",
-			"variables": map[string]interface{}{
+			"variables": map[string]any{
 				"login": "github",
 			},
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"organization": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
 					"id": "an ID",
 				},
 			},
-			"errors": []interface{}{
-				map[string]interface{}{
+			"errors": []any{
+				map[string]any{
 					"type": "NOT_FOUND",
 					"path": []string{"user"},
 				},
@@ -461,13 +461,13 @@ func TestRunViewWeb_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query": "query Viewer.*",
 		}).
 		Reply(200).
-		JSON(map[string]interface{}{
-			"data": map[string]interface{}{
-				"viewer": map[string]interface{}{
+		JSON(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{
 					"id":    "an ID",
 					"login": "theviewer",
 				},
@@ -477,9 +477,9 @@ func TestRunViewWeb_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		MatchType("json").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"query":     "query ViewerProject.*",
-			"variables": map[string]interface{}{"afterFields": nil, "afterItems": nil, "firstFields": 100, "firstItems": 0, "number": 8},
+			"variables": map[string]any{"afterFields": nil, "afterItems": nil, "firstFields": 100, "firstItems": 0, "number": 8},
 		}).
 		Reply(200).
 		JSON(`
@@ -550,21 +550,21 @@ func TestRunViewWeb_TTY(t *testing.T) {
 				gock.New("https://api.github.com").
 					Post("/graphql").
 					MatchType("json").
-					JSON(map[string]interface{}{
+					JSON(map[string]any{
 						"query": "query ViewerLoginAndOrgs.*",
-						"variables": map[string]interface{}{
+						"variables": map[string]any{
 							"after": nil,
 						},
 					}).
 					Reply(200).
-					JSON(map[string]interface{}{
-						"data": map[string]interface{}{
-							"viewer": map[string]interface{}{
+					JSON(map[string]any{
+						"data": map[string]any{
+							"viewer": map[string]any{
 								"id":    "monalisa-ID",
 								"login": "monalisa",
-								"organizations": map[string]interface{}{
-									"nodes": []interface{}{
-										map[string]interface{}{
+								"organizations": map[string]any{
+									"nodes": []any{
+										map[string]any{
 											"login":                   "github",
 											"viewerCanCreateProjects": true,
 										},
@@ -577,9 +577,9 @@ func TestRunViewWeb_TTY(t *testing.T) {
 				gock.New("https://api.github.com").
 					Post("/graphql").
 					MatchType("json").
-					JSON(map[string]interface{}{
+					JSON(map[string]any{
 						"query": "query OrgProjects.*",
-						"variables": map[string]interface{}{
+						"variables": map[string]any{
 							"after":       nil,
 							"afterFields": nil,
 							"afterItems":  nil,
@@ -590,13 +590,13 @@ func TestRunViewWeb_TTY(t *testing.T) {
 						},
 					}).
 					Reply(200).
-					JSON(map[string]interface{}{
-						"data": map[string]interface{}{
-							"organization": map[string]interface{}{
+					JSON(map[string]any{
+						"data": map[string]any{
+							"organization": map[string]any{
 								"login": "github",
-								"projectsV2": map[string]interface{}{
-									"nodes": []interface{}{
-										map[string]interface{}{
+								"projectsV2": map[string]any{
+									"nodes": []any{
+										map[string]any{
 											"id":     "a-project-ID",
 											"title":  "Get it done!",
 											"url":    "https://github.com/orgs/github/projects/1",
@@ -634,21 +634,21 @@ func TestRunViewWeb_TTY(t *testing.T) {
 				gock.New("https://api.github.com").
 					Post("/graphql").
 					MatchType("json").
-					JSON(map[string]interface{}{
+					JSON(map[string]any{
 						"query": "query ViewerLoginAndOrgs.*",
-						"variables": map[string]interface{}{
+						"variables": map[string]any{
 							"after": nil,
 						},
 					}).
 					Reply(200).
-					JSON(map[string]interface{}{
-						"data": map[string]interface{}{
-							"viewer": map[string]interface{}{
+					JSON(map[string]any{
+						"data": map[string]any{
+							"viewer": map[string]any{
 								"id":    "monalisa-ID",
 								"login": "monalisa",
-								"organizations": map[string]interface{}{
-									"nodes": []interface{}{
-										map[string]interface{}{
+								"organizations": map[string]any{
+									"nodes": []any{
+										map[string]any{
 											"login":                   "github",
 											"viewerCanCreateProjects": true,
 										},
@@ -661,21 +661,21 @@ func TestRunViewWeb_TTY(t *testing.T) {
 				gock.New("https://api.github.com").
 					Post("/graphql").
 					MatchType("json").
-					JSON(map[string]interface{}{
+					JSON(map[string]any{
 						"query": "query ViewerProjects.*",
-						"variables": map[string]interface{}{
+						"variables": map[string]any{
 							"after": nil, "afterFields": nil, "afterItems": nil, "first": 30, "firstFields": 100, "firstItems": 0,
 						},
 					}).
 					Reply(200).
-					JSON(map[string]interface{}{
-						"data": map[string]interface{}{
-							"viewer": map[string]interface{}{
+					JSON(map[string]any{
+						"data": map[string]any{
+							"viewer": map[string]any{
 								"login": "monalisa",
-								"projectsV2": map[string]interface{}{
+								"projectsV2": map[string]any{
 									"totalCount": 1,
-									"nodes": []interface{}{
-										map[string]interface{}{
+									"nodes": []any{
+										map[string]any{
 											"id":     "a-project-ID",
 											"number": 1,
 											"title":  "@monalia's first project",

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -628,7 +628,7 @@ func changelogForRange(client *git.Client, refRange string) ([]logEntry, error) 
 	}
 
 	var entries []logEntry
-	for _, cb := range bytes.Split(b, []byte{'\000'}) {
+	for cb := range bytes.SplitSeq(b, []byte{'\000'}) {
 		c := strings.ReplaceAll(string(cb), "\r\n", "\n")
 		c = strings.TrimPrefix(c, "\n")
 		if len(c) == 0 {

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -445,7 +445,7 @@ func createRun(opts *CreateOptions) error {
 		}
 	}
 
-	params := map[string]interface{}{
+	params := map[string]any{
 		"tag_name":   opts.TagName,
 		"draft":      opts.Draft,
 		"prerelease": opts.Prerelease,

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -463,8 +463,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":   "v1.2.3",
 						"name":       "The Big 1.2",
 						"body":       "* Fixed bugs",
@@ -498,8 +498,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":   "v1.2.3",
 						"name":       "The Big 1.2",
 						"body":       "* Fixed bugs",
@@ -534,8 +534,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":   "v1.2.3",
 						"name":       "The Big 1.2",
 						"body":       "* Fixed bugs",
@@ -587,8 +587,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":                 "v1.2.3",
 						"name":                     "The Big 1.2",
 						"body":                     "* Fixed bugs",
@@ -617,8 +617,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":         "v1.2.3",
 						"draft":            false,
 						"prerelease":       false,
@@ -646,8 +646,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":   "v1.2.3",
 						"draft":      true,
 						"prerelease": false,
@@ -675,8 +675,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":    "v1.2.3",
 						"draft":       false,
 						"prerelease":  false,
@@ -704,8 +704,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":               "v1.2.3",
 						"draft":                  false,
 						"prerelease":             false,
@@ -734,8 +734,8 @@ func Test_createRun(t *testing.T) {
 					httpmock.RESTPayload(200, `{
 						"name": "generated name",
 						"body": "generated body"
-				}`, func(params map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+						assert.Equal(t, map[string]any{
 							"tag_name":          "v1.2.3",
 							"previous_tag_name": "v1.1.0",
 						}, params)
@@ -744,8 +744,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":   "v1.2.3",
 						"draft":      false,
 						"prerelease": false,
@@ -775,8 +775,8 @@ func Test_createRun(t *testing.T) {
 					httpmock.RESTPayload(200, `{
 						"name": "generated name",
 						"body": "generated body"
-				}`, func(params map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+						assert.Equal(t, map[string]any{
 							"tag_name":          "v1.2.3",
 							"previous_tag_name": "v1.1.0",
 						}, params)
@@ -785,8 +785,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":   "v1.2.3",
 						"draft":      false,
 						"prerelease": false,
@@ -825,8 +825,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":   "v1.2.3",
 						"draft":      true,
 						"prerelease": false,
@@ -847,8 +847,8 @@ func Test_createRun(t *testing.T) {
 				})
 				reg.Register(httpmock.REST("PATCH", "releases/123"), httpmock.RESTPayload(201, `{
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3-final"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"draft": false,
 					}, params)
 				}))
@@ -884,8 +884,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":    "v1.2.3",
 						"draft":       true,
 						"prerelease":  false,
@@ -907,8 +907,8 @@ func Test_createRun(t *testing.T) {
 				})
 				reg.Register(httpmock.REST("PATCH", "releases/123"), httpmock.RESTPayload(201, `{
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3-final"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"draft":       false,
 						"make_latest": "false",
 					}, params)
@@ -1072,8 +1072,8 @@ func Test_createRun(t *testing.T) {
 					"url": "https://api.github.com/releases/123",
 					"upload_url": "https://api.github.com/assets/upload",
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":                 "v1.2.3",
 						"draft":                    true,
 						"prerelease":               false,
@@ -1095,8 +1095,8 @@ func Test_createRun(t *testing.T) {
 				})
 				reg.Register(httpmock.REST("PATCH", "releases/123"), httpmock.RESTPayload(201, `{
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3-final"
-				}`, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"draft":                    false,
 						"discussion_category_name": "general",
 					}, params)
@@ -1130,8 +1130,8 @@ func Test_createRun(t *testing.T) {
 						"url": "https://api.github.com/releases/123",
 						"upload_url": "https://api.github.com/assets/upload",
 						"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-					}`, func(payload map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					}`, func(payload map[string]any) {
+						assert.Equal(t, map[string]any{
 							"tag_name":   "v1.2.3",
 							"draft":      false,
 							"prerelease": false,
@@ -1168,8 +1168,8 @@ func Test_createRun(t *testing.T) {
 						"url": "https://api.github.com/releases/123",
 						"upload_url": "https://api.github.com/assets/upload",
 						"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
-					}`, func(payload map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					}`, func(payload map[string]any) {
+						assert.Equal(t, map[string]any{
 							"tag_name":   "v1.2.3",
 							"draft":      false,
 							"prerelease": false,
@@ -1318,7 +1318,7 @@ func Test_createRun_interactive(t *testing.T) {
 		prompterStubs func(*testing.T, *prompter.MockPrompter)
 		runStubs      func(*run.CommandStubber)
 		opts          *CreateOptions
-		wantParams    map[string]interface{}
+		wantParams    map[string]any
 		wantOut       string
 		wantErr       string
 	}{
@@ -1458,7 +1458,7 @@ func Test_createRun_interactive(t *testing.T) {
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
 				}`))
 			},
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"draft":      false,
 				"name":       "generated name",
 				"prerelease": false,
@@ -1503,7 +1503,7 @@ func Test_createRun_interactive(t *testing.T) {
 						"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
 					}`))
 			},
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"body":       "generated body",
 				"draft":      false,
 				"name":       "generated name",
@@ -1550,7 +1550,7 @@ func Test_createRun_interactive(t *testing.T) {
 						"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
 					}`))
 			},
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"body":       "* commit subject\n\n  commit body\n  ",
 				"draft":      false,
 				"prerelease": false,
@@ -1598,7 +1598,7 @@ func Test_createRun_interactive(t *testing.T) {
 						"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
 					}`))
 			},
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"body":       "hello from annotated tag",
 				"draft":      false,
 				"prerelease": false,
@@ -1661,7 +1661,7 @@ func Test_createRun_interactive(t *testing.T) {
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
 				}`))
 			},
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"draft":            false,
 				"name":             "generated name",
 				"prerelease":       false,
@@ -1700,8 +1700,8 @@ func Test_createRun_interactive(t *testing.T) {
 					httpmock.RESTPayload(200, `{
 						"name": "generated name",
 						"body": "generated body"
-				}`, func(params map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+				}`, func(params map[string]any) {
+						assert.Equal(t, map[string]any{
 							"tag_name":          "v1.2.3",
 							"previous_tag_name": "v1.1.0",
 						}, params)
@@ -1713,7 +1713,7 @@ func Test_createRun_interactive(t *testing.T) {
 						"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
 					}`))
 			},
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"body":       "generated body",
 				"draft":      false,
 				"name":       "generated name",
@@ -1760,7 +1760,7 @@ func Test_createRun_interactive(t *testing.T) {
 						"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
 					}`))
 			},
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"body":       "* commit subject\n\n  commit body\n  ",
 				"draft":      false,
 				"prerelease": false,
@@ -1812,7 +1812,7 @@ func Test_createRun_interactive(t *testing.T) {
 					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
 				}`))
 			},
-			wantParams: map[string]interface{}{
+			wantParams: map[string]any{
 				"draft":      false,
 				"name":       "generated name",
 				"prerelease": false,
@@ -1896,7 +1896,7 @@ func Test_createRun_interactive(t *testing.T) {
 				}
 				bb, err := io.ReadAll(r.Body)
 				assert.NoError(t, err)
-				var params map[string]interface{}
+				var params map[string]any
 				err = json.Unmarshal(bb, &params)
 				assert.NoError(t, err)
 				assert.Equal(t, tt.wantParams, params)

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -278,7 +278,7 @@ func Test_NewCmdCreate(t *testing.T) {
 				BodyProvided:  false,
 				Draft:         false,
 				Prerelease:    false,
-				IsLatest:      boolPtr(true),
+				IsLatest:      new(true),
 				RepoOverride:  "",
 				Concurrency:   5,
 				Assets:        []*shared.AssetForUpload(nil),
@@ -298,7 +298,7 @@ func Test_NewCmdCreate(t *testing.T) {
 				BodyProvided:  false,
 				Draft:         false,
 				Prerelease:    false,
-				IsLatest:      boolPtr(false),
+				IsLatest:      new(false),
 				RepoOverride:  "",
 				Concurrency:   5,
 				Assets:        []*shared.AssetForUpload(nil),
@@ -665,7 +665,7 @@ func Test_createRun(t *testing.T) {
 				Name:          "",
 				Body:          "",
 				Target:        "",
-				IsLatest:      boolPtr(true),
+				IsLatest:      new(true),
 				BodyProvided:  true,
 				GenerateNotes: false,
 			},
@@ -865,7 +865,7 @@ func Test_createRun(t *testing.T) {
 				Body:         "",
 				BodyProvided: true,
 				Draft:        false,
-				IsLatest:     boolPtr(false),
+				IsLatest:     new(false),
 				Target:       "",
 				Assets: []*shared.AssetForUpload{
 					{
@@ -2008,6 +2008,7 @@ func Test_gitTagInfo(t *testing.T) {
 	}
 }
 
+//go:fix inline
 func boolPtr(b bool) *bool {
-	return &b
+	return new(b)
 }

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -2007,8 +2007,3 @@ func Test_gitTagInfo(t *testing.T) {
 		})
 	}
 }
-
-//go:fix inline
-func boolPtr(b bool) *bool {
-	return new(b)
-}

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -227,7 +227,7 @@ func tokenHasWorkflowScope(headers http.Header) bool {
 
 	// The API returns scopes separated by a comma and a space, so each element
 	// must be trimmed before comparison.
-	for _, s := range strings.Split(scopes, ",") {
+	for s := range strings.SplitSeq(scopes, ",") {
 		if strings.TrimSpace(s) == "workflow" {
 			return true
 		}

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -49,7 +49,7 @@ func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagName str
 			} `graphql:"ref(qualifiedName: $tagName)"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":   githubv4.String(repo.RepoOwner()),
 		"name":    githubv4.String(repo.RepoName()),
 		"tagName": githubv4.String(qualifiedTagName),
@@ -74,7 +74,7 @@ func getTags(httpClient *http.Client, repo ghrepo.Interface, limit int) ([]tag, 
 }
 
 func generateReleaseNotes(httpClient *http.Client, repo ghrepo.Interface, tagName, target, previousTagName string) (*releaseNotes, error) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"tag_name": tagName,
 	}
 	if target != "" {
@@ -138,7 +138,7 @@ func publishedReleaseExists(httpClient *http.Client, repo ghrepo.Interface, tagN
 	}
 }
 
-func createRelease(httpClient *http.Client, repo ghrepo.Interface, params map[string]interface{}) (*shared.Release, error) {
+func createRelease(httpClient *http.Client, repo ghrepo.Interface, params map[string]any) (*shared.Release, error) {
 	bodyBytes, err := json.Marshal(params)
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ func createRelease(httpClient *http.Client, repo ghrepo.Interface, params map[st
 }
 
 func publishRelease(httpClient *http.Client, host string, releaseURL safeurl.SafeURL, discussionCategory string, isLatest *bool) (*shared.Release, error) {
-	params := map[string]interface{}{"draft": false}
+	params := map[string]any{"draft": false}
 	if discussionCategory != "" {
 		params["discussion_category_name"] = discussionCategory
 	}

--- a/pkg/cmd/release/create/http_test.go
+++ b/pkg/cmd/release/create/http_test.go
@@ -60,7 +60,7 @@ func TestCreateReleaseMissingWorkflowScope(t *testing.T) {
 		httpmock.StatusScopesResponder(http.StatusNotFound, "repo,read:org"),
 	)
 
-	_, err := createRelease(&http.Client{Transport: reg}, ghrepo.New("OWNER", "REPO"), map[string]interface{}{"tag_name": "v1.2.3"})
+	_, err := createRelease(&http.Client{Transport: reg}, ghrepo.New("OWNER", "REPO"), map[string]any{"tag_name": "v1.2.3"})
 
 	var scopeErr *errMissingRequiredWorkflowScope
 	require.ErrorAs(t, err, &scopeErr)
@@ -76,7 +76,7 @@ func TestCreateReleaseHTTPErrorWithoutScopesHeader(t *testing.T) {
 		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
 	)
 
-	_, err := createRelease(&http.Client{Transport: reg}, ghrepo.New("OWNER", "REPO"), map[string]interface{}{"tag_name": "v1.2.3"})
+	_, err := createRelease(&http.Client{Transport: reg}, ghrepo.New("OWNER", "REPO"), map[string]any{"tag_name": "v1.2.3"})
 
 	requireAPIHTTPError(t, err, http.StatusNotFound)
 }

--- a/pkg/cmd/release/download/download.go
+++ b/pkg/cmd/release/download/download.go
@@ -286,7 +286,7 @@ func downloadAssets(dest *destinationWriter, httpClient *http.Client, toDownload
 	close(jobs)
 
 	var downloadError error
-	for i := 0; i < len(toDownload); i++ {
+	for range toDownload {
 		if err := <-results; err != nil && !errors.Is(err, errSkipped) {
 			downloadError = err
 		}

--- a/pkg/cmd/release/edit/edit.go
+++ b/pkg/cmd/release/edit/edit.go
@@ -133,8 +133,8 @@ func editRun(tag string, opts *EditOptions) error {
 	return nil
 }
 
-func getParams(opts *EditOptions) map[string]interface{} {
-	params := map[string]interface{}{}
+func getParams(opts *EditOptions) map[string]any {
+	params := map[string]any{}
 
 	if opts.Body != nil {
 		params["body"] = opts.Body

--- a/pkg/cmd/release/edit/edit_test.go
+++ b/pkg/cmd/release/edit/edit_test.go
@@ -574,13 +574,3 @@ func Test_editRelease_bodyReadError(t *testing.T) {
 type errorReader struct{ err error }
 
 func (e errorReader) Read(_ []byte) (int, error) { return 0, e.err }
-
-//go:fix inline
-func boolPtr(b bool) *bool {
-	return new(b)
-}
-
-//go:fix inline
-func stringPtr(s string) *string {
-	return new(s)
-}

--- a/pkg/cmd/release/edit/edit_test.go
+++ b/pkg/cmd/release/edit/edit_test.go
@@ -222,8 +222,8 @@ func Test_editRun(t *testing.T) {
 				TagName: "v1.2.4",
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name": "v1.2.4",
 					}, params)
 				})
@@ -238,8 +238,8 @@ func Test_editRun(t *testing.T) {
 				Target: "c0ff33",
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":         "v1.2.3",
 						"target_commitish": "c0ff33",
 					}, params)
@@ -255,8 +255,8 @@ func Test_editRun(t *testing.T) {
 				Name: stringPtr("Hot Release #1"),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name": "v1.2.3",
 						"name":     "Hot Release #1",
 					}, params)
@@ -272,8 +272,8 @@ func Test_editRun(t *testing.T) {
 				DiscussionCategory: stringPtr("some-category"),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":                 "v1.2.3",
 						"discussion_category_name": "some-category",
 					}, params)
@@ -289,8 +289,8 @@ func Test_editRun(t *testing.T) {
 				IsLatest: boolPtr(true),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":    "v1.2.3",
 						"make_latest": "true",
 					}, params)
@@ -306,8 +306,8 @@ func Test_editRun(t *testing.T) {
 				Name: stringPtr(""),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name": "v1.2.3",
 						"name":     "",
 					}, params)
@@ -323,8 +323,8 @@ func Test_editRun(t *testing.T) {
 				Body: stringPtr("Release Notes:\n- Fix Bug #1\n- Fix Bug #2"),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name": "v1.2.3",
 						"body":     "Release Notes:\n- Fix Bug #1\n- Fix Bug #2",
 					}, params)
@@ -340,8 +340,8 @@ func Test_editRun(t *testing.T) {
 				Body: stringPtr(""),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name": "v1.2.3",
 						"body":     "",
 					}, params)
@@ -357,8 +357,8 @@ func Test_editRun(t *testing.T) {
 				Draft: boolPtr(true),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name": "v1.2.3",
 						"draft":    true,
 					}, params)
@@ -374,8 +374,8 @@ func Test_editRun(t *testing.T) {
 				Draft: boolPtr(false),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name": "v1.2.3",
 						"draft":    false,
 					}, params)
@@ -391,8 +391,8 @@ func Test_editRun(t *testing.T) {
 				Prerelease: boolPtr(true),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":   "v1.2.3",
 						"prerelease": true,
 					}, params)
@@ -408,8 +408,8 @@ func Test_editRun(t *testing.T) {
 				Prerelease: boolPtr(false),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
-					assert.Equal(t, map[string]interface{}{
+				mockSuccessfulEditResponse(reg, func(params map[string]any) {
+					assert.Equal(t, map[string]any{
 						"tag_name":   "v1.2.3",
 						"prerelease": false,
 					}, params)
@@ -474,7 +474,7 @@ func Test_editRun(t *testing.T) {
 	}
 }
 
-func mockSuccessfulEditResponse(reg *httpmock.Registry, cb func(params map[string]interface{})) {
+func mockSuccessfulEditResponse(reg *httpmock.Registry, cb func(params map[string]any)) {
 	matcher := httpmock.REST("PATCH", "repos/OWNER/REPO/releases/12345")
 	responder := httpmock.RESTPayload(201, `{
 		"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
@@ -495,7 +495,7 @@ func Test_editRelease_httpError(t *testing.T) {
 	)
 
 	httpClient := &http.Client{Transport: reg}
-	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]interface{}{"tag_name": "v1.2.3"})
+	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]any{"tag_name": "v1.2.3"})
 
 	var httpErr api.HTTPError
 	require.ErrorAs(t, err, &httpErr)
@@ -517,7 +517,7 @@ func Test_editRelease_decodeError(t *testing.T) {
 	)
 
 	httpClient := &http.Client{Transport: reg}
-	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]interface{}{"tag_name": "v1.2.3"})
+	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]any{"tag_name": "v1.2.3"})
 
 	require.Error(t, err)
 	assert.NotNil(t, release) // decode was attempted - non-nil pointer even on decode error
@@ -536,7 +536,7 @@ func Test_editRelease_204(t *testing.T) {
 	)
 
 	httpClient := &http.Client{Transport: reg}
-	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]interface{}{"tag_name": "v1.2.3"})
+	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]any{"tag_name": "v1.2.3"})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected end of JSON input")
@@ -563,7 +563,7 @@ func Test_editRelease_bodyReadError(t *testing.T) {
 	)
 
 	httpClient := &http.Client{Transport: reg}
-	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]interface{}{"tag_name": "v1.2.3"})
+	release, err := editRelease(httpClient, ghrepo.New("OWNER", "REPO"), 12345, map[string]any{"tag_name": "v1.2.3"})
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, readErr)

--- a/pkg/cmd/release/edit/edit_test.go
+++ b/pkg/cmd/release/edit/edit_test.go
@@ -47,8 +47,8 @@ func Test_NewCmdEdit(t *testing.T) {
 			isTTY: false,
 			want: EditOptions{
 				TagName: "",
-				Name:    stringPtr("Some Title"),
-				Body:    stringPtr("Some Notes"),
+				Name:    new("Some Title"),
+				Body:    new("Some Notes"),
 			},
 		},
 		{
@@ -57,7 +57,7 @@ func Test_NewCmdEdit(t *testing.T) {
 			isTTY: false,
 			want: EditOptions{
 				TagName:            "",
-				DiscussionCategory: stringPtr("some-category"),
+				DiscussionCategory: new("some-category"),
 			},
 		},
 		{
@@ -75,7 +75,7 @@ func Test_NewCmdEdit(t *testing.T) {
 			isTTY: false,
 			want: EditOptions{
 				TagName:    "",
-				Prerelease: boolPtr(true),
+				Prerelease: new(true),
 			},
 		},
 		{
@@ -84,7 +84,7 @@ func Test_NewCmdEdit(t *testing.T) {
 			isTTY: false,
 			want: EditOptions{
 				TagName:    "",
-				Prerelease: boolPtr(false),
+				Prerelease: new(false),
 			},
 		},
 		{
@@ -93,7 +93,7 @@ func Test_NewCmdEdit(t *testing.T) {
 			isTTY: false,
 			want: EditOptions{
 				TagName: "",
-				Draft:   boolPtr(true),
+				Draft:   new(true),
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func Test_NewCmdEdit(t *testing.T) {
 			isTTY: false,
 			want: EditOptions{
 				TagName: "",
-				Draft:   boolPtr(false),
+				Draft:   new(false),
 			},
 		},
 		{
@@ -111,7 +111,7 @@ func Test_NewCmdEdit(t *testing.T) {
 			isTTY: false,
 			want: EditOptions{
 				TagName:  "",
-				IsLatest: boolPtr(true),
+				IsLatest: new(true),
 			},
 		},
 		{
@@ -120,7 +120,7 @@ func Test_NewCmdEdit(t *testing.T) {
 			isTTY: false,
 			want: EditOptions{
 				TagName:  "",
-				IsLatest: boolPtr(false),
+				IsLatest: new(false),
 			},
 		},
 		{
@@ -129,7 +129,7 @@ func Test_NewCmdEdit(t *testing.T) {
 			isTTY: false,
 			want: EditOptions{
 				TagName: "",
-				Body:    stringPtr("MY NOTES"),
+				Body:    new("MY NOTES"),
 			},
 		},
 		{
@@ -139,7 +139,7 @@ func Test_NewCmdEdit(t *testing.T) {
 			stdin: "MY NOTES",
 			want: EditOptions{
 				TagName: "",
-				Body:    stringPtr("MY NOTES"),
+				Body:    new("MY NOTES"),
 			},
 		},
 		{
@@ -252,7 +252,7 @@ func Test_editRun(t *testing.T) {
 			name:  "edit the release name",
 			isTTY: true,
 			opts: EditOptions{
-				Name: stringPtr("Hot Release #1"),
+				Name: new("Hot Release #1"),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockSuccessfulEditResponse(reg, func(params map[string]any) {
@@ -269,7 +269,7 @@ func Test_editRun(t *testing.T) {
 			name:  "edit the discussion category",
 			isTTY: true,
 			opts: EditOptions{
-				DiscussionCategory: stringPtr("some-category"),
+				DiscussionCategory: new("some-category"),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockSuccessfulEditResponse(reg, func(params map[string]any) {
@@ -286,7 +286,7 @@ func Test_editRun(t *testing.T) {
 			name:  "edit the latest marker",
 			isTTY: false,
 			opts: EditOptions{
-				IsLatest: boolPtr(true),
+				IsLatest: new(true),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockSuccessfulEditResponse(reg, func(params map[string]any) {
@@ -303,7 +303,7 @@ func Test_editRun(t *testing.T) {
 			name:  "edit the release name (empty)",
 			isTTY: true,
 			opts: EditOptions{
-				Name: stringPtr(""),
+				Name: new(""),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockSuccessfulEditResponse(reg, func(params map[string]any) {
@@ -320,7 +320,7 @@ func Test_editRun(t *testing.T) {
 			name:  "edit the release notes",
 			isTTY: true,
 			opts: EditOptions{
-				Body: stringPtr("Release Notes:\n- Fix Bug #1\n- Fix Bug #2"),
+				Body: new("Release Notes:\n- Fix Bug #1\n- Fix Bug #2"),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockSuccessfulEditResponse(reg, func(params map[string]any) {
@@ -337,7 +337,7 @@ func Test_editRun(t *testing.T) {
 			name:  "edit the release notes (empty)",
 			isTTY: true,
 			opts: EditOptions{
-				Body: stringPtr(""),
+				Body: new(""),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockSuccessfulEditResponse(reg, func(params map[string]any) {
@@ -354,7 +354,7 @@ func Test_editRun(t *testing.T) {
 			name:  "edit draft (true)",
 			isTTY: true,
 			opts: EditOptions{
-				Draft: boolPtr(true),
+				Draft: new(true),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockSuccessfulEditResponse(reg, func(params map[string]any) {
@@ -371,7 +371,7 @@ func Test_editRun(t *testing.T) {
 			name:  "edit draft (false)",
 			isTTY: true,
 			opts: EditOptions{
-				Draft: boolPtr(false),
+				Draft: new(false),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockSuccessfulEditResponse(reg, func(params map[string]any) {
@@ -388,7 +388,7 @@ func Test_editRun(t *testing.T) {
 			name:  "edit prerelease (true)",
 			isTTY: true,
 			opts: EditOptions{
-				Prerelease: boolPtr(true),
+				Prerelease: new(true),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockSuccessfulEditResponse(reg, func(params map[string]any) {
@@ -405,7 +405,7 @@ func Test_editRun(t *testing.T) {
 			name:  "edit prerelease (false)",
 			isTTY: true,
 			opts: EditOptions{
-				Prerelease: boolPtr(false),
+				Prerelease: new(false),
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockSuccessfulEditResponse(reg, func(params map[string]any) {
@@ -575,10 +575,12 @@ type errorReader struct{ err error }
 
 func (e errorReader) Read(_ []byte) (int, error) { return 0, e.err }
 
+//go:fix inline
 func boolPtr(b bool) *bool {
-	return &b
+	return new(b)
 }
 
+//go:fix inline
 func stringPtr(s string) *string {
-	return &s
+	return new(s)
 }

--- a/pkg/cmd/release/edit/http.go
+++ b/pkg/cmd/release/edit/http.go
@@ -16,7 +16,7 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
-func editRelease(httpClient *http.Client, repo ghrepo.Interface, releaseID int64, params map[string]interface{}) (*shared.Release, error) {
+func editRelease(httpClient *http.Client, repo ghrepo.Interface, releaseID int64, params map[string]any) (*shared.Release, error) {
 	bodyBytes, err := json.Marshal(params)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagName str
 			} `graphql:"ref(qualifiedName: $tagName)"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":   githubv4.String(repo.RepoOwner()),
 		"name":    githubv4.String(repo.RepoName()),
 		"tagName": githubv4.String(qualifiedTagName),

--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -34,7 +34,7 @@ type Release struct {
 	PublishedAt  time.Time
 }
 
-func (r *Release) ExportData(fields []string) map[string]interface{} {
+func (r *Release) ExportData(fields []string) map[string]any {
 	return cmdutil.StructExportData(r, fields)
 }
 
@@ -77,7 +77,7 @@ func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, ex
 		perPage = 100
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"perPage":   githubv4.Int(perPage),
@@ -162,7 +162,7 @@ func fetchReleasesWithoutImmutableReleases(httpClient *http.Client, repo ghrepo.
 		perPage = 100
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"perPage":   githubv4.Int(perPage),

--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -72,10 +72,7 @@ func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, ex
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	perPage := limit
-	if limit > 100 {
-		perPage = 100
-	}
+	perPage := min(limit, 100)
 
 	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),
@@ -157,10 +154,7 @@ func fetchReleasesWithoutImmutableReleases(httpClient *http.Client, repo ghrepo.
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	perPage := limit
-	if limit > 100 {
-		perPage = 100
-	}
+	perPage := min(limit, 100)
 
 	variables := map[string]any{
 		"owner":     githubv4.String(repo.RepoOwner()),

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -172,7 +172,7 @@ func Test_listRun(t *testing.T) {
 								}
 							]
 						} } } }`, createdAt.Format(time.RFC3339)),
-					func(s string, m map[string]interface{}) {
+					func(s string, m map[string]any) {
 						// Assert "immutable" field is requested
 						assert.Regexp(t, `\bimmutable\b`, s)
 					},
@@ -229,7 +229,7 @@ func Test_listRun(t *testing.T) {
 								}
 							]
 						} } } }`, createdAt.Format(time.RFC3339)),
-					func(s string, m map[string]interface{}) {
+					func(s string, m map[string]any) {
 						// Assert "immutable" field is NOT requested
 						assert.NotRegexp(t, `\bimmutable\b`, s)
 					},

--- a/pkg/cmd/release/shared/fetch.go
+++ b/pkg/cmd/release/shared/fetch.go
@@ -86,26 +86,26 @@ type ReleaseAsset struct {
 	BrowserDownloadURL string    `json:"browser_download_url"`
 }
 
-func (rel *Release) ExportData(fields []string) map[string]interface{} {
+func (rel *Release) ExportData(fields []string) map[string]any {
 	v := reflect.ValueOf(rel).Elem()
 	fieldByName := func(v reflect.Value, field string) reflect.Value {
 		return v.FieldByNameFunc(func(s string) bool {
 			return strings.EqualFold(field, s)
 		})
 	}
-	data := map[string]interface{}{}
+	data := map[string]any{}
 
 	for _, f := range fields {
 		switch f {
 		case "author":
-			data[f] = map[string]interface{}{
+			data[f] = map[string]any{
 				"id":    rel.Author.ID,
 				"login": rel.Author.Login,
 			}
 		case "assets":
-			assets := make([]interface{}, 0, len(rel.Assets))
+			assets := make([]any, 0, len(rel.Assets))
 			for _, a := range rel.Assets {
-				assets = append(assets, map[string]interface{}{
+				assets = append(assets, map[string]any{
 					"url":           a.BrowserDownloadURL,
 					"apiUrl":        a.APIURL,
 					"id":            a.ID,
@@ -254,7 +254,7 @@ func fetchDraftRelease(ctx context.Context, httpClient *http.Client, repo ghrepo
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":   githubv4.String(repo.RepoOwner()),
 		"name":    githubv4.String(repo.RepoName()),
 		"tagName": githubv4.String(tagName),
@@ -317,7 +317,7 @@ func StubFetchRelease(t *testing.T, reg *httpmock.Registry, owner, repoName, tag
 		reg.Register(
 			httpmock.GraphQL(`query RepositoryReleaseByTag\b`),
 			httpmock.GraphQLQuery(`{ "data": { "repository": { "release": null }}}`,
-				func(q string, vars map[string]interface{}) {
+				func(q string, vars map[string]any) {
 					assert.Equal(t, owner, vars["owner"])
 					assert.Equal(t, repoName, vars["name"])
 					assert.Equal(t, tagName, vars["tagName"])

--- a/pkg/cmd/repo/archive/http.go
+++ b/pkg/cmd/repo/archive/http.go
@@ -16,7 +16,7 @@ func archiveRepo(client *http.Client, repo *api.Repository) error {
 		} `graphql:"archiveRepository(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.ArchiveRepositoryInput{
 			RepositoryID: repo.ID,
 		},

--- a/pkg/cmd/repo/autolink/create/http_test.go
+++ b/pkg/cmd/repo/autolink/create/http_test.go
@@ -133,8 +133,8 @@ func TestAutolinkCreator_Create(t *testing.T) {
 					http.MethodPost,
 					fmt.Sprintf("repos/%s/%s/autolinks", repo.RepoOwner(), repo.RepoName())),
 				httpmock.RESTPayload(tt.stubStatus, tt.stubRespJSON,
-					func(payload map[string]interface{}) {
-						require.Equal(t, map[string]interface{}{
+					func(payload map[string]any) {
+						require.Equal(t, map[string]any{
 							"is_alphanumeric": tt.req.IsAlphanumeric,
 							"key_prefix":      tt.req.KeyPrefix,
 							"url_template":    tt.req.URLTemplate,

--- a/pkg/cmd/repo/autolink/shared/autolink.go
+++ b/pkg/cmd/repo/autolink/shared/autolink.go
@@ -16,6 +16,6 @@ var AutolinkFields = []string{
 	"urlTemplate",
 }
 
-func (a *Autolink) ExportData(fields []string) map[string]interface{} {
+func (a *Autolink) ExportData(fields []string) map[string]any {
 	return cmdutil.StructExportData(a, fields)
 }

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -876,9 +876,9 @@ func Test_createRun(t *testing.T) {
 				reg.Register(
 					httpmock.REST("POST", "user/repos"),
 					httpmock.RESTPayload(200, "{\"name\":\"ElliotAlderson\", \"owner\":{\"login\": \"OWNER\"}, \"html_url\":\"https://github.com/OWNER/ElliotAlderson\"}",
-						func(payload map[string]interface{}) {
+						func(payload map[string]any) {
 							payload["name"] = "ElliotAlderson"
-							payload["owner"] = map[string]interface{}{"login": "OWNER"}
+							payload["owner"] = map[string]any{"login": "OWNER"}
 							payload["auto_init"] = true
 							payload["private"] = true
 						},
@@ -918,7 +918,7 @@ func Test_createRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(s string, m map[string]interface{}) {
+					}`, func(s string, m map[string]any) {
 						assert.Equal(t, "OWNER", m["owner"])
 						assert.Equal(t, "mytemplate", m["name"])
 					}),
@@ -940,7 +940,7 @@ func Test_createRun(t *testing.T) {
 								}
 							}
 						}
-					}`, func(m map[string]interface{}) {
+					}`, func(m map[string]any) {
 						assert.Equal(t, "REPOID", m["repositoryId"])
 					}))
 			},

--- a/pkg/cmd/repo/create/http.go
+++ b/pkg/cmd/repo/create/http.go
@@ -120,7 +120,7 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput) (*a
 			}
 		}
 
-		variables := map[string]interface{}{
+		variables := map[string]any{
 			"input": cloneTemplateRepositoryInput{
 				Name:               input.Name,
 				Description:        input.Description,
@@ -148,7 +148,7 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput) (*a
 		}
 
 		if !input.HasWikiEnabled || !input.HasIssuesEnabled || input.HomepageURL != "" {
-			updateVariables := map[string]interface{}{
+			updateVariables := map[string]any{
 				"input": updateRepositoryInput{
 					RepositoryID:     response.CloneTemplateRepository.Repository.ID,
 					HasWikiEnabled:   input.HasWikiEnabled,
@@ -218,7 +218,7 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput) (*a
 		}
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": createRepositoryInput{
 			Name:             input.Name,
 			Description:      input.Description,
@@ -290,7 +290,7 @@ func resolveOrganizationTeam(client *api.Client, hostname, orgName, teamSlug str
 func listTemplateRepositories(client *http.Client, hostname, owner string) ([]api.Repository, error) {
 	ownerConnection := "repositoryOwner(login: $owner)"
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"perPage": githubv4.Int(100),
 		"owner":   githubv4.String(owner),
 	}

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -46,8 +46,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"name":             "winter-foods",
 								"description":      "roasted chestnuts",
 								"homepageUrl":      "http://example.com",
@@ -87,8 +87,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"name":             "winter-foods",
 								"description":      "roasted chestnuts",
 								"homepageUrl":      "http://example.com",
@@ -130,8 +130,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"name":             "crisps",
 								"visibility":       "INTERNAL",
 								"ownerId":          "ORGID",
@@ -173,8 +173,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"name":             "crisps",
 								"visibility":       "INTERNAL",
 								"ownerId":          "ORGID",
@@ -218,8 +218,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"name":               "gen-project",
 								"description":        "my generated project",
 								"visibility":         "PRIVATE",
@@ -263,8 +263,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"name":               "gen-project",
 								"description":        "my generated project",
 								"visibility":         "PRIVATE",
@@ -286,8 +286,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"repositoryId":     "REPOID",
 								"hasIssuesEnabled": true,
 								"hasWikiEnabled":   false,
@@ -328,8 +328,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"name":               "gen-project",
 								"description":        "my generated project",
 								"visibility":         "PRIVATE",
@@ -351,8 +351,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"repositoryId":     "REPOID",
 								"hasIssuesEnabled": false,
 								"hasWikiEnabled":   true,
@@ -393,8 +393,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"name":               "gen-project",
 								"description":        "my generated project",
 								"visibility":         "PRIVATE",
@@ -416,8 +416,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"repositoryId":     "REPOID",
 								"hasIssuesEnabled": false,
 								"hasWikiEnabled":   false,
@@ -459,8 +459,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"name":               "gen-project",
 								"description":        "my generated project",
 								"visibility":         "PRIVATE",
@@ -482,8 +482,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"repositoryId":     "REPOID",
 								"hasIssuesEnabled": true,
 								"hasWikiEnabled":   true,
@@ -526,8 +526,8 @@ func Test_repoCreate(t *testing.T) {
 								}
 							}
 						}`,
-						func(inputs map[string]interface{}) {
-							assert.Equal(t, map[string]interface{}{
+						func(inputs map[string]any) {
+							assert.Equal(t, map[string]any{
 								"name":               "gen-project",
 								"description":        "my generated project",
 								"visibility":         "INTERNAL",
@@ -554,8 +554,8 @@ func Test_repoCreate(t *testing.T) {
 			stubs: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.REST("POST", "user/repos"),
-					httpmock.RESTPayload(201, `{"name":"crisps", "owner":{"login": "snacks-inc"}, "html_url":"the://URL"}`, func(payload map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					httpmock.RESTPayload(201, `{"name":"crisps", "owner":{"login": "snacks-inc"}, "html_url":"the://URL"}`, func(payload map[string]any) {
+						assert.Equal(t, map[string]any{
 							"name":               "crisps",
 							"private":            true,
 							"gitignore_template": "Go",
@@ -577,8 +577,8 @@ func Test_repoCreate(t *testing.T) {
 			stubs: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.REST("POST", "user/repos"),
-					httpmock.RESTPayload(201, `{"name":"crisps", "owner":{"login": "snacks-inc"}, "html_url":"the://URL"}`, func(payload map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					httpmock.RESTPayload(201, `{"name":"crisps", "owner":{"login": "snacks-inc"}, "html_url":"the://URL"}`, func(payload map[string]any) {
+						assert.Equal(t, map[string]any{
 							"name":       "crisps",
 							"private":    false,
 							"has_issues": false,
@@ -603,8 +603,8 @@ func Test_repoCreate(t *testing.T) {
 			stubs: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.REST("POST", "api/v3/user/repos"),
-					httpmock.RESTPayload(201, `{"name":"crisps", "owner":{"login": "snacks-inc"}, "html_url":"the://URL"}`, func(payload map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					httpmock.RESTPayload(201, `{"name":"crisps", "owner":{"login": "snacks-inc"}, "html_url":"the://URL"}`, func(payload map[string]any) {
+						assert.Equal(t, map[string]any{
 							"name":               "crisps",
 							"private":            true,
 							"gitignore_template": "Go",
@@ -634,8 +634,8 @@ func Test_repoCreate(t *testing.T) {
 					httpmock.StringResponse(`{ "node_id": "ORGID", "type": "Organization" }`))
 				r.Register(
 					httpmock.REST("POST", "orgs/snacks-inc/repos"),
-					httpmock.RESTPayload(201, `{"name":"crisps", "owner":{"login": "snacks-inc"}, "html_url":"the://URL"}`, func(payload map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					httpmock.RESTPayload(201, `{"name":"crisps", "owner":{"login": "snacks-inc"}, "html_url":"the://URL"}`, func(payload map[string]any) {
+						assert.Equal(t, map[string]any{
 							"name":               "crisps",
 							"private":            false,
 							"visibility":         "internal",
@@ -667,8 +667,8 @@ func Test_repoCreate(t *testing.T) {
 					httpmock.StringResponse(`{ "node_id": "TEAMID", "id": 1234, "organization": {"node_id": "ORGID"} }`))
 				r.Register(
 					httpmock.REST("POST", "orgs/snacks-inc/repos"),
-					httpmock.RESTPayload(201, `{"name":"crisps", "owner":{"login": "snacks-inc"}, "html_url":"the://URL"}`, func(payload map[string]interface{}) {
-						assert.Equal(t, map[string]interface{}{
+					httpmock.RESTPayload(201, `{"name":"crisps", "owner":{"login": "snacks-inc"}, "html_url":"the://URL"}`, func(payload map[string]any) {
+						assert.Equal(t, map[string]any{
 							"name":               "crisps",
 							"private":            false,
 							"visibility":         "internal",

--- a/pkg/cmd/repo/credits/credits.go
+++ b/pkg/cmd/repo/credits/credits.go
@@ -250,7 +250,7 @@ func creditsRun(opts *CreditsOptions) error {
 }
 
 func starLine(r *rand.Rand, width int) string {
-	line := ""
+	var line strings.Builder
 	starChance := 0.1
 	for range width {
 		chance := r.Float64()
@@ -258,18 +258,18 @@ func starLine(r *rand.Rand, width int) string {
 			charRoll := r.Float64()
 			switch {
 			case charRoll < 0.3:
-				line += "."
+				line.WriteString(".")
 			case charRoll > 0.3 && charRoll < 0.6:
-				line += "+"
+				line.WriteString("+")
 			default:
-				line += "*"
+				line.WriteString("*")
 			}
 		} else {
-			line += " "
+			line.WriteString(" ")
 		}
 	}
 
-	return line
+	return line.String()
 }
 
 func twinkle(starLine string) string {

--- a/pkg/cmd/repo/credits/credits.go
+++ b/pkg/cmd/repo/credits/credits.go
@@ -252,7 +252,7 @@ func creditsRun(opts *CreditsOptions) error {
 func starLine(r *rand.Rand, width int) string {
 	line := ""
 	starChance := 0.1
-	for y := 0; y < width; y++ {
+	for range width {
 		chance := r.Float64()
 		if chance <= starChance {
 			charRoll := r.Float64()

--- a/pkg/cmd/repo/deploy-key/add/add_test.go
+++ b/pkg/cmd/repo/deploy-key/add/add_test.go
@@ -36,7 +36,7 @@ func Test_addRun(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/keys"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						if title := payload["title"].(string); title != "my sacred key" {
 							t.Errorf("POST title %q, want %q", title, "my sacred key")
 						}

--- a/pkg/cmd/repo/deploy-key/add/http.go
+++ b/pkg/cmd/repo/deploy-key/add/http.go
@@ -22,7 +22,7 @@ func uploadDeployKey(httpClient *http.Client, repo ghrepo.Interface, keyFile io.
 		return err
 	}
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"title":     title,
 		"key":       string(keyBytes),
 		"read_only": !isWritable,

--- a/pkg/cmd/repo/edit/edit_test.go
+++ b/pkg/cmd/repo/edit/edit_test.go
@@ -186,7 +186,7 @@ func Test_editRun(t *testing.T) {
 			httpStubs: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, 2, len(payload))
 						assert.Equal(t, "newURL", payload["homepage"])
 						assert.Equal(t, "hello world!", payload["description"])
@@ -206,9 +206,9 @@ func Test_editRun(t *testing.T) {
 					httpmock.StringResponse(`{"names":["topic2", "topic3", "go"]}`))
 				r.Register(
 					httpmock.REST("PUT", "repos/OWNER/REPO/topics"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, 1, len(payload))
-						assert.Equal(t, []interface{}{"topic2", "go", "topic1"}, payload["names"])
+						assert.Equal(t, []any{"topic2", "go", "topic1"}, payload["names"])
 					}))
 			},
 		},
@@ -223,7 +223,7 @@ func Test_editRun(t *testing.T) {
 			httpStubs: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, 1, len(payload))
 						assert.Equal(t, true, payload["allow_update_branch"])
 					}))
@@ -254,12 +254,12 @@ func Test_editRun(t *testing.T) {
 
 				r.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, 1, len(payload))
-						securityAndAnalysis := payload["security_and_analysis"].(map[string]interface{})
-						assert.Equal(t, "enabled", securityAndAnalysis["advanced_security"].(map[string]interface{})["status"])
-						assert.Equal(t, "enabled", securityAndAnalysis["secret_scanning"].(map[string]interface{})["status"])
-						assert.Equal(t, "disabled", securityAndAnalysis["secret_scanning_push_protection"].(map[string]interface{})["status"])
+						securityAndAnalysis := payload["security_and_analysis"].(map[string]any)
+						assert.Equal(t, "enabled", securityAndAnalysis["advanced_security"].(map[string]any)["status"])
+						assert.Equal(t, "enabled", securityAndAnalysis["secret_scanning"].(map[string]any)["status"])
+						assert.Equal(t, "disabled", securityAndAnalysis["secret_scanning_push_protection"].(map[string]any)["status"])
 					}))
 			},
 		},
@@ -276,7 +276,7 @@ func Test_editRun(t *testing.T) {
 			httpStubs: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, true, payload["allow_squash_merge"])
 						assert.Equal(t, "PR_TITLE", payload["squash_merge_commit_title"])
 						assert.Equal(t, "PR_BODY", payload["squash_merge_commit_message"])
@@ -400,7 +400,7 @@ func Test_editRun_interactive(t *testing.T) {
 					}`))
 				reg.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, true, payload["allow_forking"])
 					}))
 			},
@@ -502,7 +502,7 @@ func Test_editRun_interactive(t *testing.T) {
 					}`))
 				reg.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, "private", payload["visibility"])
 					}))
 			},
@@ -565,7 +565,7 @@ func Test_editRun_interactive(t *testing.T) {
 					}`))
 				reg.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, "trunk", payload["default_branch"])
 						assert.Equal(t, "https://zombo.com", payload["homepage"])
 						assert.Equal(t, true, payload["has_issues"])
@@ -616,7 +616,7 @@ func Test_editRun_interactive(t *testing.T) {
 					}`))
 				reg.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, "awesome repo description", payload["description"])
 					}))
 			},
@@ -670,13 +670,13 @@ func Test_editRun_interactive(t *testing.T) {
 					}`))
 				reg.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, "awesome repo description", payload["description"])
 					}))
 				reg.Register(
 					httpmock.REST("PUT", "repos/OWNER/REPO/topics"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
-						assert.Equal(t, []interface{}{"a", "b", "c", "d"}, payload["names"])
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
+						assert.Equal(t, []any{"a", "b", "c", "d"}, payload["names"])
 					}))
 			},
 		},
@@ -732,7 +732,7 @@ func Test_editRun_interactive(t *testing.T) {
 					}`))
 				reg.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, true, payload["allow_merge_commit"])
 						assert.Equal(t, false, payload["allow_squash_merge"])
 						assert.Equal(t, true, payload["allow_rebase_merge"])
@@ -796,7 +796,7 @@ func Test_editRun_interactive(t *testing.T) {
 					}`))
 				reg.Register(
 					httpmock.REST("PATCH", "repos/OWNER/REPO"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Equal(t, false, payload["allow_merge_commit"])
 						assert.Equal(t, true, payload["allow_squash_merge"])
 						assert.Equal(t, false, payload["allow_rebase_merge"])

--- a/pkg/cmd/repo/edit/edit_test.go
+++ b/pkg/cmd/repo/edit/edit_test.go
@@ -994,13 +994,3 @@ func Test_validateSquashMergeCommitMsg(t *testing.T) {
 	assert.Error(t, validateSquashMergeCommitMsg("blah"))
 	assert.Error(t, validateSquashMergeCommitMsg(""))
 }
-
-//go:fix inline
-func sp(v string) *string {
-	return new(v)
-}
-
-//go:fix inline
-func bp(b bool) *bool {
-	return new(b)
-}

--- a/pkg/cmd/repo/edit/edit_test.go
+++ b/pkg/cmd/repo/edit/edit_test.go
@@ -30,7 +30,7 @@ func TestNewCmdEdit(t *testing.T) {
 			wantOpts: EditOptions{
 				Repository: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				Edits: EditRepositoryInput{
-					Description: sp("hello"),
+					Description: new("hello"),
 				},
 			},
 		},
@@ -49,7 +49,7 @@ func TestNewCmdEdit(t *testing.T) {
 			wantOpts: EditOptions{
 				Repository: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				Edits: EditRepositoryInput{
-					Visibility: sp("public"),
+					Visibility: new("public"),
 				},
 			},
 		},
@@ -68,7 +68,7 @@ func TestNewCmdEdit(t *testing.T) {
 			wantOpts: EditOptions{
 				Repository: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				Edits: EditRepositoryInput{
-					Visibility: sp("private"),
+					Visibility: new("private"),
 				},
 			},
 		},
@@ -87,7 +87,7 @@ func TestNewCmdEdit(t *testing.T) {
 			wantOpts: EditOptions{
 				Repository: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				Edits: EditRepositoryInput{
-					Visibility: sp("internal"),
+					Visibility: new("internal"),
 				},
 			},
 		},
@@ -97,10 +97,10 @@ func TestNewCmdEdit(t *testing.T) {
 			wantOpts: EditOptions{
 				Repository: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				Edits: EditRepositoryInput{
-					squashMergeCommitMsg:     sp("pr-title"),
-					EnableSquashMerge:        bp(true),
-					SquashMergeCommitTitle:   sp("PR_TITLE"),
-					SquashMergeCommitMessage: sp("BLANK"),
+					squashMergeCommitMsg:     new("pr-title"),
+					EnableSquashMerge:        new(true),
+					SquashMergeCommitTitle:   new("PR_TITLE"),
+					SquashMergeCommitMessage: new("BLANK"),
 				},
 			},
 		},
@@ -179,8 +179,8 @@ func Test_editRun(t *testing.T) {
 			opts: EditOptions{
 				Repository: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				Edits: EditRepositoryInput{
-					Homepage:    sp("newURL"),
-					Description: sp("hello world!"),
+					Homepage:    new("newURL"),
+					Description: new("hello world!"),
 				},
 			},
 			httpStubs: func(t *testing.T, r *httpmock.Registry) {
@@ -217,7 +217,7 @@ func Test_editRun(t *testing.T) {
 			opts: EditOptions{
 				Repository: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				Edits: EditRepositoryInput{
-					AllowUpdateBranch: bp(true),
+					AllowUpdateBranch: new(true),
 				},
 			},
 			httpStubs: func(t *testing.T, r *httpmock.Registry) {
@@ -236,13 +236,13 @@ func Test_editRun(t *testing.T) {
 				Edits: EditRepositoryInput{
 					SecurityAndAnalysis: &SecurityAndAnalysisInput{
 						EnableAdvancedSecurity: &SecurityAndAnalysisStatus{
-							Status: sp("enabled"),
+							Status: new("enabled"),
 						},
 						EnableSecretScanning: &SecurityAndAnalysisStatus{
-							Status: sp("enabled"),
+							Status: new("enabled"),
 						},
 						EnableSecretScanningPushProtection: &SecurityAndAnalysisStatus{
-							Status: sp("disabled"),
+							Status: new("disabled"),
 						},
 					},
 				},
@@ -268,9 +268,9 @@ func Test_editRun(t *testing.T) {
 			opts: EditOptions{
 				Repository: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				Edits: EditRepositoryInput{
-					EnableSquashMerge:        bp(true),
-					SquashMergeCommitTitle:   sp("PR_TITLE"),
-					SquashMergeCommitMessage: sp("PR_BODY"),
+					EnableSquashMerge:        new(true),
+					SquashMergeCommitTitle:   new("PR_TITLE"),
+					SquashMergeCommitMessage: new("PR_BODY"),
 				},
 			},
 			httpStubs: func(t *testing.T, r *httpmock.Registry) {
@@ -290,13 +290,13 @@ func Test_editRun(t *testing.T) {
 				Edits: EditRepositoryInput{
 					SecurityAndAnalysis: &SecurityAndAnalysisInput{
 						EnableAdvancedSecurity: &SecurityAndAnalysisStatus{
-							Status: sp("enabled"),
+							Status: new("enabled"),
 						},
 						EnableSecretScanning: &SecurityAndAnalysisStatus{
-							Status: sp("enabled"),
+							Status: new("enabled"),
 						},
 						EnableSecretScanningPushProtection: &SecurityAndAnalysisStatus{
-							Status: sp("disabled"),
+							Status: new("disabled"),
 						},
 					},
 				},
@@ -853,20 +853,20 @@ func Test_transformSecurityAndAnalysisOpts(t *testing.T) {
 			name: "Enable all security and analysis settings",
 			opts: EditOptions{
 				Edits: EditRepositoryInput{
-					enableAdvancedSecurity:             bp(true),
-					enableSecretScanning:               bp(true),
-					enableSecretScanningPushProtection: bp(true),
+					enableAdvancedSecurity:             new(true),
+					enableSecretScanning:               new(true),
+					enableSecretScanningPushProtection: new(true),
 				},
 			},
 			want: &SecurityAndAnalysisInput{
 				EnableAdvancedSecurity: &SecurityAndAnalysisStatus{
-					Status: sp("enabled"),
+					Status: new("enabled"),
 				},
 				EnableSecretScanning: &SecurityAndAnalysisStatus{
-					Status: sp("enabled"),
+					Status: new("enabled"),
 				},
 				EnableSecretScanningPushProtection: &SecurityAndAnalysisStatus{
-					Status: sp("enabled"),
+					Status: new("enabled"),
 				},
 			},
 		},
@@ -874,20 +874,20 @@ func Test_transformSecurityAndAnalysisOpts(t *testing.T) {
 			name: "Disable all security and analysis settings",
 			opts: EditOptions{
 				Edits: EditRepositoryInput{
-					enableAdvancedSecurity:             bp(false),
-					enableSecretScanning:               bp(false),
-					enableSecretScanningPushProtection: bp(false),
+					enableAdvancedSecurity:             new(false),
+					enableSecretScanning:               new(false),
+					enableSecretScanningPushProtection: new(false),
 				},
 			},
 			want: &SecurityAndAnalysisInput{
 				EnableAdvancedSecurity: &SecurityAndAnalysisStatus{
-					Status: sp("disabled"),
+					Status: new("disabled"),
 				},
 				EnableSecretScanning: &SecurityAndAnalysisStatus{
-					Status: sp("disabled"),
+					Status: new("disabled"),
 				},
 				EnableSecretScanningPushProtection: &SecurityAndAnalysisStatus{
-					Status: sp("disabled"),
+					Status: new("disabled"),
 				},
 			},
 		},
@@ -895,12 +895,12 @@ func Test_transformSecurityAndAnalysisOpts(t *testing.T) {
 			name: "Enable only advanced security",
 			opts: EditOptions{
 				Edits: EditRepositoryInput{
-					enableAdvancedSecurity: bp(true),
+					enableAdvancedSecurity: new(true),
 				},
 			},
 			want: &SecurityAndAnalysisInput{
 				EnableAdvancedSecurity: &SecurityAndAnalysisStatus{
-					Status: sp("enabled"),
+					Status: new("enabled"),
 				},
 				EnableSecretScanning:               nil,
 				EnableSecretScanningPushProtection: nil,
@@ -910,13 +910,13 @@ func Test_transformSecurityAndAnalysisOpts(t *testing.T) {
 			name: "Disable only secret scanning",
 			opts: EditOptions{
 				Edits: EditRepositoryInput{
-					enableSecretScanning: bp(false),
+					enableSecretScanning: new(false),
 				},
 			},
 			want: &SecurityAndAnalysisInput{
 				EnableAdvancedSecurity: nil,
 				EnableSecretScanning: &SecurityAndAnalysisStatus{
-					Status: sp("disabled"),
+					Status: new("disabled"),
 				},
 				EnableSecretScanningPushProtection: nil,
 			},
@@ -968,7 +968,7 @@ func Test_transformSquashMergeOpts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			edits := &EditRepositoryInput{
-				squashMergeCommitMsg: sp(tt.input),
+				squashMergeCommitMsg: new(tt.input),
 			}
 			transformSquashMergeOpts(edits)
 			assert.Equal(t, tt.wantTitle, *edits.SquashMergeCommitTitle)
@@ -979,7 +979,7 @@ func Test_transformSquashMergeOpts(t *testing.T) {
 
 func Test_transformSquashMergeOpts_unknownInput(t *testing.T) {
 	edits := &EditRepositoryInput{
-		squashMergeCommitMsg: sp("unknown-value"),
+		squashMergeCommitMsg: new("unknown-value"),
 	}
 	transformSquashMergeOpts(edits)
 	assert.Nil(t, edits.SquashMergeCommitTitle)
@@ -995,10 +995,12 @@ func Test_validateSquashMergeCommitMsg(t *testing.T) {
 	assert.Error(t, validateSquashMergeCommitMsg(""))
 }
 
+//go:fix inline
 func sp(v string) *string {
-	return &v
+	return new(v)
 }
 
+//go:fix inline
 func bp(b bool) *bool {
-	return &b
+	return new(b)
 }

--- a/pkg/cmd/repo/garden/garden.go
+++ b/pkg/cmd/repo/garden/garden.go
@@ -483,13 +483,13 @@ func shaToColorFunc(sha string) func(string) string {
 }
 
 func computeSeed(seed string) int64 {
-	lol := ""
+	var lol strings.Builder
 
 	for _, r := range seed {
-		lol += fmt.Sprintf("%d", int(r))
+		lol.WriteString(fmt.Sprintf("%d", int(r)))
 	}
 
-	result, err := strconv.ParseInt(lol[0:10], 10, 64)
+	result, err := strconv.ParseInt(lol.String()[0:10], 10, 64)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cmd/repo/garden/http.go
+++ b/pkg/cmd/repo/garden/http.go
@@ -80,7 +80,7 @@ func getCommits(client *http.Client, repo ghrepo.Interface, maxCommits int) ([]*
 
 // getResponse performs the API call and returns the response's link header values.
 // If the "Link" header is missing, the returned slice will be nil.
-func getResponse(client *http.Client, url safeurl.SafeURL, data interface{}) ([]string, error) {
+func getResponse(client *http.Client, url safeurl.SafeURL, data any) ([]string, error) {
 	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -34,10 +34,7 @@ func listRepos(client *http.Client, hostname string, limit int, owner string, fi
 		return searchRepos(client, hostname, limit, owner, filter)
 	}
 
-	perPage := limit
-	if perPage > 100 {
-		perPage = 100
-	}
+	perPage := min(limit, 100)
 
 	variables := map[string]any{
 		"perPage": githubv4.Int(perPage),
@@ -138,10 +135,7 @@ func searchRepos(client *http.Client, hostname string, limit int, owner string, 
 		}
 	}`, api.RepositoryGraphQL(filter.Fields))
 
-	perPage := limit
-	if perPage > 100 {
-		perPage = 100
-	}
+	perPage := min(limit, 100)
 
 	variables := map[string]any{
 		"query":   githubv4.String(searchQuery(owner, filter)),

--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -39,7 +39,7 @@ func listRepos(client *http.Client, hostname string, limit int, owner string, fi
 		perPage = 100
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"perPage": githubv4.Int(perPage),
 	}
 
@@ -143,7 +143,7 @@ func searchRepos(client *http.Client, hostname string, limit int, owner string, 
 		perPage = 100
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"query":   githubv4.String(searchQuery(owner, filter)),
 		"perPage": githubv4.Int(perPage),
 	}

--- a/pkg/cmd/repo/list/http_test.go
+++ b/pkg/cmd/repo/list/http_test.go
@@ -18,7 +18,7 @@ func Test_listReposWithLanguage(t *testing.T) {
 
 	var searchData struct {
 		Query     string
-		Variables map[string]interface{}
+		Variables map[string]any
 	}
 	reg.Register(
 		httpmock.GraphQL(`query RepositoryListSearch\b`),

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -472,7 +472,7 @@ func TestRepoList_filtering(t *testing.T) {
 
 	http.Register(
 		httpmock.GraphQL(`query RepositoryList\b`),
-		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
+		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]any) {
 			assert.Equal(t, "PRIVATE", params["privacy"])
 			assert.Equal(t, float64(2), params["perPage"])
 		}),
@@ -499,7 +499,7 @@ func TestRepoList_noVisibilityField(t *testing.T) {
 	reg.Register(
 		httpmock.GraphQL(`query RepositoryList\b`),
 		httpmock.GraphQLQuery(`{"data":{"repositoryOwner":{"login":"octocat","repositories":{"totalCount":0}}}}`,
-			func(query string, params map[string]interface{}) {
+			func(query string, params map[string]any) {
 				assert.False(t, strings.Contains(query, "visibility"))
 			},
 		),

--- a/pkg/cmd/repo/read-dir/http.go
+++ b/pkg/cmd/repo/read-dir/http.go
@@ -60,8 +60,8 @@ func (e dirEntry) modeOctal() string {
 }
 
 // ExportData implements the cmdutil exportable interface for a single entry.
-func (e dirEntry) ExportData(fields []string) map[string]interface{} {
-	data := map[string]interface{}{}
+func (e dirEntry) ExportData(fields []string) map[string]any {
+	data := map[string]any{}
 	for _, field := range fields {
 		switch field {
 		case "name":
@@ -88,7 +88,7 @@ func (e dirEntry) ExportData(fields []string) map[string]interface{} {
 			if e.Submodule == nil {
 				data[field] = nil
 			} else {
-				data[field] = map[string]interface{}{
+				data[field] = map[string]any{
 					"gitUrl":              e.Submodule.GitURL,
 					"branch":              e.Submodule.Branch,
 					"subprojectCommitOid": e.Submodule.SubprojectCommitOid,
@@ -103,12 +103,12 @@ func (e dirEntry) ExportData(fields []string) map[string]interface{} {
 //
 // gitSHA and id are structural and always present; the requested fields select
 // which properties appear on each entry.
-func (d *repoDir) ExportData(fields []string) map[string]interface{} {
-	entries := make([]interface{}, 0, len(d.Entries))
+func (d *repoDir) ExportData(fields []string) map[string]any {
+	entries := make([]any, 0, len(d.Entries))
 	for _, e := range d.Entries {
 		entries = append(entries, e.ExportData(fields))
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"gitSHA":  d.GitSHA,
 		"id":      d.ID,
 		"entries": entries,
@@ -162,7 +162,7 @@ func fetchTree(httpClient *http.Client, repo ghrepo.Interface, dirPath, ref stri
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":      githubv4.String(repo.RepoOwner()),
 		"name":       githubv4.String(repo.RepoName()),
 		"expression": githubv4.String(expression),

--- a/pkg/cmd/repo/read-dir/read_dir_test.go
+++ b/pkg/cmd/repo/read-dir/read_dir_test.go
@@ -260,7 +260,7 @@ func Test_readDirRun(t *testing.T) {
 									]
 								}}}
 							}`),
-						func(_ string, vars map[string]interface{}) {
+						func(_ string, vars map[string]any) {
 							assert.Equal(t, "HEAD:foo/bar", vars["expression"])
 						},
 					),
@@ -294,7 +294,7 @@ func Test_readDirRun(t *testing.T) {
 									]
 								}}}
 							}`),
-						func(_ string, vars map[string]interface{}) {
+						func(_ string, vars map[string]any) {
 							assert.Equal(t, "v1.2.3:docs", vars["expression"])
 						},
 					),

--- a/pkg/cmd/repo/read-file/http.go
+++ b/pkg/cmd/repo/read-file/http.go
@@ -30,8 +30,8 @@ type repoFile struct {
 }
 
 // ExportData implements the cmdutil exportable interface for --json output.
-func (f *repoFile) ExportData(fields []string) map[string]interface{} {
-	data := map[string]interface{}{}
+func (f *repoFile) ExportData(fields []string) map[string]any {
+	data := map[string]any{}
 	for _, field := range fields {
 		switch field {
 		case "name":

--- a/pkg/cmd/repo/read-file/read_file_test.go
+++ b/pkg/cmd/repo/read-file/read_file_test.go
@@ -255,7 +255,7 @@ func Test_readFileRun(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/contents/meta.md"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"type":         "file",
 						"name":         "meta.md",
 						"path":         "meta.md",
@@ -305,7 +305,7 @@ func Test_readFileRun(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/contents/src"),
-					httpmock.JSONResponse(map[string]interface{}{"type": "dir", "path": "src"}),
+					httpmock.JSONResponse(map[string]any{"type": "dir", "path": "src"}),
 				)
 			},
 			opts:       ReadFileOptions{Path: "src"},
@@ -317,7 +317,7 @@ func Test_readFileRun(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/contents/link"),
-					httpmock.JSONResponse(map[string]interface{}{"type": "symlink", "path": "link", "target": "missing.txt"}),
+					httpmock.JSONResponse(map[string]any{"type": "symlink", "path": "link", "target": "missing.txt"}),
 				)
 			},
 			opts:       ReadFileOptions{Path: "link"},
@@ -329,7 +329,7 @@ func Test_readFileRun(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/contents/sub"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"type":              "submodule",
 						"path":              "sub",
 						"submodule_git_url": "https://github.com/OWNER/sub",
@@ -418,7 +418,7 @@ func Test_readFileRun(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/contents/big.txt"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"type":     "file",
 						"name":     "big.txt",
 						"path":     "big.txt",
@@ -444,7 +444,7 @@ func Test_readFileRun(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/contents/big.txt"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"type":     "file",
 						"name":     "big.txt",
 						"path":     "big.txt",
@@ -480,7 +480,7 @@ func Test_readFileRun(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/contents/big.txt"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"type":     "file",
 						"name":     "big.txt",
 						"path":     "big.txt",
@@ -500,7 +500,7 @@ func Test_readFileRun(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/contents/big.txt"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"type":     "file",
 						"name":     "big.txt",
 						"path":     "big.txt",
@@ -683,12 +683,12 @@ func Test_writeToOutput(t *testing.T) {
 
 // fileContentResponse builds a Contents API object response for a regular file
 // with base64-encoded inline content.
-func fileContentResponse(name, content string) map[string]interface{} {
+func fileContentResponse(name, content string) map[string]any {
 	return fileContentResponseBytes(name, []byte(content))
 }
 
-func fileContentResponseBytes(name string, content []byte) map[string]interface{} {
-	return map[string]interface{}{
+func fileContentResponseBytes(name string, content []byte) map[string]any {
+	return map[string]any{
 		"type":         "file",
 		"name":         name,
 		"path":         name,
@@ -700,7 +700,7 @@ func fileContentResponseBytes(name string, content []byte) map[string]interface{
 		"git_url":      "https://api.github.com/repos/OWNER/REPO/git/blobs/deadbeef",
 		"html_url":     "https://github.com/OWNER/REPO/blob/main/" + name,
 		"download_url": "https://raw.githubusercontent.com/OWNER/REPO/main/" + name,
-		"_links": map[string]interface{}{
+		"_links": map[string]any{
 			"self": "https://api.github.com/repos/OWNER/REPO/contents/" + name,
 			"git":  "https://api.github.com/repos/OWNER/REPO/git/blobs/deadbeef",
 			"html": "https://github.com/OWNER/REPO/blob/main/" + name,

--- a/pkg/cmd/repo/setdefault/setdefault_test.go
+++ b/pkg/cmd/repo/setdefault/setdefault_test.go
@@ -475,7 +475,7 @@ func TestDefaultRun(t *testing.T) {
             "repo_004":{"name":"REPO5","owner":{"login":"OWNER5"}},
             "repo_005":{"name":"REPO6","owner":{"login":"OWNER6"}}
           }}`,
-						func(query string, inputs map[string]interface{}) {
+						func(query string, inputs map[string]any) {
 							assert.Contains(t, query, "repo_000")
 							assert.Contains(t, query, "repo_001")
 							assert.Contains(t, query, "repo_002")

--- a/pkg/cmd/repo/sync/http.go
+++ b/pkg/cmd/repo/sync/http.go
@@ -41,7 +41,7 @@ var missingWorkflowScopeErr = errors.New("Upstream commits contain workflow chan
 
 func triggerUpstreamMerge(client *api.Client, repo ghrepo.Interface, branch string) (string, error) {
 	var payload bytes.Buffer
-	if err := json.NewEncoder(&payload).Encode(map[string]interface{}{
+	if err := json.NewEncoder(&payload).Encode(map[string]any{
 		"branch": branch,
 	}); err != nil {
 		return "", err
@@ -77,7 +77,7 @@ func syncFork(client *api.Client, repo ghrepo.Interface, branch, SHA string, for
 	if err != nil {
 		return err
 	}
-	body := map[string]interface{}{
+	body := map[string]any{
 		"sha":   SHA,
 		"force": force,
 	}

--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -203,8 +203,8 @@ func syncRemoteRepo(opts *SyncOptions) error {
 	if opts.IO.IsStdoutTTY() {
 		cs := opts.IO.ColorScheme()
 		branchName := opts.Branch
-		if idx := strings.Index(baseBranchLabel, ":"); idx >= 0 {
-			branchName = baseBranchLabel[idx+1:]
+		if _, after, ok := strings.Cut(baseBranchLabel, ":"); ok {
+			branchName = after
 		}
 		fmt.Fprintf(opts.IO.Out, "%s Synced the \"%s:%s\" branch from \"%s\"\n",
 			cs.SuccessIcon(),

--- a/pkg/cmd/repo/unarchive/http.go
+++ b/pkg/cmd/repo/unarchive/http.go
@@ -16,7 +16,7 @@ func unarchiveRepo(client *http.Client, repo *api.Repository) error {
 		} `graphql:"unarchiveRepository(input: $input)"`
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": githubv4.UnarchiveRepositoryInput{
 			RepositoryID: repo.ID,
 		},

--- a/pkg/cmd/repo/view/view_test.go
+++ b/pkg/cmd/repo/view/view_test.go
@@ -747,7 +747,7 @@ func (e *testExporter) Fields() []string {
 	return e.fields
 }
 
-func (e *testExporter) Write(io *iostreams.IOStreams, data interface{}) error {
+func (e *testExporter) Write(io *iostreams.IOStreams, data any) error {
 	r := data.(*api.Repository)
 	fmt.Fprintf(io.Out, "name: %s\n", r.Name)
 	fmt.Fprintf(io.Out, "defaultBranchRef: %s\n", r.DefaultBranchRef.Name)

--- a/pkg/cmd/ruleset/shared/http.go
+++ b/pkg/cmd/ruleset/shared/http.go
@@ -84,13 +84,6 @@ func listRulesets(httpClient *http.Client, query string, variables map[string]an
 	return &res, nil
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func rulesetsQuery(org bool) string {
 	if org {
 		return orgGraphQLHeader + sharedGraphQLBody

--- a/pkg/cmd/ruleset/shared/http.go
+++ b/pkg/cmd/ruleset/shared/http.go
@@ -28,7 +28,7 @@ type RulesetList struct {
 }
 
 func ListRepoRulesets(httpClient *http.Client, repo ghrepo.Interface, limit int, includeParents bool) (*RulesetList, error) {
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":          repo.RepoOwner(),
 		"repo":           repo.RepoName(),
 		"includeParents": includeParents,
@@ -38,7 +38,7 @@ func ListRepoRulesets(httpClient *http.Client, repo ghrepo.Interface, limit int,
 }
 
 func ListOrgRulesets(httpClient *http.Client, orgLogin string, limit int, host string, includeParents bool) (*RulesetList, error) {
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"login":          orgLogin,
 		"includeParents": includeParents,
 	}
@@ -46,7 +46,7 @@ func ListOrgRulesets(httpClient *http.Client, orgLogin string, limit int, host s
 	return listRulesets(httpClient, rulesetsQuery(true), variables, limit, host)
 }
 
-func listRulesets(httpClient *http.Client, query string, variables map[string]interface{}, limit int, host string) (*RulesetList, error) {
+func listRulesets(httpClient *http.Client, query string, variables map[string]any, limit int, host string) (*RulesetList, error) {
 	pageLimit := min(limit, 100)
 
 	res := RulesetList{

--- a/pkg/cmd/ruleset/shared/shared.go
+++ b/pkg/cmd/ruleset/shared/shared.go
@@ -34,7 +34,7 @@ type RulesetREST struct {
 		ActorType  string `json:"actor_type"`
 		BypassMode string `json:"bypass_mode"`
 	} `json:"bypass_actors"`
-	Conditions map[string]map[string]interface{}
+	Conditions map[string]map[string]any
 	SourceType string `json:"source_type"`
 	Source     string
 	Rules      []RulesetRule
@@ -47,7 +47,7 @@ type RulesetREST struct {
 
 type RulesetRule struct {
 	Type              string
-	Parameters        map[string]interface{}
+	Parameters        map[string]any
 	RulesetSourceType string `json:"ruleset_source_type"`
 	RulesetSource     string `json:"ruleset_source"`
 	RulesetId         int64  `json:"ruleset_id"`

--- a/pkg/cmd/run/download/download.go
+++ b/pkg/cmd/run/download/download.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/safepaths"
@@ -222,12 +223,7 @@ func isolateArtifacts(wantNames []string, wantPatterns []string) bool {
 }
 
 func matchAnyName(names []string, name string) bool {
-	for _, n := range names {
-		if name == n {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(names, name)
 }
 
 func matchAnyPattern(patterns []string, name string) bool {

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -161,14 +161,14 @@ func (r Run) WorkflowName() string {
 	return r.workflowName
 }
 
-func (r *Run) ExportData(fields []string) map[string]interface{} {
+func (r *Run) ExportData(fields []string) map[string]any {
 	v := reflect.ValueOf(r).Elem()
 	fieldByName := func(v reflect.Value, field string) reflect.Value {
 		return v.FieldByNameFunc(func(s string) bool {
 			return strings.EqualFold(field, s)
 		})
 	}
-	data := map[string]interface{}{}
+	data := map[string]any{}
 
 	for _, f := range fields {
 		switch f {
@@ -179,15 +179,15 @@ func (r *Run) ExportData(fields []string) map[string]interface{} {
 		case "workflowName":
 			data[f] = r.WorkflowName()
 		case "jobs":
-			jobs := make([]interface{}, 0, len(r.Jobs))
+			jobs := make([]any, 0, len(r.Jobs))
 			for _, j := range r.Jobs {
-				steps := make([]interface{}, 0, len(j.Steps))
+				steps := make([]any, 0, len(j.Steps))
 				for _, s := range j.Steps {
 					var stepCompletedAt time.Time
 					if !s.CompletedAt.IsZero() {
 						stepCompletedAt = s.CompletedAt
 					}
-					steps = append(steps, map[string]interface{}{
+					steps = append(steps, map[string]any{
 						"name":        s.Name,
 						"status":      s.Status,
 						"conclusion":  s.Conclusion,
@@ -200,7 +200,7 @@ func (r *Run) ExportData(fields []string) map[string]interface{} {
 				if !j.CompletedAt.IsZero() {
 					jobCompletedAt = j.CompletedAt
 				}
-				jobs = append(jobs, map[string]interface{}{
+				jobs = append(jobs, map[string]any{
 					"databaseId":  j.ID,
 					"status":      j.Status,
 					"conclusion":  j.Conclusion,
@@ -634,7 +634,7 @@ func PullRequestForRun(client *api.Client, repo ghrepo.Interface, run Run) (int,
 		Number int
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"owner":       repo.RepoOwner(),
 		"repo":        repo.RepoName(),
 		"headRefName": run.HeadBranch,

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -377,10 +377,7 @@ func GetRuns(client *api.Client, repo ghrepo.Interface, opts *FilterOptions, lim
 		}
 	}
 
-	perPage := limit
-	if limit > 100 {
-		perPage = 100
-	}
+	perPage := min(limit, 100)
 	u.SetQuery("per_page", strconv.Itoa(perPage))
 	u.SetQuery("exclude_pull_requests", "true") // significantly reduces payload size
 

--- a/pkg/cmd/run/shared/test.go
+++ b/pkg/cmd/run/shared/test.go
@@ -276,10 +276,10 @@ var TestWorkflow workflowShared.Workflow = workflowShared.Workflow{
 
 type TestExporter struct {
 	fields       []string
-	writeHandler func(io *iostreams.IOStreams, data interface{}) error
+	writeHandler func(io *iostreams.IOStreams, data any) error
 }
 
-func MakeTestExporter(fields []string, wh func(io *iostreams.IOStreams, data interface{}) error) *TestExporter {
+func MakeTestExporter(fields []string, wh func(io *iostreams.IOStreams, data any) error) *TestExporter {
 	return &TestExporter{fields: fields, writeHandler: wh}
 }
 
@@ -287,6 +287,6 @@ func (t *TestExporter) Fields() []string {
 	return t.fields
 }
 
-func (t *TestExporter) Write(io *iostreams.IOStreams, data interface{}) error {
+func (t *TestExporter) Write(io *iostreams.IOStreams, data any) error {
 	return t.writeHandler(io, data)
 }

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"time"
 
@@ -461,10 +462,8 @@ func shouldFetchJobs(opts *ViewOptions) bool {
 		return true
 	}
 	if opts.Exporter != nil {
-		for _, f := range opts.Exporter.Fields() {
-			if f == "jobs" {
-				return true
-			}
+		if slices.Contains(opts.Exporter.Fields(), "jobs") {
+			return true
 		}
 	}
 	return false

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -2553,7 +2553,7 @@ func TestViewRun(t *testing.T) {
 				RunID: "3",
 				Exporter: shared.MakeTestExporter(
 					[]string{"jobs"},
-					func(io *iostreams.IOStreams, data interface{}) error {
+					func(io *iostreams.IOStreams, data any) error {
 						run, ok := data.(*shared.Run)
 						if !ok {
 							return fmt.Errorf("expected data type *shared.Run")

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -228,7 +228,7 @@ type Secret struct {
 	NumSelectedRepos int               `json:"num_selected_repos"`
 }
 
-func (s *Secret) ExportData(fields []string) map[string]interface{} {
+func (s *Secret) ExportData(fields []string) map[string]any {
 	return cmdutil.StructExportData(s, fields)
 }
 

--- a/pkg/cmd/secret/set/http.go
+++ b/pkg/cmd/secret/set/http.go
@@ -72,7 +72,7 @@ func getEnvPubKey(client *api.Client, repo ghrepo.Interface, envName string) (*P
 	return getPubKey(client, repo.RepoHost(), u)
 }
 
-func putSecret(client *api.Client, host string, path safeurl.SafeURL, payload interface{}) error {
+func putSecret(client *api.Client, host string, path safeurl.SafeURL, payload any) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("failed to serialize: %w", err)

--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -726,10 +726,7 @@ func selectSkillsWithSelector(opts *InstallOptions, skills []discovery.Skill, ca
 		sel.fetchDescriptions()
 	}
 
-	labelWidth := opts.IO.TerminalWidth() - multiSelectLabelMargin
-	if labelWidth < 1 {
-		labelWidth = 1
-	}
+	labelWidth := max(opts.IO.TerminalWidth()-multiSelectLabelMargin, 1)
 
 	selected, err := opts.Prompter.MultiSelectWithSearch(
 		"Select skill(s) to install:",
@@ -780,10 +777,7 @@ func listAvailableSkills(opts *InstallOptions, skills []discovery.Skill, sel ski
 	}
 
 	tw := opts.IO.TerminalWidth()
-	descWidth := tw - 40
-	if descWidth < 20 {
-		descWidth = 20
-	}
+	descWidth := max(tw-40, 20)
 	isTTY := opts.IO.IsStdoutTTY()
 
 	table := tableprinter.New(opts.IO, tableprinter.WithHeader("SKILL", "DESCRIPTION"))

--- a/pkg/cmd/skills/install/install_test.go
+++ b/pkg/cmd/skills/install/install_test.go
@@ -2565,7 +2565,7 @@ func TestInstallRun_TelemetryVisibility(t *testing.T) {
 			} else {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"visibility": tt.visibility,
 					}),
 				)
@@ -2658,7 +2658,7 @@ func TestInstallRun_TelemetryMultipleSkills(t *testing.T) {
 
 	reg.Register(
 		httpmock.REST("GET", "repos/monalisa/octocat-skills"),
-		httpmock.JSONResponse(map[string]interface{}{
+		httpmock.JSONResponse(map[string]any{
 			"visibility": "public",
 		}),
 	)

--- a/pkg/cmd/skills/list/list.go
+++ b/pkg/cmd/skills/list/list.go
@@ -81,8 +81,8 @@ type listedSkill struct {
 }
 
 // ExportData implements cmdutil.exportable for --json output.
-func (s listedSkill) ExportData(fields []string) map[string]interface{} {
-	data := map[string]interface{}{}
+func (s listedSkill) ExportData(fields []string) map[string]any {
+	data := map[string]any{}
 	for _, f := range fields {
 		switch f {
 		case "skillName":
@@ -444,7 +444,7 @@ func parseInstalledSkill(data []byte, name, dir string, agentHostIDs []string, s
 	return s, installMetadata
 }
 
-func hasInstallMetadata(meta map[string]interface{}) bool {
+func hasInstallMetadata(meta map[string]any) bool {
 	for _, key := range []string{"github-repo", "github-ref", "github-tree-sha", "github-path", "github-pinned", "local-path"} {
 		value, ok := meta[key]
 		if !ok {

--- a/pkg/cmd/skills/list/list.go
+++ b/pkg/cmd/skills/list/list.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -286,10 +287,8 @@ func selectedScopes(scope string) []registry.Scope {
 }
 
 func appendAgentHostID(agentHostIDs []string, agentHostID string) []string {
-	for _, existing := range agentHostIDs {
-		if existing == agentHostID {
-			return agentHostIDs
-		}
+	if slices.Contains(agentHostIDs, agentHostID) {
+		return agentHostIDs
 	}
 	return append(agentHostIDs, agentHostID)
 }
@@ -312,12 +311,7 @@ func shouldListPublishedProjectSkills(agentID string, scopes []registry.Scope, g
 	if agentID != "" || gitRoot == "" {
 		return false
 	}
-	for _, scope := range scopes {
-		if scope == registry.ScopeProject {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(scopes, registry.ScopeProject)
 }
 
 func scanInstalledSkills(skillsDir string, agentHostIDs []string, scope string, filter scanFilter) ([]listedSkill, error) {

--- a/pkg/cmd/skills/preview/preview_test.go
+++ b/pkg/cmd/skills/preview/preview_test.go
@@ -946,7 +946,7 @@ func TestPreviewRun_InteractiveTelemetryCapturesSelectedSkillName(t *testing.T) 
 	)
 	reg.Register(
 		httpmock.REST("GET", "repos/owner/repo"),
-		httpmock.JSONResponse(map[string]interface{}{
+		httpmock.JSONResponse(map[string]any{
 			"visibility": "public",
 		}),
 	)
@@ -1062,7 +1062,7 @@ func TestPreviewRun_TelemetryVisibility(t *testing.T) {
 			} else {
 				reg.Register(
 					httpmock.REST("GET", "repos/owner/repo"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"visibility": tt.visibility,
 					}),
 				)

--- a/pkg/cmd/skills/publish/publish.go
+++ b/pkg/cmd/skills/publish/publish.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -452,12 +453,7 @@ func repoHasTopic(client *api.Client, host, owner, repo string) bool {
 	if err := client.REST(host, "GET", apiPath.String(), nil, &resp); err != nil {
 		return false
 	}
-	for _, t := range resp.Names {
-		if t == "agent-skills" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(resp.Names, "agent-skills")
 }
 
 // fetchTags returns the most recent tags from the repo.
@@ -718,10 +714,8 @@ func addAgentSkillsTopic(client *api.Client, host, owner, repo string) error {
 	}
 
 	// Deduplicate: only add if not already present
-	for _, t := range resp.Names {
-		if t == "agent-skills" {
-			return nil
-		}
+	if slices.Contains(resp.Names, "agent-skills") {
+		return nil
 	}
 
 	topics := append(resp.Names, "agent-skills")

--- a/pkg/cmd/skills/publish/publish.go
+++ b/pkg/cmd/skills/publish/publish.go
@@ -262,7 +262,7 @@ func publishRun(opts *PublishOptions) error {
 
 		// Validate allowed-tools is string, not array
 		if raw, ok := result.RawYAML["allowed-tools"]; ok {
-			if _, isSlice := raw.([]interface{}); isSlice {
+			if _, isSlice := raw.([]any); isSlice {
 				diagnostics = append(diagnostics, publishDiagnostic{
 					skill:    skill.DisplayName(),
 					severity: "error",
@@ -272,7 +272,7 @@ func publishRun(opts *PublishOptions) error {
 		}
 
 		// Check for install metadata that should be stripped
-		if meta, ok := result.RawYAML["metadata"].(map[string]interface{}); ok {
+		if meta, ok := result.RawYAML["metadata"].(map[string]any); ok {
 			githubKeys := findGitHubMetadataKeys(meta)
 			if len(githubKeys) > 0 {
 				if opts.Fix {
@@ -605,7 +605,7 @@ func runPublishRelease(opts *PublishOptions, client *api.Client, host, owner, re
 	}
 
 	// Create release via REST API
-	releaseBody := map[string]interface{}{
+	releaseBody := map[string]any{
 		"tag_name":               tag,
 		"generate_release_notes": true,
 	}
@@ -827,7 +827,7 @@ func checkSecuritySettings(client *api.Client, host, owner, repo string, skillDi
 		if u, err := safeurl.JoinPath("repos", owner, repo, "code-scanning", "alerts"); err == nil {
 			u.SetQuery("per_page", "1")
 			u.SetQuery("state", "open")
-			if err := client.REST(host, "GET", u.String(), nil, new([]interface{})); err != nil {
+			if err := client.REST(host, "GET", u.String(), nil, new([]any)); err != nil {
 				diagnostics = append(diagnostics, publishDiagnostic{
 					severity: "info",
 					message:  "skills include code files but code scanning does not appear to be configured (Settings > Code security > Code scanning)",
@@ -1128,7 +1128,7 @@ func renderDiagnosticsPlain(opts *PublishOptions, diagnostics []publishDiagnosti
 }
 
 // findGitHubMetadataKeys returns metadata keys with the "github-" prefix.
-func findGitHubMetadataKeys(meta map[string]interface{}) []string {
+func findGitHubMetadataKeys(meta map[string]any) []string {
 	var keys []string
 	for k := range meta {
 		if strings.HasPrefix(k, "github-") {
@@ -1146,7 +1146,7 @@ func stripGitHubMetadata(content string) (string, error) {
 		return "", err
 	}
 
-	meta, ok := result.RawYAML["metadata"].(map[string]interface{})
+	meta, ok := result.RawYAML["metadata"].(map[string]any)
 	if !ok {
 		return content, nil
 	}

--- a/pkg/cmd/skills/publish/publish_test.go
+++ b/pkg/cmd/skills/publish/publish_test.go
@@ -51,28 +51,28 @@ func stubEnsurePushed(cs *run.CommandStubber, branch string) {
 func stubAllSecureRemote(reg *httpmock.Registry, owner, repo string) {
 	reg.Register(
 		httpmock.REST("GET", "repos/"+owner+"/"+repo+"/topics"),
-		httpmock.JSONResponse(map[string]interface{}{
+		httpmock.JSONResponse(map[string]any{
 			"names": []string{"agent-skills"},
 		}),
 	)
 	reg.Register(
 		httpmock.REST("GET", "repos/"+owner+"/"+repo+"/tags"),
-		httpmock.JSONResponse([]map[string]interface{}{
+		httpmock.JSONResponse([]map[string]any{
 			{"name": "v1.0.0"},
 		}),
 	)
 	reg.Register(
 		httpmock.REST("GET", "repos/"+owner+"/"+repo+"/rulesets"),
-		httpmock.JSONResponse([]map[string]interface{}{
+		httpmock.JSONResponse([]map[string]any{
 			{"id": 1, "name": "tags", "target": "tag", "enforcement": "active"},
 		}),
 	)
 	reg.Register(
 		httpmock.REST("GET", "repos/"+owner+"/"+repo),
-		httpmock.JSONResponse(map[string]interface{}{
-			"security_and_analysis": map[string]interface{}{
-				"secret_scanning":                 map[string]interface{}{"status": "enabled"},
-				"secret_scanning_push_protection": map[string]interface{}{"status": "enabled"},
+		httpmock.JSONResponse(map[string]any{
+			"security_and_analysis": map[string]any{
+				"secret_scanning":                 map[string]any{"status": "enabled"},
+				"secret_scanning_push_protection": map[string]any{"status": "enabled"},
 			},
 		}),
 	)
@@ -399,17 +399,17 @@ func TestPublishRun(t *testing.T) {
 				// immutable releases check
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/immutable-releases"),
-					httpmock.JSONResponse(map[string]interface{}{"enabled": true}),
+					httpmock.JSONResponse(map[string]any{"enabled": true}),
 				)
 				// default branch for branch comparison
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo"),
-					httpmock.JSONResponse(map[string]interface{}{"default_branch": "main"}),
+					httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
 				)
 				// create release
 				reg.Register(
 					httpmock.REST("POST", "repos/monalisa/skills-repo/releases"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"html_url": "https://github.com/monalisa/skills-repo/releases/tag/v1.0.1",
 					}),
 				)
@@ -548,26 +548,26 @@ func TestPublishRun(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/secure-repo/topics"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"names": []string{"agent-skills"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/secure-repo/tags"),
-					httpmock.JSONResponse([]interface{}{}),
+					httpmock.JSONResponse([]any{}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/secure-repo/rulesets"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"id": 1, "name": "branch-only", "target": "branch", "enforcement": "active"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/secure-repo"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"security_and_analysis": map[string]interface{}{
-							"secret_scanning":                 map[string]interface{}{"status": "disabled"},
-							"secret_scanning_push_protection": map[string]interface{}{"status": "disabled"},
+					httpmock.JSONResponse(map[string]any{
+						"security_and_analysis": map[string]any{
+							"secret_scanning":                 map[string]any{"status": "disabled"},
+							"secret_scanning_push_protection": map[string]any{"status": "disabled"},
 						},
 					}),
 				)
@@ -605,24 +605,24 @@ func TestPublishRun(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/tag-repo/topics"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"names": []string{"agent-skills"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/tag-repo/tags"),
-					httpmock.JSONResponse([]interface{}{}),
+					httpmock.JSONResponse([]any{}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/tag-repo/rulesets"),
-					httpmock.JSONResponse([]interface{}{}),
+					httpmock.JSONResponse([]any{}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/tag-repo"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"security_and_analysis": map[string]interface{}{
-							"secret_scanning":                 map[string]interface{}{"status": "enabled"},
-							"secret_scanning_push_protection": map[string]interface{}{"status": "enabled"},
+					httpmock.JSONResponse(map[string]any{
+						"security_and_analysis": map[string]any{
+							"secret_scanning":                 map[string]any{"status": "enabled"},
+							"secret_scanning_push_protection": map[string]any{"status": "enabled"},
 						},
 					}),
 				)
@@ -664,26 +664,26 @@ func TestPublishRun(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/code-repo/topics"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"names": []string{"agent-skills"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/code-repo/tags"),
-					httpmock.JSONResponse([]interface{}{}),
+					httpmock.JSONResponse([]any{}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/code-repo/rulesets"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"id": 1, "name": "tags", "target": "tag", "enforcement": "active"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/code-repo"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"security_and_analysis": map[string]interface{}{
-							"secret_scanning":                 map[string]interface{}{"status": "enabled"},
-							"secret_scanning_push_protection": map[string]interface{}{"status": "enabled"},
+					httpmock.JSONResponse(map[string]any{
+						"security_and_analysis": map[string]any{
+							"secret_scanning":                 map[string]any{"status": "enabled"},
+							"secret_scanning_push_protection": map[string]any{"status": "enabled"},
 						},
 					}),
 				)
@@ -731,26 +731,26 @@ func TestPublishRun(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/dep-repo/topics"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"names": []string{"agent-skills"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/dep-repo/tags"),
-					httpmock.JSONResponse([]interface{}{}),
+					httpmock.JSONResponse([]any{}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/dep-repo/rulesets"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"id": 1, "name": "tags", "target": "tag", "enforcement": "active"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/octocat/dep-repo"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"security_and_analysis": map[string]interface{}{
-							"secret_scanning":                 map[string]interface{}{"status": "enabled"},
-							"secret_scanning_push_protection": map[string]interface{}{"status": "enabled"},
+					httpmock.JSONResponse(map[string]any{
+						"security_and_analysis": map[string]any{
+							"secret_scanning":                 map[string]any{"status": "enabled"},
+							"secret_scanning_push_protection": map[string]any{"status": "enabled"},
 						},
 					}),
 				)
@@ -964,54 +964,54 @@ func TestPublishRun(t *testing.T) {
 				// topic missing
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/topics"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"names": []string{"golang"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/tags"),
-					httpmock.JSONResponse([]interface{}{}),
+					httpmock.JSONResponse([]any{}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/rulesets"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"id": 1, "name": "tags", "target": "tag", "enforcement": "active"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"security_and_analysis": map[string]interface{}{
-							"secret_scanning":                 map[string]interface{}{"status": "enabled"},
-							"secret_scanning_push_protection": map[string]interface{}{"status": "enabled"},
+					httpmock.JSONResponse(map[string]any{
+						"security_and_analysis": map[string]any{
+							"secret_scanning":                 map[string]any{"status": "enabled"},
+							"secret_scanning_push_protection": map[string]any{"status": "enabled"},
 						},
 					}),
 				)
 				// addAgentSkillsTopic fetches topics again then PUTs
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/topics"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"names": []string{"golang"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("PUT", "repos/monalisa/skills-repo/topics"),
-					httpmock.JSONResponse(map[string]interface{}{}),
+					httpmock.JSONResponse(map[string]any{}),
 				)
 				// immutable releases
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/immutable-releases"),
-					httpmock.JSONResponse(map[string]interface{}{"enabled": true}),
+					httpmock.JSONResponse(map[string]any{"enabled": true}),
 				)
 				// default branch
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo"),
-					httpmock.JSONResponse(map[string]interface{}{"default_branch": "main"}),
+					httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
 				)
 				// create release
 				reg.Register(
 					httpmock.REST("POST", "repos/monalisa/skills-repo/releases"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"html_url": "https://github.com/monalisa/skills-repo/releases/tag/v1.0.0",
 					}),
 				)
@@ -1053,45 +1053,45 @@ func TestPublishRun(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/topics"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"names": []string{"agent-skills"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/tags"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"name": "v2.3.4"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/rulesets"),
-					httpmock.JSONResponse([]map[string]interface{}{
+					httpmock.JSONResponse([]map[string]any{
 						{"id": 1, "name": "tags", "target": "tag", "enforcement": "active"},
 					}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo"),
-					httpmock.JSONResponse(map[string]interface{}{
-						"security_and_analysis": map[string]interface{}{
-							"secret_scanning":                 map[string]interface{}{"status": "enabled"},
-							"secret_scanning_push_protection": map[string]interface{}{"status": "enabled"},
+					httpmock.JSONResponse(map[string]any{
+						"security_and_analysis": map[string]any{
+							"secret_scanning":                 map[string]any{"status": "enabled"},
+							"secret_scanning_push_protection": map[string]any{"status": "enabled"},
 						},
 					}),
 				)
 				// immutable releases
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/immutable-releases"),
-					httpmock.JSONResponse(map[string]interface{}{"enabled": true}),
+					httpmock.JSONResponse(map[string]any{"enabled": true}),
 				)
 				// default branch
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo"),
-					httpmock.JSONResponse(map[string]interface{}{"default_branch": "main"}),
+					httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
 				)
 				// create release with the suggested v2.3.5 tag
 				reg.Register(
 					httpmock.REST("POST", "repos/monalisa/skills-repo/releases"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"html_url": "https://github.com/monalisa/skills-repo/releases/tag/v2.3.5",
 					}),
 				)
@@ -1225,12 +1225,12 @@ func TestPublishRun(t *testing.T) {
 				// No topic yet, first GET for diagnostic check
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/topics"),
-					httpmock.JSONResponse(map[string]interface{}{"names": []string{}}),
+					httpmock.JSONResponse(map[string]any{"names": []string{}}),
 				)
 				// Second GET inside addAgentSkillsTopic
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/topics"),
-					httpmock.JSONResponse(map[string]interface{}{"names": []string{}}),
+					httpmock.JSONResponse(map[string]any{"names": []string{}}),
 				)
 				// Add topic
 				reg.Register(
@@ -1239,31 +1239,31 @@ func TestPublishRun(t *testing.T) {
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/tags"),
-					httpmock.JSONResponse([]map[string]interface{}{}),
+					httpmock.JSONResponse([]map[string]any{}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/rulesets"),
-					httpmock.JSONResponse([]map[string]interface{}{}),
+					httpmock.JSONResponse([]map[string]any{}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"default_branch": "main",
-						"security_and_analysis": map[string]interface{}{
-							"secret_scanning":                 map[string]interface{}{"status": "enabled"},
-							"secret_scanning_push_protection": map[string]interface{}{"status": "enabled"},
+						"security_and_analysis": map[string]any{
+							"secret_scanning":                 map[string]any{"status": "enabled"},
+							"secret_scanning_push_protection": map[string]any{"status": "enabled"},
 						},
 					}),
 				)
 				// Immutable releases already enabled
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/immutable-releases"),
-					httpmock.JSONResponse(map[string]interface{}{"enabled": true}),
+					httpmock.JSONResponse(map[string]any{"enabled": true}),
 				)
 				// Create release
 				reg.Register(
 					httpmock.REST("POST", "repos/monalisa/skills-repo/releases"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"html_url": "https://github.com/monalisa/skills-repo/releases/tag/v1.0.0",
 					}),
 				)
@@ -1317,15 +1317,15 @@ func TestPublishRun(t *testing.T) {
 				stubAllSecureRemote(reg, "monalisa", "skills-repo")
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/immutable-releases"),
-					httpmock.JSONResponse(map[string]interface{}{"enabled": true}),
+					httpmock.JSONResponse(map[string]any{"enabled": true}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo"),
-					httpmock.JSONResponse(map[string]interface{}{"default_branch": "main"}),
+					httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
 				)
 				reg.Register(
 					httpmock.REST("POST", "repos/monalisa/skills-repo/releases"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"html_url": "https://github.com/monalisa/skills-repo/releases/tag/beta-1",
 					}),
 				)
@@ -1377,11 +1377,11 @@ func TestPublishRun(t *testing.T) {
 				stubAllSecureRemote(reg, "monalisa", "skills-repo")
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/immutable-releases"),
-					httpmock.JSONResponse(map[string]interface{}{"enabled": true}),
+					httpmock.JSONResponse(map[string]any{"enabled": true}),
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo"),
-					httpmock.JSONResponse(map[string]interface{}{"default_branch": "main"}),
+					httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
 				)
 			},
 			cmdStubs: func(cs *run.CommandStubber) {
@@ -1438,7 +1438,7 @@ func TestPublishRun(t *testing.T) {
 				// Immutable releases NOT enabled
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo/immutable-releases"),
-					httpmock.JSONResponse(map[string]interface{}{"enabled": false}),
+					httpmock.JSONResponse(map[string]any{"enabled": false}),
 				)
 				// Enable immutable releases
 				reg.Register(
@@ -1447,11 +1447,11 @@ func TestPublishRun(t *testing.T) {
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/skills-repo"),
-					httpmock.JSONResponse(map[string]interface{}{"default_branch": "main"}),
+					httpmock.JSONResponse(map[string]any{"default_branch": "main"}),
 				)
 				reg.Register(
 					httpmock.REST("POST", "repos/monalisa/skills-repo/releases"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"html_url": "https://github.com/monalisa/skills-repo/releases/tag/v1.0.1",
 					}),
 				)

--- a/pkg/cmd/skills/publish/publish_test.go
+++ b/pkg/cmd/skills/publish/publish_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
@@ -28,11 +29,11 @@ func newTestGitClient() *git.Client {
 
 // stubGitRemote registers CommandStubber stubs for git remote detection.
 func stubGitRemote(cs *run.CommandStubber, remoteURLs map[string]string) {
-	var remoteLines string
+	var remoteLines strings.Builder
 	for name, url := range remoteURLs {
-		remoteLines += fmt.Sprintf("%[1]s\t%[2]s (fetch)\n%[1]s\t%[2]s (push)\n", name, url)
+		remoteLines.WriteString(fmt.Sprintf("%[1]s\t%[2]s (fetch)\n%[1]s\t%[2]s (push)\n", name, url))
 	}
-	cs.Register(`git( .+)? remote -v`, 0, remoteLines)
+	cs.Register(`git( .+)? remote -v`, 0, remoteLines.String())
 	cs.Register(`git( .+)? config --get-regexp \^remote\\\.`, 1, "")
 	for name, url := range remoteURLs {
 		cs.Register(fmt.Sprintf(`git( .+)? remote get-url -- %s`, regexp.QuoteMeta(name)), 0, url+"\n")

--- a/pkg/cmd/skills/search/search.go
+++ b/pkg/cmd/skills/search/search.go
@@ -183,8 +183,8 @@ func (s skillResult) qualifiedName() string {
 }
 
 // ExportData implements cmdutil.exportable for --json output.
-func (s skillResult) ExportData(fields []string) map[string]interface{} {
-	data := map[string]interface{}{}
+func (s skillResult) ExportData(fields []string) map[string]any {
+	data := map[string]any{}
 	for _, f := range fields {
 		switch f {
 		case "repo":

--- a/pkg/cmd/skills/search/search.go
+++ b/pkg/cmd/skills/search/search.go
@@ -305,11 +305,9 @@ func searchByKeyword(client *api.Client, host, queryTerm, owner string, page, li
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		pathResult, pathErr = executeSearch(client, host, pathQ, 1, searchPageSize)
-	}()
+	})
 
 	// When no explicit --owner is set and the query looks like it could be a
 	// GitHub username, fire an additional user:<query> search to discover
@@ -317,11 +315,9 @@ func searchByKeyword(client *api.Client, host, queryTerm, owner string, page, li
 	// everything else (no scoring boost).
 	if owner == "" && couldBeOwner(queryTerm) {
 		ownerQ := fmt.Sprintf("filename:SKILL.md user:%s", queryTerm)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ownerResult, ownerErr = executeSearch(client, host, ownerQ, 1, searchPageSize)
-		}()
+		})
 	}
 
 	// When the query has spaces (e.g. "mcp apps"), run an additional content
@@ -329,11 +325,9 @@ func searchByKeyword(client *api.Client, host, queryTerm, owner string, page, li
 	// whose names use hyphens as word separators.
 	if hasSpaces {
 		hyphenQ := fmt.Sprintf("filename:SKILL.md %s%s", pathTerm, ownerScope)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			hyphenResult, hyphenErr = executeSearch(client, host, hyphenQ, 1, searchPageSize)
-		}()
+		})
 	}
 
 	// Primary content search runs on the main goroutine.

--- a/pkg/cmd/skills/search/search.go
+++ b/pkg/cmd/skills/search/search.go
@@ -374,10 +374,7 @@ func noResults(opts *SearchOptions, msg string) error {
 // potentially a repo fetch (stars), so keeping this small matters for
 // performance. Pre-ranking ensures the best candidates are at the top.
 func truncateForProcessing(skills []skillResult, page, limit int) []skillResult {
-	maxToProcess := page * limit * 3
-	if maxToProcess < limit*3 {
-		maxToProcess = limit * 3
-	}
+	maxToProcess := max(page*limit*3, limit*3)
 	if len(skills) > maxToProcess {
 		return skills[:maxToProcess]
 	}
@@ -421,10 +418,7 @@ func paginate(skills []skillResult, page, limit int) ([]skillResult, int) {
 	if start >= total {
 		return nil, totalPages
 	}
-	end := start + limit
-	if end > total {
-		end = total
-	}
+	end := min(start+limit, total)
 	return skills[start:end], totalPages
 }
 
@@ -494,10 +488,7 @@ func renderResults(opts *SearchOptions, skills []skillResult, totalPages int) er
 func renderTable(io *iostreams.IOStreams, skills []skillResult) error {
 	isTTY := io.IsStdoutTTY()
 	tw := io.TerminalWidth()
-	descWidth := tw - 70
-	if descWidth < 20 {
-		descWidth = 20
-	}
+	descWidth := max(tw-70, 20)
 
 	table := tableprinter.New(io, tableprinter.WithHeader("REPOSITORY", "SKILL", "DESCRIPTION", "STARS"))
 	for _, s := range skills {
@@ -524,10 +515,7 @@ func promptInstall(opts *SearchOptions, skills []skillResult) error {
 	// Reserve space for the checkbox UI prefix ("[ ] ") and the description
 	// indent ("\n       " = 7 chars), then use the remaining terminal width.
 	tw := opts.IO.TerminalWidth()
-	descWidth := tw - 11
-	if descWidth < 30 {
-		descWidth = 30
-	}
+	descWidth := max(tw-11, 30)
 
 	options := make([]string, len(skills))
 	for i, s := range skills {
@@ -758,10 +746,7 @@ func fetchPrimaryPages(client *api.Client, host, query string, displayPage, disp
 	// good buffer for typical filter rates while staying well within
 	// the rate-limit budget.
 	needed := displayPage * displayLimit * 3
-	numPages := (needed + searchPageSize - 1) / searchPageSize
-	if numPages < 1 {
-		numPages = 1
-	}
+	numPages := max((needed+searchPageSize-1)/searchPageSize, 1)
 	maxAPIPages := maxResults / searchPageSize
 	if numPages > maxAPIPages {
 		numPages = maxAPIPages

--- a/pkg/cmd/ssh-key/add/add_test.go
+++ b/pkg/cmd/ssh-key/add/add_test.go
@@ -33,7 +33,7 @@ func Test_runAdd(t *testing.T) {
 					httpmock.StringResponse("[]"))
 				reg.Register(
 					httpmock.REST("POST", "user/keys"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Contains(t, payload, "key")
 						assert.Empty(t, payload["title"])
 					}))
@@ -52,7 +52,7 @@ func Test_runAdd(t *testing.T) {
 					httpmock.StringResponse("[]"))
 				reg.Register(
 					httpmock.REST("POST", "user/ssh_signing_keys"),
-					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]any) {
 						assert.Contains(t, payload, "key")
 						assert.Empty(t, payload["title"])
 					}))

--- a/pkg/cmd/ssh-key/shared/user_keys.go
+++ b/pkg/cmd/ssh-key/shared/user_keys.go
@@ -40,7 +40,7 @@ func UserKeys(httpClient *http.Client, host, userHandle string) ([]sshKey, error
 		return nil, err
 	}
 
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i].Type = AuthenticationKey
 	}
 
@@ -66,7 +66,7 @@ func UserSigningKeys(httpClient *http.Client, host, userHandle string) ([]sshKey
 		return nil, err
 	}
 
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i].Type = SigningKey
 	}
 

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -417,18 +417,19 @@ func (s *StatusGetter) LoadSearchResults() error {
 
 	var searchAssigns strings.Builder
 	searchAssigns.WriteString(`assignee:@me state:open archived:false`)
-	searchReviews := `review-requested:@me state:open archived:false`
+	var searchReviews strings.Builder
+	searchReviews.WriteString(`review-requested:@me state:open archived:false`)
 	if s.Org != "" {
 		searchAssigns.WriteString(" org:" + s.Org)
-		searchReviews += " org:" + s.Org
+		searchReviews.WriteString(" org:" + s.Org)
 	}
 	for _, repo := range s.Exclude {
 		searchAssigns.WriteString(" -repo:" + repo)
-		searchReviews += " -repo:" + repo
+		searchReviews.WriteString(" -repo:" + repo)
 	}
 	variables := map[string]any{
 		"searchAssigns": searchAssigns.String(),
-		"searchReviews": searchReviews,
+		"searchReviews": searchReviews.String(),
 	}
 
 	var resp struct {

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -207,12 +208,7 @@ func (s *StatusGetter) CachedClient(ttl time.Duration) *http.Client {
 }
 
 func (s *StatusGetter) ShouldExclude(repo string) bool {
-	for _, exclude := range s.Exclude {
-		if repo == exclude {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.Exclude, repo)
 }
 
 func (s *StatusGetter) CurrentUsername() (string, error) {

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -415,18 +415,19 @@ query AssignedSearch($searchAssigns: String!, $searchReviews: String!, $limit: I
 func (s *StatusGetter) LoadSearchResults() error {
 	c := api.NewClientFromHTTP(s.Client)
 
-	searchAssigns := `assignee:@me state:open archived:false`
+	var searchAssigns strings.Builder
+	searchAssigns.WriteString(`assignee:@me state:open archived:false`)
 	searchReviews := `review-requested:@me state:open archived:false`
 	if s.Org != "" {
-		searchAssigns += " org:" + s.Org
+		searchAssigns.WriteString(" org:" + s.Org)
 		searchReviews += " org:" + s.Org
 	}
 	for _, repo := range s.Exclude {
-		searchAssigns += " -repo:" + repo
+		searchAssigns.WriteString(" -repo:" + repo)
 		searchReviews += " -repo:" + repo
 	}
 	variables := map[string]any{
-		"searchAssigns": searchAssigns,
+		"searchAssigns": searchAssigns.String(),
 		"searchReviews": searchReviews,
 	}
 

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -273,7 +273,7 @@ func (s *StatusGetter) LoadNotifications() error {
 	fetched := make(chan StatusItem)
 
 	wg := new(errgroup.Group)
-	for i := 0; i < fetchWorkers; i++ {
+	for range fetchWorkers {
 		wg.Go(func() error {
 			for {
 				select {
@@ -341,7 +341,7 @@ func (s *StatusGetter) LoadNotifications() error {
 	u.SetQuery("participating", "true")
 	u.SetQuery("all", "true")
 	var p safeurl.SafeURL = u
-	for pages := 0; pages < 3; pages++ {
+	for range 3 {
 		var resp []Notification
 		next, err := c.RESTWithNext(s.hostname(), "GET", p.String(), nil, &resp)
 		if err != nil {

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -429,7 +429,7 @@ func (s *StatusGetter) LoadSearchResults() error {
 		searchAssigns += " -repo:" + repo
 		searchReviews += " -repo:" + repo
 	}
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"searchAssigns": searchAssigns,
 		"searchReviews": searchReviews,
 	}

--- a/pkg/cmd/variable/get/get_test.go
+++ b/pkg/cmd/variable/get/get_test.go
@@ -208,7 +208,7 @@ func Test_getRun(t *testing.T) {
 						NumSelectedRepos: 0, // This should be populated in a second API call.
 					}))
 				reg.Register(httpmock.REST("GET", "path/to/fetch/selected/repos"),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"total_count": 99,
 					}))
 			},

--- a/pkg/cmd/variable/set/http.go
+++ b/pkg/cmd/variable/set/http.go
@@ -84,7 +84,7 @@ func setVariable(client *api.Client, host string, opts setOptions) setResult {
 	return result
 }
 
-func postVariable(client *api.Client, host string, path safeurl.SafeURL, payload interface{}) error {
+func postVariable(client *api.Client, host string, path safeurl.SafeURL, payload any) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("failed to serialize: %w", err)
@@ -131,7 +131,7 @@ func postRepoVariable(client *api.Client, repo ghrepo.Interface, variableName, v
 	return postVariable(client, repo.RepoHost(), path, payload)
 }
 
-func patchVariable(client *api.Client, host string, path safeurl.SafeURL, payload interface{}) error {
+func patchVariable(client *api.Client, host string, path safeurl.SafeURL, payload any) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("failed to serialize: %w", err)

--- a/pkg/cmd/variable/set/set.go
+++ b/pkg/cmd/variable/set/set.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"strings"
@@ -248,9 +249,7 @@ func getVariablesFromOptions(opts *SetOptions) (map[string]string, error) {
 		if len(envs) == 0 {
 			return nil, fmt.Errorf("no variables found in file")
 		}
-		for key, value := range envs {
-			variables[key] = value
-		}
+		maps.Copy(variables, envs)
 		return variables, nil
 	}
 

--- a/pkg/cmd/variable/shared/shared.go
+++ b/pkg/cmd/variable/shared/shared.go
@@ -45,7 +45,7 @@ var VariableJSONFields = []string{
 	"selectedReposURL",
 }
 
-func (v *Variable) ExportData(fields []string) map[string]interface{} {
+func (v *Variable) ExportData(fields []string) map[string]any {
 	return cmdutil.StructExportData(v, fields)
 }
 

--- a/pkg/cmd/workflow/list/list_test.go
+++ b/pkg/cmd/workflow/list/list_test.go
@@ -168,7 +168,7 @@ func TestListRun(t *testing.T) {
 			stubs: func(reg *httpmock.Registry) {
 				workflows := []shared.Workflow{}
 				var flowID int64
-				for flowID = 0; flowID < 103; flowID++ {
+				for flowID = range 103 {
 					workflows = append(workflows, shared.Workflow{
 						ID:    flowID,
 						Name:  fmt.Sprintf("flow %d", flowID),

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -195,7 +195,7 @@ type InputAnswer struct {
 	providedInputs map[string]string
 }
 
-func (ia *InputAnswer) WriteAnswer(name string, value interface{}) error {
+func (ia *InputAnswer) WriteAnswer(name string, value any) error {
 	if s, ok := value.(string); ok {
 		ia.providedInputs[name] = s
 		return nil
@@ -325,7 +325,7 @@ func runRun(opts *RunOptions) error {
 		return err
 	}
 
-	requestBody := map[string]interface{}{
+	requestBody := map[string]any{
 		"ref":    ref,
 		"inputs": providedInputs,
 	}

--- a/pkg/cmd/workflow/run/run_test.go
+++ b/pkg/cmd/workflow/run/run_test.go
@@ -168,7 +168,7 @@ func Test_magicFieldValue(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{
@@ -420,7 +420,7 @@ jobs:
 			}))
 		reg.Register(
 			httpmock.REST("POST", "repos/OWNER/REPO/actions/workflows/12345/dispatches"),
-			httpmock.StatusJSONResponse(200, map[string]interface{}{
+			httpmock.StatusJSONResponse(200, map[string]any{
 				"workflow_run_id": int64(6789),
 				"run_url":         "https://api.github.com/repos/OWNER/REPO/actions/runs/6789",
 				"html_url":        "https://github.com/OWNER/REPO/actions/runs/6789",
@@ -434,7 +434,7 @@ jobs:
 		wantErr     bool
 		errOut      string
 		wantOut     string
-		wantBody    map[string]interface{}
+		wantBody    map[string]any
 		httpStubs   func(*httpmock.Registry)
 		promptStubs func(*prompter.MockPrompter)
 	}{
@@ -464,8 +464,8 @@ jobs:
 				JSONInput: `{"name":"scully"}`,
 				Detector:  &fd.DisabledDetectorMock{},
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name": "scully",
 				},
 				"ref": "trunk",
@@ -485,8 +485,8 @@ jobs:
 				JSONInput: `{"name":"scully"}`,
 				Detector:  &fd.EnabledDetectorMock{},
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name": "scully",
 				},
 				"ref":                "trunk",
@@ -510,8 +510,8 @@ jobs:
 				JSONInput: `{"name":"scully"}`,
 				Detector:  &fd.DisabledDetectorMock{},
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name": "scully",
 				},
 				"ref": "trunk",
@@ -525,8 +525,8 @@ jobs:
 				JSONInput: `{"name":"scully"}`,
 				Detector:  &fd.EnabledDetectorMock{},
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name": "scully",
 				},
 				"ref":                "trunk",
@@ -545,8 +545,8 @@ jobs:
 				MagicFields: []string{`greeting=hey`},
 				Detector:    &fd.DisabledDetectorMock{},
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name":     "scully",
 					"greeting": "hey",
 				},
@@ -562,8 +562,8 @@ jobs:
 				MagicFields: []string{`greeting=hey`},
 				Detector:    &fd.EnabledDetectorMock{},
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name":     "scully",
 					"greeting": "hey",
 				},
@@ -584,8 +584,8 @@ jobs:
 				Ref:       "good-branch",
 				Detector:  &fd.DisabledDetectorMock{},
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name": "scully",
 				},
 				"ref": "good-branch",
@@ -606,8 +606,8 @@ jobs:
 				Ref:       "good-branch",
 				Detector:  &fd.EnabledDetectorMock{},
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name": "scully",
 				},
 				"ref":                "good-branch",
@@ -642,8 +642,8 @@ jobs:
 					httpmock.REST("POST", "repos/OWNER/REPO/actions/workflows/12345/dispatches"),
 					httpmock.StatusStringResponse(422, "missing something"))
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"greeting": "hello there",
 				},
 				"ref":                "trunk",
@@ -665,14 +665,14 @@ jobs:
 					httpmock.StatusStringResponse(200, `{"id": 12345}`))
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/actions/workflows/12345/dispatches"),
-					httpmock.StatusJSONResponse(200, map[string]interface{}{
+					httpmock.StatusJSONResponse(200, map[string]any{
 						"workflow_run_id": int64(6789),
 						"run_url":         "https://api.github.com/repos/OWNER/REPO/actions/runs/6789",
 						"html_url":        "https://github.com/OWNER/REPO/actions/runs/6789",
 					}))
 			},
-			wantBody: map[string]interface{}{
-				"inputs":             map[string]interface{}{},
+			wantBody: map[string]any{
+				"inputs":             map[string]any{},
 				"ref":                "trunk",
 				"return_run_details": true,
 			},
@@ -777,8 +777,8 @@ jobs:
 					return 0, nil
 				})
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{},
+			wantBody: map[string]any{
+				"inputs": map[string]any{},
 				"ref":    "trunk",
 			},
 			wantOut: heredoc.Doc(`
@@ -814,7 +814,7 @@ jobs:
 					}))
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/actions/workflows/1/dispatches"),
-					httpmock.StatusJSONResponse(200, map[string]interface{}{
+					httpmock.StatusJSONResponse(200, map[string]any{
 						"workflow_run_id": int64(6789),
 						"run_url":         "https://api.github.com/repos/OWNER/REPO/actions/runs/6789",
 						"html_url":        "https://github.com/OWNER/REPO/actions/runs/6789",
@@ -825,8 +825,8 @@ jobs:
 					return 0, nil
 				})
 			},
-			wantBody: map[string]interface{}{
-				"inputs":             map[string]interface{}{},
+			wantBody: map[string]any{
+				"inputs":             map[string]any{},
 				"ref":                "trunk",
 				"return_run_details": true,
 			},
@@ -880,8 +880,8 @@ jobs:
 					return "scully", nil
 				})
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name":     "scully",
 					"greeting": "hi",
 				},
@@ -920,7 +920,7 @@ jobs:
 					}))
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/actions/workflows/12345/dispatches"),
-					httpmock.StatusJSONResponse(200, map[string]interface{}{
+					httpmock.StatusJSONResponse(200, map[string]any{
 						"workflow_run_id": int64(6789),
 						"run_url":         "https://api.github.com/repos/OWNER/REPO/actions/runs/6789",
 						"html_url":        "https://github.com/OWNER/REPO/actions/runs/6789",
@@ -937,8 +937,8 @@ jobs:
 					return "scully", nil
 				})
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name":     "scully",
 					"greeting": "hi",
 				},
@@ -996,8 +996,8 @@ jobs:
 				})
 
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name":             "monalisa",
 					"favourite-animal": "dog",
 				},
@@ -1036,7 +1036,7 @@ jobs:
 					}))
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/actions/workflows/12345/dispatches"),
-					httpmock.StatusJSONResponse(200, map[string]interface{}{
+					httpmock.StatusJSONResponse(200, map[string]any{
 						"workflow_run_id": int64(6789),
 						"run_url":         "https://api.github.com/repos/OWNER/REPO/actions/runs/6789",
 						"html_url":        "https://github.com/OWNER/REPO/actions/runs/6789",
@@ -1054,8 +1054,8 @@ jobs:
 				})
 
 			},
-			wantBody: map[string]interface{}{
-				"inputs": map[string]interface{}{
+			wantBody: map[string]any{
+				"inputs": map[string]any{
 					"name":             "monalisa",
 					"favourite-animal": "dog",
 				},
@@ -1151,7 +1151,7 @@ jobs:
 				lastRequest := reg.Requests[len(reg.Requests)-1]
 				if lastRequest.Method == "POST" {
 					bodyBytes, _ := io.ReadAll(lastRequest.Body)
-					reqBody := make(map[string]interface{})
+					reqBody := make(map[string]any)
 					err := json.Unmarshal(bodyBytes, &reqBody)
 					if err != nil {
 						t.Fatalf("error decoding JSON: %v", err)

--- a/pkg/cmd/workflow/shared/shared.go
+++ b/pkg/cmd/workflow/shared/shared.go
@@ -50,7 +50,7 @@ func (w *Workflow) Base() string {
 	return path.Base(w.Path)
 }
 
-func (w *Workflow) ExportData(fields []string) map[string]interface{} {
+func (w *Workflow) ExportData(fields []string) map[string]any {
 	return cmdutil.StructExportData(w, fields)
 }
 

--- a/pkg/cmd/workflow/shared/shared.go
+++ b/pkg/cmd/workflow/shared/shared.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -106,12 +107,9 @@ func selectWorkflow(p iprompter, workflows []Workflow, promptMsg string, states 
 	filtered := []Workflow{}
 	candidates := []string{}
 	for _, workflow := range workflows {
-		for _, state := range states {
-			if workflow.State == state {
-				filtered = append(filtered, workflow)
-				candidates = append(candidates, fmt.Sprintf("%s (%s)", workflow.Name, workflow.Base()))
-				break
-			}
+		if slices.Contains(states, workflow.State) {
+			filtered = append(filtered, workflow)
+			candidates = append(candidates, fmt.Sprintf("%s (%s)", workflow.Name, workflow.Base()))
 		}
 	}
 
@@ -186,11 +184,8 @@ func getWorkflowsByName(client *api.Client, repo ghrepo.Interface, name string, 
 		if !strings.EqualFold(workflow.Name, name) {
 			continue
 		}
-		for _, state := range states {
-			if workflow.State == state {
-				filtered = append(filtered, workflow)
-				break
-			}
+		if slices.Contains(states, workflow.State) {
+			filtered = append(filtered, workflow)
 		}
 	}
 

--- a/pkg/cmd/workflow/shared/shared.go
+++ b/pkg/cmd/workflow/shared/shared.go
@@ -225,11 +225,12 @@ func ResolveWorkflow(p iprompter, io *iostreams.IOStreams, client *api.Client, r
 	}
 
 	if !io.CanPrompt() {
-		errMsg := "could not resolve to a unique workflow; found:"
+		var errMsg strings.Builder
+		errMsg.WriteString("could not resolve to a unique workflow; found:")
 		for _, workflow := range workflows {
-			errMsg += fmt.Sprintf(" %s", workflow.Base())
+			errMsg.WriteString(fmt.Sprintf(" %s", workflow.Base()))
 		}
-		return nil, errors.New(errMsg)
+		return nil, errors.New(errMsg.String())
 	}
 
 	return selectWorkflow(p, workflows, "Which workflow do you mean?", states)

--- a/pkg/cmd/workflow/shared/shared_test.go
+++ b/pkg/cmd/workflow/shared/shared_test.go
@@ -412,7 +412,7 @@ func TestGetWorkflows(t *testing.T) {
 func generateWorkflows(t *testing.T, workflowCount int, pageNum int) []Workflow {
 	t.Helper()
 	workflows := []Workflow{}
-	for i := 0; i < workflowCount; i++ {
+	for i := range workflowCount {
 		workflows = append(workflows, Workflow{
 			Name: fmt.Sprintf("Workflow-%d-%d", pageNum, i),
 			ID:   int64(i) + int64(pageNum-1)*100,

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -9,7 +9,7 @@ import (
 
 // FlagErrorf returns a new FlagError that wraps an error produced by
 // fmt.Errorf(format, args...).
-func FlagErrorf(format string, args ...interface{}) error {
+func FlagErrorf(format string, args ...any) error {
 	return FlagErrorWrap(fmt.Errorf(format, args...))
 }
 

--- a/pkg/cmdutil/json_flags.go
+++ b/pkg/cmdutil/json_flags.go
@@ -294,7 +294,6 @@ type exportable interface {
 }
 
 var exportableType = reflect.TypeFor[exportable]()
-var sliceOfEmptyInterface []any
 var emptyInterfaceType = reflect.TypeFor[[]any]().Elem()
 
 // Basic function that can be used with structs that need to implement

--- a/pkg/cmdutil/json_flags.go
+++ b/pkg/cmdutil/json_flags.go
@@ -197,7 +197,7 @@ func checkFormatFlags(cmd *cobra.Command) (*jsonExporter, error) {
 
 type Exporter interface {
 	Fields() []string
-	Write(io *iostreams.IOStreams, data interface{}) error
+	Write(io *iostreams.IOStreams, data any) error
 }
 
 type jsonExporter struct {
@@ -222,7 +222,7 @@ func (e *jsonExporter) SetFields(fields []string) {
 // Write serializes data into JSON output written to w. If the object passed as data implements exportable,
 // or if data is a map or slice of exportable object, ExportData() will be called on each object to obtain
 // raw data for serialization.
-func (e *jsonExporter) Write(ios *iostreams.IOStreams, data interface{}) error {
+func (e *jsonExporter) Write(ios *iostreams.IOStreams, data any) error {
 	buf := bytes.Buffer{}
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
@@ -256,14 +256,14 @@ func (e *jsonExporter) Write(ios *iostreams.IOStreams, data interface{}) error {
 	return err
 }
 
-func (e *jsonExporter) exportData(v reflect.Value) interface{} {
+func (e *jsonExporter) exportData(v reflect.Value) any {
 	switch v.Kind() {
 	case reflect.Pointer, reflect.Interface:
 		if !v.IsNil() {
 			return e.exportData(v.Elem())
 		}
 	case reflect.Slice:
-		a := make([]interface{}, v.Len())
+		a := make([]any, v.Len())
 		for i := 0; i < v.Len(); i++ {
 			a[i] = e.exportData(v.Index(i))
 		}
@@ -290,11 +290,11 @@ func (e *jsonExporter) exportData(v reflect.Value) interface{} {
 }
 
 type exportable interface {
-	ExportData([]string) map[string]interface{}
+	ExportData([]string) map[string]any
 }
 
 var exportableType = reflect.TypeOf((*exportable)(nil)).Elem()
-var sliceOfEmptyInterface []interface{}
+var sliceOfEmptyInterface []any
 var emptyInterfaceType = reflect.TypeOf(sliceOfEmptyInterface).Elem()
 
 // Basic function that can be used with structs that need to implement
@@ -304,7 +304,7 @@ var emptyInterfaceType = reflect.TypeOf(sliceOfEmptyInterface).Elem()
 // Perhaps this should be moved up into exportData for the case when
 // a struct does not implement the exportable interface, but for now it will
 // need to be explicitly used.
-func StructExportData(s interface{}, fields []string) map[string]interface{} {
+func StructExportData(s any, fields []string) map[string]any {
 	v := reflect.ValueOf(s)
 	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
@@ -313,7 +313,7 @@ func StructExportData(s interface{}, fields []string) map[string]interface{} {
 		// If s is not a struct or pointer to a struct return nil.
 		return nil
 	}
-	data := make(map[string]interface{}, len(fields))
+	data := make(map[string]any, len(fields))
 	for _, f := range fields {
 		sf := fieldByName(v, f)
 		if sf.IsValid() && sf.CanInterface() {

--- a/pkg/cmdutil/json_flags.go
+++ b/pkg/cmdutil/json_flags.go
@@ -293,9 +293,9 @@ type exportable interface {
 	ExportData([]string) map[string]any
 }
 
-var exportableType = reflect.TypeOf((*exportable)(nil)).Elem()
+var exportableType = reflect.TypeFor[exportable]()
 var sliceOfEmptyInterface []any
-var emptyInterfaceType = reflect.TypeOf(sliceOfEmptyInterface).Elem()
+var emptyInterfaceType = reflect.TypeFor[[]any]().Elem()
 
 // Basic function that can be used with structs that need to implement
 // the exportable interface. It has numerous limitations so verify

--- a/pkg/cmdutil/json_flags_test.go
+++ b/pkg/cmdutil/json_flags_test.go
@@ -300,7 +300,7 @@ func TestAddFormatFlags(t *testing.T) {
 
 func Test_exportFormat_Write(t *testing.T) {
 	type args struct {
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name     string
@@ -334,7 +334,7 @@ func Test_exportFormat_Write(t *testing.T) {
 			name:     "recursively call ExportData",
 			exporter: jsonExporter{fields: []string{"f1", "f2"}},
 			args: args{
-				data: map[string]interface{}{
+				data: map[string]any{
 					"s1": []exportableItem{{"i1"}, {"i2"}},
 					"s2": []exportableItem{{"i3"}},
 				},
@@ -393,8 +393,8 @@ type exportableItem struct {
 	Name string
 }
 
-func (e *exportableItem) ExportData(fields []string) map[string]interface{} {
-	m := map[string]interface{}{}
+func (e *exportableItem) ExportData(fields []string) map[string]any {
+	m := map[string]any{}
 	for _, f := range fields {
 		m[f] = fmt.Sprintf("%s:%s", e.Name, f)
 	}
@@ -442,7 +442,7 @@ func TestStructExportData(t *testing.T) {
 	fields := []string{"stringField", "intField", "boolField", "sliceField", "mapField", "structField"}
 	tests := []struct {
 		name    string
-		export  interface{}
+		export  any
 		fields  []string
 		wantOut string
 	}{

--- a/pkg/httpmock/registry.go
+++ b/pkg/httpmock/registry.go
@@ -53,7 +53,7 @@ func (r *Registry) Exclude(t *testing.T, m Matcher) {
 }
 
 type Testing interface {
-	Errorf(string, ...interface{})
+	Errorf(string, ...any)
 	Helper()
 }
 

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -61,7 +61,7 @@ func GraphQL(q string) Matcher {
 	}
 }
 
-func GraphQLMutationMatcher(q string, cb func(map[string]interface{}) bool) Matcher {
+func GraphQLMutationMatcher(q string, cb func(map[string]any) bool) Matcher {
 	re := regexp.MustCompile(q)
 
 	return func(req *http.Request) bool {
@@ -75,7 +75,7 @@ func GraphQLMutationMatcher(q string, cb func(map[string]interface{}) bool) Matc
 		var bodyData struct {
 			Query     string
 			Variables struct {
-				Input map[string]interface{}
+				Input map[string]any
 			}
 		}
 		_ = decodeJSONBody(req, &bodyData)
@@ -113,7 +113,7 @@ func readBody(req *http.Request) ([]byte, error) {
 	return io.ReadAll(r)
 }
 
-func decodeJSONBody(req *http.Request, dest interface{}) error {
+func decodeJSONBody(req *http.Request, dest any) error {
 	b, err := readBody(req)
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func StatusStringResponse(status int, body string) Responder {
 	}
 }
 
-func JSONResponse(body interface{}) Responder {
+func JSONResponse(body any) Responder {
 	return func(req *http.Request) (*http.Response, error) {
 		b, _ := json.Marshal(body)
 		header := http.Header{
@@ -172,7 +172,7 @@ func JSONResponse(body interface{}) Responder {
 // StatusJSONResponse turns the given argument into a JSON response.
 //
 // The argument is not meant to be a JSON string, unless it's intentional.
-func StatusJSONResponse(status int, body interface{}) Responder {
+func StatusJSONResponse(status int, body any) Responder {
 	return func(req *http.Request) (*http.Response, error) {
 		b, _ := json.Marshal(body)
 		header := http.Header{
@@ -198,9 +198,9 @@ func FileResponse(filename string) Responder {
 	}
 }
 
-func RESTPayload(responseStatus int, responseBody string, cb func(payload map[string]interface{})) Responder {
+func RESTPayload(responseStatus int, responseBody string, cb func(payload map[string]any)) Responder {
 	return func(req *http.Request) (*http.Response, error) {
-		bodyData := make(map[string]interface{})
+		bodyData := make(map[string]any)
 		err := decodeJSONBody(req, &bodyData)
 		if err != nil {
 			return nil, err
@@ -214,11 +214,11 @@ func RESTPayload(responseStatus int, responseBody string, cb func(payload map[st
 	}
 }
 
-func GraphQLMutation(body string, cb func(map[string]interface{})) Responder {
+func GraphQLMutation(body string, cb func(map[string]any)) Responder {
 	return func(req *http.Request) (*http.Response, error) {
 		var bodyData struct {
 			Variables struct {
-				Input map[string]interface{}
+				Input map[string]any
 			}
 		}
 		err := decodeJSONBody(req, &bodyData)
@@ -231,11 +231,11 @@ func GraphQLMutation(body string, cb func(map[string]interface{})) Responder {
 	}
 }
 
-func GraphQLQuery(body string, cb func(string, map[string]interface{})) Responder {
+func GraphQLQuery(body string, cb func(string, map[string]any)) Responder {
 	return func(req *http.Request) (*http.Response, error) {
 		var bodyData struct {
 			Query     string
-			Variables map[string]interface{}
+			Variables map[string]any
 		}
 		err := decodeJSONBody(req, &bodyData)
 		if err != nil {

--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -64,7 +64,7 @@ func (c *ColorScheme) Bold(t string) string {
 	return bold(t)
 }
 
-func (c *ColorScheme) Boldf(t string, args ...interface{}) string {
+func (c *ColorScheme) Boldf(t string, args ...any) string {
 	return c.Bold(fmt.Sprintf(t, args...))
 }
 
@@ -89,7 +89,7 @@ func (c *ColorScheme) Muted(t string) string {
 	}
 }
 
-func (c *ColorScheme) Mutedf(t string, args ...interface{}) string {
+func (c *ColorScheme) Mutedf(t string, args ...any) string {
 	return c.Muted(fmt.Sprintf(t, args...))
 }
 
@@ -100,7 +100,7 @@ func (c *ColorScheme) Red(t string) string {
 	return red(t)
 }
 
-func (c *ColorScheme) Redf(t string, args ...interface{}) string {
+func (c *ColorScheme) Redf(t string, args ...any) string {
 	return c.Red(fmt.Sprintf(t, args...))
 }
 
@@ -111,7 +111,7 @@ func (c *ColorScheme) Yellow(t string) string {
 	return yellow(t)
 }
 
-func (c *ColorScheme) Yellowf(t string, args ...interface{}) string {
+func (c *ColorScheme) Yellowf(t string, args ...any) string {
 	return c.Yellow(fmt.Sprintf(t, args...))
 }
 
@@ -122,7 +122,7 @@ func (c *ColorScheme) Green(t string) string {
 	return green(t)
 }
 
-func (c *ColorScheme) Greenf(t string, args ...interface{}) string {
+func (c *ColorScheme) Greenf(t string, args ...any) string {
 	return c.Green(fmt.Sprintf(t, args...))
 }
 
@@ -145,7 +145,7 @@ func (c *ColorScheme) Gray(t string) string {
 }
 
 // Deprecated: Use Mutedf instead for thematically contrasting color.
-func (c *ColorScheme) Grayf(t string, args ...interface{}) string {
+func (c *ColorScheme) Grayf(t string, args ...any) string {
 	return c.Gray(fmt.Sprintf(t, args...))
 }
 
@@ -156,7 +156,7 @@ func (c *ColorScheme) Magenta(t string) string {
 	return magenta(t)
 }
 
-func (c *ColorScheme) Magentaf(t string, args ...interface{}) string {
+func (c *ColorScheme) Magentaf(t string, args ...any) string {
 	return c.Magenta(fmt.Sprintf(t, args...))
 }
 
@@ -167,7 +167,7 @@ func (c *ColorScheme) Cyan(t string) string {
 	return cyan(t)
 }
 
-func (c *ColorScheme) Cyanf(t string, args ...interface{}) string {
+func (c *ColorScheme) Cyanf(t string, args ...any) string {
 	return c.Cyan(fmt.Sprintf(t, args...))
 }
 
@@ -185,7 +185,7 @@ func (c *ColorScheme) Blue(t string) string {
 	return blue(t)
 }
 
-func (c *ColorScheme) Bluef(t string, args ...interface{}) string {
+func (c *ColorScheme) Bluef(t string, args ...any) string {
 	return c.Blue(fmt.Sprintf(t, args...))
 }
 

--- a/pkg/jsoncolor/jsoncolor.go
+++ b/pkg/jsoncolor/jsoncolor.go
@@ -119,7 +119,7 @@ func WriteDelims(w io.Writer, delims, indent string) error {
 }
 
 // marshalJSON works like json.Marshal but with HTML-escaping disabled
-func marshalJSON(v interface{}) ([]byte, error) {
+func marshalJSON(v any) ([]byte, error) {
 	buf := bytes.Buffer{}
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -249,7 +249,7 @@ func groupWithOR(qualifier string, vs []string) string {
 func (q Qualifiers) Map() map[string][]string {
 	m := map[string][]string{}
 	v := reflect.ValueOf(q)
-	t := reflect.TypeOf(q)
+	t := reflect.TypeFor[Qualifiers]()
 	for i := 0; i < v.NumField(); i++ {
 		field := t.Field(i)
 		key := field.Tag.Get("qualifier")

--- a/pkg/search/result.go
+++ b/pkg/search/result.go
@@ -264,13 +264,13 @@ func (u User) IsBot() bool {
 	return u.ID == ""
 }
 
-func (u User) ExportData() map[string]interface{} {
+func (u User) ExportData() map[string]any {
 	isBot := u.IsBot()
 	login := u.Login
 	if isBot {
 		login = "app/" + login
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"id":     u.ID,
 		"login":  login,
 		"type":   u.Type,
@@ -279,13 +279,13 @@ func (u User) ExportData() map[string]interface{} {
 	}
 }
 
-func (code Code) ExportData(fields []string) map[string]interface{} {
+func (code Code) ExportData(fields []string) map[string]any {
 	v := reflect.ValueOf(code)
-	data := map[string]interface{}{}
+	data := map[string]any{}
 	for _, f := range fields {
 		switch f {
 		case "textMatches":
-			matches := make([]interface{}, 0, len(code.TextMatches))
+			matches := make([]any, 0, len(code.TextMatches))
 			for _, match := range code.TextMatches {
 				matches = append(matches, match.ExportData(textMatchFields))
 			}
@@ -298,40 +298,40 @@ func (code Code) ExportData(fields []string) map[string]interface{} {
 	return data
 }
 
-func (textMatch TextMatch) ExportData(fields []string) map[string]interface{} {
+func (textMatch TextMatch) ExportData(fields []string) map[string]any {
 	return cmdutil.StructExportData(textMatch, fields)
 }
 
-func (commit Commit) ExportData(fields []string) map[string]interface{} {
+func (commit Commit) ExportData(fields []string) map[string]any {
 	v := reflect.ValueOf(commit)
-	data := map[string]interface{}{}
+	data := map[string]any{}
 	for _, f := range fields {
 		switch f {
 		case "author":
 			data[f] = commit.Author.ExportData()
 		case "commit":
 			info := commit.Info
-			data[f] = map[string]interface{}{
-				"author": map[string]interface{}{
+			data[f] = map[string]any{
+				"author": map[string]any{
 					"date":  info.Author.Date,
 					"email": info.Author.Email,
 					"name":  info.Author.Name,
 				},
-				"committer": map[string]interface{}{
+				"committer": map[string]any{
 					"date":  info.Committer.Date,
 					"email": info.Committer.Email,
 					"name":  info.Committer.Name,
 				},
 				"comment_count": info.CommentCount,
 				"message":       info.Message,
-				"tree":          map[string]interface{}{"sha": info.Tree.Sha},
+				"tree":          map[string]any{"sha": info.Tree.Sha},
 			}
 		case "committer":
 			data[f] = commit.Committer.ExportData()
 		case "parents":
-			parents := make([]interface{}, 0, len(commit.Parents))
+			parents := make([]any, 0, len(commit.Parents))
 			for _, parent := range commit.Parents {
-				parents = append(parents, map[string]interface{}{
+				parents = append(parents, map[string]any{
 					"sha": parent.Sha,
 					"url": parent.URL,
 				})
@@ -339,7 +339,7 @@ func (commit Commit) ExportData(fields []string) map[string]interface{} {
 			data[f] = parents
 		case "repository":
 			repo := commit.Repo
-			data[f] = map[string]interface{}{
+			data[f] = map[string]any{
 				"description": repo.Description,
 				"fullName":    repo.FullName,
 				"name":        repo.Name,
@@ -357,13 +357,13 @@ func (commit Commit) ExportData(fields []string) map[string]interface{} {
 	return data
 }
 
-func (repo Repository) ExportData(fields []string) map[string]interface{} {
+func (repo Repository) ExportData(fields []string) map[string]any {
 	v := reflect.ValueOf(repo)
-	data := map[string]interface{}{}
+	data := map[string]any{}
 	for _, f := range fields {
 		switch f {
 		case "license":
-			data[f] = map[string]interface{}{
+			data[f] = map[string]any{
 				"key":  repo.License.Key,
 				"name": repo.License.Name,
 				"url":  repo.License.URL,
@@ -379,7 +379,7 @@ func (repo Repository) ExportData(fields []string) map[string]interface{} {
 }
 
 func (repo Repository) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
+	return json.Marshal(map[string]any{
 		"id":            repo.ID,
 		"nameWithOwner": repo.FullName,
 		"url":           repo.URL,
@@ -402,13 +402,13 @@ func (issue Issue) IsPullRequest() bool {
 	return issue.PullRequest.URL != ""
 }
 
-func (issue Issue) ExportData(fields []string) map[string]interface{} {
+func (issue Issue) ExportData(fields []string) map[string]any {
 	v := reflect.ValueOf(issue)
-	data := map[string]interface{}{}
+	data := map[string]any{}
 	for _, f := range fields {
 		switch f {
 		case "assignees":
-			assignees := make([]interface{}, 0, len(issue.Assignees))
+			assignees := make([]any, 0, len(issue.Assignees))
 			for _, assignee := range issue.Assignees {
 				assignees = append(assignees, assignee.ExportData())
 			}
@@ -418,9 +418,9 @@ func (issue Issue) ExportData(fields []string) map[string]interface{} {
 		case "isPullRequest":
 			data[f] = issue.IsPullRequest()
 		case "labels":
-			labels := make([]interface{}, 0, len(issue.Labels))
+			labels := make([]any, 0, len(issue.Labels))
 			for _, label := range issue.Labels {
-				labels = append(labels, map[string]interface{}{
+				labels = append(labels, map[string]any{
 					"color":       label.Color,
 					"description": label.Description,
 					"id":          label.ID,
@@ -432,7 +432,7 @@ func (issue Issue) ExportData(fields []string) map[string]interface{} {
 			comp := strings.Split(issue.RepositoryURL, "/")
 			name := comp[len(comp)-1]
 			nameWithOwner := strings.Join(comp[len(comp)-2:], "/")
-			data[f] = map[string]interface{}{
+			data[f] = map[string]any{
 				"name":          name,
 				"nameWithOwner": nameWithOwner,
 			}

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -205,7 +205,7 @@ func (s searcher) Issues(query Query) (IssuesResult, error) {
 // - Items: the actual matching search results, up to 100 max items per page
 //
 // For more information, see https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28.
-func (s searcher) search(query Query, result interface{}) (string, error) {
+func (s searcher) search(query Query, result any) (string, error) {
 	u, err := safeurl.JoinPathWithHostPrefix(ghinstance.RESTPrefix(s.host), "search", string(query.Kind))
 	if err != nil {
 		return "", err

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -361,10 +361,3 @@ func nextPage(link string) (page int) {
 	}
 	return 0
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/pkg/search/searcher_test.go
+++ b/pkg/search/searcher_test.go
@@ -50,11 +50,11 @@ func TestSearcherCode(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "search/code", values),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"incomplete_results": false,
 						"total_count":        1,
-						"items": []interface{}{
-							map[string]interface{}{
+						"items": []any{
+							map[string]any{
 								"name": "file.go",
 							},
 						},
@@ -74,11 +74,11 @@ func TestSearcherCode(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "api/v3/search/code", values),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"incomplete_results": false,
 						"total_count":        1,
-						"items": []interface{}{
-							map[string]interface{}{
+						"items": []any{
+							map[string]any{
 								"name": "file.go",
 							},
 						},
@@ -96,11 +96,11 @@ func TestSearcherCode(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				firstReq := httpmock.QueryMatcher("GET", "search/code", values)
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"name": "file.go",
 						},
 					},
@@ -111,11 +111,11 @@ func TestSearcherCode(t *testing.T) {
 					"per_page": []string{"30"},
 					"q":        []string{"keyword language:go"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"name": "file2.go",
 						},
 					},
@@ -145,11 +145,11 @@ func TestSearcherCode(t *testing.T) {
 					"per_page": []string{"30"},
 					"q":        []string{"\"keyword with whitespace\" language:go"},
 				})
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"name": "file.go",
 						},
 					},
@@ -160,11 +160,11 @@ func TestSearcherCode(t *testing.T) {
 					"per_page": []string{"30"},
 					"q":        []string{"\"keyword with whitespace\" language:go"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"name": "file2.go",
 						},
 					},
@@ -198,11 +198,11 @@ func TestSearcherCode(t *testing.T) {
 					"per_page": []string{"100"},
 					"q":        []string{"keyword language:go"},
 				})
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        287,
-					"items": initialize(0, 100, func(i int) interface{} {
-						return map[string]interface{}{
+					"items": initialize(0, 100, func(i int) any {
+						return map[string]any{
 							"name": fmt.Sprintf("name%d.go", i),
 						}
 					}),
@@ -213,11 +213,11 @@ func TestSearcherCode(t *testing.T) {
 					"per_page": []string{"100"},
 					"q":        []string{"keyword language:go"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        287,
-					"items": initialize(100, 200, func(i int) interface{} {
-						return map[string]interface{}{
+					"items": initialize(100, 200, func(i int) any {
+						return map[string]any{
 							"name": fmt.Sprintf("name%d.go", i),
 						}
 					}),
@@ -320,11 +320,11 @@ func TestSearcherCommits(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "search/commits", values),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"incomplete_results": false,
 						"total_count":        1,
-						"items": []interface{}{
-							map[string]interface{}{
+						"items": []any{
+							map[string]any{
 								"sha": "abc",
 							},
 						},
@@ -344,11 +344,11 @@ func TestSearcherCommits(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "api/v3/search/commits", values),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"incomplete_results": false,
 						"total_count":        1,
-						"items": []interface{}{
-							map[string]interface{}{
+						"items": []any{
+							map[string]any{
 								"sha": "abc",
 							},
 						},
@@ -382,11 +382,11 @@ func TestSearcherCommits(t *testing.T) {
 					"sort":     []string{"committer-date"},
 					"q":        []string{"\"keyword with whitespace\" author:foobar committer-date:>2021-02-28"},
 				})
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"sha": "abc",
 						},
 					},
@@ -399,11 +399,11 @@ func TestSearcherCommits(t *testing.T) {
 					"sort":     []string{"committer-date"},
 					"q":        []string{"\"keyword with whitespace\" author:foobar committer-date:>2021-02-28"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"sha": "def",
 						},
 					},
@@ -422,11 +422,11 @@ func TestSearcherCommits(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				firstReq := httpmock.QueryMatcher("GET", "search/commits", values)
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"sha": "abc",
 						},
 					},
@@ -439,11 +439,11 @@ func TestSearcherCommits(t *testing.T) {
 					"sort":     []string{"committer-date"},
 					"q":        []string{"keyword author:foobar committer-date:>2021-02-28"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"sha": "def",
 						},
 					},
@@ -482,11 +482,11 @@ func TestSearcherCommits(t *testing.T) {
 					"sort":     []string{"committer-date"},
 					"q":        []string{"keyword author:foobar committer-date:>2021-02-28"},
 				})
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        287,
-					"items": initialize(0, 100, func(i int) map[string]interface{} {
-						return map[string]interface{}{
+					"items": initialize(0, 100, func(i int) map[string]any {
+						return map[string]any{
 							"sha": strconv.Itoa(i),
 						}
 					}),
@@ -499,11 +499,11 @@ func TestSearcherCommits(t *testing.T) {
 					"sort":     []string{"committer-date"},
 					"q":        []string{"keyword author:foobar committer-date:>2021-02-28"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        287,
-					"items": initialize(100, 200, func(i int) map[string]interface{} {
-						return map[string]interface{}{
+					"items": initialize(100, 200, func(i int) map[string]any {
+						return map[string]any{
 							"sha": strconv.Itoa(i),
 						}
 					}),
@@ -606,11 +606,11 @@ func TestSearcherRepositories(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "search/repositories", values),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"incomplete_results": false,
 						"total_count":        1,
-						"items": []interface{}{
-							map[string]interface{}{
+						"items": []any{
+							map[string]any{
 								"name": "test",
 							},
 						},
@@ -630,11 +630,11 @@ func TestSearcherRepositories(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "api/v3/search/repositories", values),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"incomplete_results": false,
 						"total_count":        1,
-						"items": []interface{}{
-							map[string]interface{}{
+						"items": []any{
+							map[string]any{
 								"name": "test",
 							},
 						},
@@ -652,11 +652,11 @@ func TestSearcherRepositories(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				firstReq := httpmock.QueryMatcher("GET", "search/repositories", values)
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"name": "test",
 						},
 					},
@@ -669,11 +669,11 @@ func TestSearcherRepositories(t *testing.T) {
 					"sort":     []string{"stars"},
 					"q":        []string{"keyword stars:>=5 topic:topic"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"name": "cli",
 						},
 					},
@@ -708,11 +708,11 @@ func TestSearcherRepositories(t *testing.T) {
 					"sort":     []string{"stars"},
 					"q":        []string{"\"keyword with whitespace\" stars:>=5 topic:topic"},
 				})
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"name": "test",
 						},
 					},
@@ -725,11 +725,11 @@ func TestSearcherRepositories(t *testing.T) {
 					"sort":     []string{"stars"},
 					"q":        []string{"\"keyword with whitespace\" stars:>=5 topic:topic"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"name": "cli",
 						},
 					},
@@ -768,11 +768,11 @@ func TestSearcherRepositories(t *testing.T) {
 					"sort":     []string{"stars"},
 					"q":        []string{"keyword stars:>=5 topic:topic"},
 				})
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        287,
-					"items": initialize(0, 100, func(i int) interface{} {
-						return map[string]interface{}{
+					"items": initialize(0, 100, func(i int) any {
+						return map[string]any{
 							"name": fmt.Sprintf("name%d", i),
 						}
 					}),
@@ -785,11 +785,11 @@ func TestSearcherRepositories(t *testing.T) {
 					"sort":     []string{"stars"},
 					"q":        []string{"keyword stars:>=5 topic:topic"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        287,
-					"items": initialize(100, 200, func(i int) interface{} {
-						return map[string]interface{}{
+					"items": initialize(100, 200, func(i int) any {
+						return map[string]any{
 							"name": fmt.Sprintf("name%d", i),
 						}
 					}),
@@ -892,11 +892,11 @@ func TestSearcherIssues(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "search/issues", values),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"incomplete_results": false,
 						"total_count":        1,
-						"items": []interface{}{
-							map[string]interface{}{
+						"items": []any{
+							map[string]any{
 								"number": 1234,
 							},
 						},
@@ -916,11 +916,11 @@ func TestSearcherIssues(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "api/v3/search/issues", values),
-					httpmock.JSONResponse(map[string]interface{}{
+					httpmock.JSONResponse(map[string]any{
 						"incomplete_results": false,
 						"total_count":        1,
-						"items": []interface{}{
-							map[string]interface{}{
+						"items": []any{
+							map[string]any{
 								"number": 1234,
 							},
 						},
@@ -938,11 +938,11 @@ func TestSearcherIssues(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				firstReq := httpmock.QueryMatcher("GET", "search/issues", values)
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"number": 1234,
 						},
 					},
@@ -955,11 +955,11 @@ func TestSearcherIssues(t *testing.T) {
 					"sort":     []string{"comments"},
 					"q":        []string{"keyword is:locked is:public language:go"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"number": 5678,
 						},
 					},
@@ -994,11 +994,11 @@ func TestSearcherIssues(t *testing.T) {
 					"sort":     []string{"comments"},
 					"q":        []string{"\"keyword with whitespace\" is:locked is:public language:go"},
 				})
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"number": 1234,
 						},
 					},
@@ -1011,11 +1011,11 @@ func TestSearcherIssues(t *testing.T) {
 					"sort":     []string{"comments"},
 					"q":        []string{"\"keyword with whitespace\" is:locked is:public language:go"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items": []interface{}{
-						map[string]interface{}{
+					"items": []any{
+						map[string]any{
 							"number": 5678,
 						},
 					},
@@ -1054,11 +1054,11 @@ func TestSearcherIssues(t *testing.T) {
 					"sort":     []string{"comments"},
 					"q":        []string{"keyword is:locked is:public language:go"},
 				})
-				firstRes := httpmock.JSONResponse(map[string]interface{}{
+				firstRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        287,
-					"items": initialize(0, 100, func(i int) interface{} {
-						return map[string]interface{}{
+					"items": initialize(0, 100, func(i int) any {
+						return map[string]any{
 							"number": i,
 						}
 					}),
@@ -1071,11 +1071,11 @@ func TestSearcherIssues(t *testing.T) {
 					"sort":     []string{"comments"},
 					"q":        []string{"keyword is:locked is:public language:go"},
 				})
-				secondRes := httpmock.JSONResponse(map[string]interface{}{
+				secondRes := httpmock.JSONResponse(map[string]any{
 					"incomplete_results": false,
 					"total_count":        287,
-					"items": initialize(100, 200, func(i int) interface{} {
-						return map[string]interface{}{
+					"items": initialize(100, 200, func(i int) any {
+						return map[string]any{
 							"number": i,
 						}
 					}),
@@ -1298,11 +1298,11 @@ func TestSearcherIssuesSemanticSearchIsBoundedToSinglePage(t *testing.T) {
 	// The response advertises a next page via the Link header. Only the first
 	// page is registered, so if fetching were to paginate it would request an
 	// unregistered second page and fail.
-	firstRes := httpmock.JSONResponse(map[string]interface{}{
+	firstRes := httpmock.JSONResponse(map[string]any{
 		"incomplete_results": false,
 		"total_count":        2,
-		"items": []interface{}{
-			map[string]interface{}{"number": 1234},
+		"items": []any{
+			map[string]any{"number": 1234},
 		},
 	})
 	firstRes = httpmock.WithHeader(firstRes, "Link", `<https://api.github.com/search/issues?page=2&per_page=30&q=org%3Agithub>; rel="next"`)

--- a/pkg/surveyext/editor.go
+++ b/pkg/surveyext/editor.go
@@ -65,7 +65,7 @@ type EditorTemplateData struct {
 }
 
 // EXTENDED to augment prompt text and keypress handling
-func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (interface{}, error) {
+func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (any, error) {
 	err := e.Render(
 		EditorQuestionTemplate,
 		// EXTENDED to support printing editor in prompt and BlankAllowed
@@ -151,7 +151,7 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 }
 
 // EXTENDED This is straight copypasta from survey to get our overridden prompt called.;
-func (e *GhEditor) Prompt(config *survey.PromptConfig) (interface{}, error) {
+func (e *GhEditor) Prompt(config *survey.PromptConfig) (any, error) {
 	initialValue := ""
 	if e.Default != "" && e.AppendDefault {
 		initialValue = e.Default

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -42,7 +42,7 @@ func (s OutputStub) Run() error {
 
 type T interface {
 	Helper()
-	Errorf(string, ...interface{})
+	Errorf(string, ...any)
 }
 
 // Deprecated: prefer exact matches for command output

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,7 +28,7 @@ func IsDebugEnabled() (bool, string) {
 	}
 }
 
-var TerminalSize = func(w interface{}) (int, int, error) {
+var TerminalSize = func(w any) (int, int, error) {
 	if f, isFile := w.(*os.File); isFile {
 		return term.GetSize(int(f.Fd()))
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

No related issue.

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

The codebase had not applied the source migrations available from Go 1.26's `go fix`. This applies every relevant fixer and keeps each fix type in its own commit so reviewers can inspect the mechanical changes independently.

The lint workflow now runs `go fix ./...` through its existing clean-worktree assertion. Fixable code will fail CI unless the generated changes are checked in.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

TBD

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- Each fixer is isolated in its own commit. Follow-up fixes unlocked by earlier passes remain separate.
- Cleanup commits remove helper declarations made unused by the inline and reflection fixes.
- The lint job reuses its existing mutation guard so `go fix` failures show the same checked-in-diff guidance as `go mod tidy`.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with the lint workflow commit, then review the fixer commits independently. The largest commit only replaces `interface{}` with `any`; the remaining commits are scoped to one analyzer each.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @bagtoad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
