### PR TITLE
Fall back to an installed macOS browser when open URL fails

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -2,15 +2,81 @@ package browser
 
 import (
 	"io"
+	"os"
+	"os/exec"
 
 	ghBrowser "github.com/cli/go-gh/v2/pkg/browser"
+	"github.com/cli/go-gh/v2/pkg/config"
 )
 
+// Browser opens a URL in a web browser.
 type Browser interface {
 	Browse(string) error
 }
 
+type execFunc func(name string, arg ...string) error
+
+type statFunc func(name string) (os.FileInfo, error)
+
+// fallbackBrowser retries with a specific installed browser when the default
+// macOS URL opener fails. `open <url>` goes through Launch Services, and Chrome
+// can leave that HTTP/HTTPS mapping pointing at itself even after another
+// browser is set as the default. If Chrome is then missing, `open` fails even
+// though Edge or Safari is installed. `open -a` targets the .app directly and
+// bypasses the broken scheme mapping.
+type fallbackBrowser struct {
+	inner Browser
+	exec  execFunc
+	stat  statFunc
+	apps  []string
+	dirs  []string
+}
+
+// New returns a Browser. If launcher, GH_BROWSER, BROWSER, and the browser
+// config are all empty, a failed default open is retried against installed
+// browsers on macOS.
 func New(launcher string, stdout, stderr io.Writer) Browser {
-	b := ghBrowser.New(launcher, stdout, stderr)
-	return b
+	inner := ghBrowser.New(launcher, stdout, stderr)
+	if hasExplicitLauncher(launcher) {
+		return inner
+	}
+	return &fallbackBrowser{
+		inner: inner,
+		exec: func(name string, arg ...string) error {
+			cmd := exec.Command(name, arg...)
+			cmd.Stdout = stdout
+			cmd.Stderr = stderr
+			return cmd.Run()
+		},
+		stat: os.Stat,
+		apps: fallbackApps,
+		dirs: applicationDirs(),
+	}
+}
+
+func (b *fallbackBrowser) Browse(url string) error {
+	err := b.inner.Browse(url)
+	if err == nil {
+		return nil
+	}
+	if fallbackErr := openFirstInstalledApp(url, b.apps, b.dirs, b.exec, b.stat); fallbackErr == nil {
+		return nil
+	}
+	return err
+}
+
+func hasExplicitLauncher(launcher string) bool {
+	if launcher != "" {
+		return true
+	}
+	if os.Getenv("GH_BROWSER") != "" || os.Getenv("BROWSER") != "" {
+		return true
+	}
+	cfg, err := config.Read(nil)
+	if err == nil {
+		if cfgBrowser, _ := cfg.Get([]string{"browser"}); cfgBrowser != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1,0 +1,157 @@
+package browser
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type browseFunc func(string) error
+
+func (f browseFunc) Browse(url string) error {
+	return f(url)
+}
+
+func TestFallbackBrowser_Browse(t *testing.T) {
+	innerErr := errors.New("open url failed")
+	opened := [][]string{}
+	appRoot := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(appRoot, "Microsoft Edge.app"), 0o755))
+
+	b := &fallbackBrowser{
+		inner: browseFunc(func(string) error {
+			return innerErr
+		}),
+		exec: func(name string, arg ...string) error {
+			opened = append(opened, append([]string{name}, arg...))
+			return nil
+		},
+		stat: os.Stat,
+		apps: []string{"Microsoft Edge", "Safari"},
+		dirs: []string{appRoot},
+	}
+
+	err := b.Browse("https://github.com/login/device")
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{
+		{"open", "-a", "Microsoft Edge", "https://github.com/login/device"},
+	}, opened)
+}
+
+func TestFallbackBrowser_BrowseKeepsOriginalError(t *testing.T) {
+	innerErr := errors.New("open url failed")
+	b := &fallbackBrowser{
+		inner: browseFunc(func(string) error {
+			return innerErr
+		}),
+		exec: func(string, ...string) error {
+			t.Fatal("should not launch a fallback browser when none are installed")
+			return nil
+		},
+		stat: os.Stat,
+		apps: []string{"Microsoft Edge", "Safari"},
+		dirs: []string{t.TempDir()},
+	}
+
+	err := b.Browse("https://github.com/login/device")
+	require.Equal(t, innerErr, err)
+}
+
+func TestFallbackBrowser_BrowseSkipsFallbackOnSuccess(t *testing.T) {
+	b := &fallbackBrowser{
+		inner: browseFunc(func(string) error {
+			return nil
+		}),
+		exec: func(string, ...string) error {
+			t.Fatal("should not launch a fallback browser when the default opener succeeds")
+			return nil
+		},
+		stat: func(string) (os.FileInfo, error) {
+			t.Fatal("should not look for fallback browsers when the default opener succeeds")
+			return nil, os.ErrNotExist
+		},
+	}
+
+	require.NoError(t, b.Browse("https://github.com/login/device"))
+}
+
+func TestOpenFirstInstalledApp(t *testing.T) {
+	appRoot := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(appRoot, "Safari.app"), 0o755))
+
+	var opened [][]string
+	err := openFirstInstalledApp(
+		"https://example.com",
+		[]string{"Microsoft Edge", "Safari"},
+		[]string{appRoot},
+		func(name string, arg ...string) error {
+			opened = append(opened, append([]string{name}, arg...))
+			return nil
+		},
+		os.Stat,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{
+		{"open", "-a", "Safari", "https://example.com"},
+	}, opened)
+}
+
+func TestOpenFirstInstalledAppTriesNextApp(t *testing.T) {
+	appRoot := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(appRoot, "Microsoft Edge.app"), 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(appRoot, "Safari.app"), 0o755))
+
+	var opened [][]string
+	err := openFirstInstalledApp(
+		"https://example.com",
+		[]string{"Microsoft Edge", "Safari"},
+		[]string{appRoot},
+		func(name string, arg ...string) error {
+			opened = append(opened, append([]string{name}, arg...))
+			if arg[1] == "Microsoft Edge" {
+				return errors.New("failed to launch Edge")
+			}
+			return nil
+		},
+		os.Stat,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{
+		{"open", "-a", "Microsoft Edge", "https://example.com"},
+		{"open", "-a", "Safari", "https://example.com"},
+	}, opened)
+}
+
+func TestHasExplicitLauncher(t *testing.T) {
+	t.Run("launcher argument", func(t *testing.T) {
+		assert.True(t, hasExplicitLauncher("open -a Safari"))
+	})
+
+	t.Run("GH_BROWSER", func(t *testing.T) {
+		t.Setenv("GH_BROWSER", "false")
+		t.Setenv("BROWSER", "")
+		assert.True(t, hasExplicitLauncher(""))
+	})
+
+	t.Run("BROWSER", func(t *testing.T) {
+		t.Setenv("GH_BROWSER", "")
+		t.Setenv("BROWSER", "false")
+		assert.True(t, hasExplicitLauncher(""))
+	})
+}
+
+func TestNewSkipsFallbackWhenBrowserEnvSet(t *testing.T) {
+	t.Setenv("BROWSER", "false")
+	t.Setenv("GH_BROWSER", "")
+
+	b := New("", io.Discard, io.Discard)
+	_, isFallback := b.(*fallbackBrowser)
+	assert.False(t, isFallback, "BROWSER=false must keep the documented no-browser workaround")
+}

--- a/internal/browser/fallback.go
+++ b/internal/browser/fallback.go
@@ -1,0 +1,47 @@
+package browser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func openFirstInstalledApp(url string, apps []string, dirs []string, run execFunc, stat statFunc) error {
+	var lastErr error
+	for _, app := range apps {
+		if !appInstalled(app, dirs, stat) {
+			continue
+		}
+		if err := run("open", "-a", app, url); err != nil {
+			lastErr = err
+			continue
+		}
+		return nil
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("no installed browser found")
+}
+
+func appInstalled(app string, dirs []string, stat statFunc) bool {
+	for _, dir := range dirs {
+		if _, err := stat(filepath.Join(dir, app+".app")); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func applicationDirs() []string {
+	dirs := []string{
+		"/Applications",
+		"/System/Applications",
+		"/System/Cryptexes/App/System/Applications",
+		"/System/Volumes/Preboot/Cryptexes/App/System/Applications",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, "Applications"))
+	}
+	return dirs
+}

--- a/internal/browser/fallback_darwin.go
+++ b/internal/browser/fallback_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+package browser
+
+// Prefer browsers that are commonly used as a Chrome alternative, then Safari
+// which is always present on macOS. Chrome is last because the failure mode we
+// are recovering from is a broken Launch Services mapping left behind by Chrome.
+var fallbackApps = []string{
+	"Microsoft Edge",
+	"Safari",
+	"Firefox",
+	"Brave Browser",
+	"Arc",
+	"Chromium",
+	"Google Chrome",
+}
+

--- a/internal/browser/fallback_other.go
+++ b/internal/browser/fallback_other.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package browser
+
+var fallbackApps []string


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

Fixes #14279

### Description

On macOS, `gh` opens URLs with `open <url>`. That path goes through Launch Services. Chrome can leave the `http`/`https` mapping pointing at itself even after another browser, such as Microsoft Edge, is set as the system default. If Chrome is then missing, `open <url>` fails, so commands like `gh auth login` cannot open a browser even though Edge is installed and is the default. After Chrome is reinstalled, the same `open <url>` call starts working again and the page opens in Edge.

This change keeps the existing default opener. When that opener fails and the user has not set `GH_BROWSER`, `BROWSER`, or `gh` `browser` config, macOS now retries with `open -a` against installed browsers, preferring Edge, then Safari, then other common browsers. `open -a` targets the app bundle directly and does not use the broken URL-scheme mapping. `BROWSER=false` still skips the fallback so the documented no-browser workaround keeps working.

### How did you test this change?

Not tested against a live Chrome-missing install. I did not uninstall Chrome on this machine after the code change.

I did inspect the machine that reported the bug:

- Launch Services `http`/`https` handlers were `com.microsoft.edgemac`
- `GH_BROWSER` and `BROWSER` were unset
- `gh config get browser` was empty
- Chrome, Edge, and Safari were all present in `/Applications`

I added unit tests for the fallback path: default opener failure then `open -a "Microsoft Edge"`, keeping the original error when no app is installed, skipping fallback when the default opener succeeds, and leaving `BROWSER=false` unwrapped.

### Key points

- I only retry after the default opener fails. I did not change the happy path that uses `open <url>`.
- I skipped the fallback when a launcher is explicit so `BROWSER=false` and `GH_BROWSER=false` still work.
- I put the retry in `internal/browser` so `auth login`, `pr view -w`, and other browse calls share it.
- A more precise fix would read the current default browser bundle and call `open -b`. I used an installed-app list instead because the Launch Services mapping is what is broken in this report.

### Notes for reviewers

Start in `internal/browser/browser.go`, then `fallback_darwin.go` for the app order, then `browser_test.go`.

#14279 is the bug report this change is meant to fix. #7736 is earlier macOS `open` / default-browser discussion.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [x] An agent will draft replies and @ylfeng250 will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

Made with [Cursor](https://cursor.com)