### PR TITLE
Propagate gh path to extensions

### DIFF
--- a/acceptance/testdata/extension/extension-env.txtar
+++ b/acceptance/testdata/extension/extension-env.txtar
@@ -36,10 +36,6 @@ stdout 'GH_PATH was set correctly'
 exec ./$EXT_DIR
 stdout 'GH_EXTENSION=0'
 
-# Verify GH_EXTENSION is documented
-exec gh help environment
-stdout 'GH_EXTENSION`: set to `1` by gh when it invokes an extension'
-
 -- print-env.sh --
 #!/usr/bin/env bash
 set -e

--- a/acceptance/testdata/extension/extension-env.txtar
+++ b/acceptance/testdata/extension/extension-env.txtar
@@ -36,6 +36,11 @@ stdout 'GH_PATH was set correctly'
 exec ./$EXT_DIR
 stdout 'GH_EXTENSION=0'
 
+# Verify GH_EXTENSION and GH_PATH are documented
+exec gh help environment
+stdout 'GH_EXTENSION`: set to `1` by gh when it invokes an extension'
+stdout 'GH_PATH`: set the path to the gh executable, useful for when gh can not properly determine'
+
 -- print-env.sh --
 #!/usr/bin/env bash
 set -e

--- a/acceptance/testdata/extension/extension-env.txtar
+++ b/acceptance/testdata/extension/extension-env.txtar
@@ -11,7 +11,8 @@ fixture-repo none
 env EXT_NAME=printenv-${RANDOM_STRING}
 env EXT_DIR=gh-${EXT_NAME}
 
-# Setup a local extension that reports the value of GH_EXTENSION
+# Setup a local extension that reports the extension environment and verifies
+# it can invoke the current gh executable without relying on PATH
 mkdir $EXT_DIR
 mv print-env.sh $EXT_DIR/$EXT_DIR
 chmod 777 $EXT_DIR/$EXT_DIR
@@ -24,10 +25,12 @@ defer gh extension remove $EXT_NAME
 # Verify GH_EXTENSION is set when the extension is run as gh <extension>
 exec gh $EXT_NAME
 stdout 'GH_EXTENSION=1'
+stdout 'GH_PATH was set correctly'
 
 # Verify GH_EXTENSION is set when the extension is run via gh extension exec
 exec gh extension exec $EXT_NAME
 stdout 'GH_EXTENSION=1'
+stdout 'GH_PATH was set correctly'
 
 # Verify GH_EXTENSION is absent when the extension is run standalone
 exec ./$EXT_DIR
@@ -39,4 +42,15 @@ stdout 'GH_EXTENSION`: set to `1` by gh when it invokes an extension'
 
 -- print-env.sh --
 #!/usr/bin/env bash
+set -e
+
 echo "GH_EXTENSION=${GH_EXTENSION:-0}"
+
+if [[ "${GH_EXTENSION:-0}" == "1" ]]; then
+  expected_token=$GH_TOKEN
+  mkdir -p empty-path
+  PATH=$PWD/empty-path
+  actual_token=$("$GH_PATH" auth token --hostname "$GH_HOST")
+  [[ "$actual_token" == "$expected_token" ]]
+  echo "GH_PATH was set correctly"
+fi

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -53,10 +53,11 @@ type Manager struct {
 	gitClient  gitClient
 	config     gh.Config
 	io         *iostreams.IOStreams
+	ghPath     string
 	dryRunMode bool
 }
 
-func NewManager(ios *iostreams.IOStreams, gc *git.Client) *Manager {
+func NewManager(ios *iostreams.IOStreams, gc *git.Client, ghPath string) *Manager {
 	return &Manager{
 		dataDir: config.DataDir,
 		updateDir: func() string {
@@ -74,6 +75,7 @@ func NewManager(ios *iostreams.IOStreams, gc *git.Client) *Manager {
 		},
 		io:        ios,
 		gitClient: &gitExecuter{client: gc},
+		ghPath:    ghPath,
 	}
 }
 
@@ -128,9 +130,8 @@ func (m *Manager) Dispatch(args []string, stdin io.Reader, stdout, stderr io.Wri
 		forwardArgs = append([]string{"-c", `command "$@"`, "--", exe}, forwardArgs...)
 		externalCmd = m.newCommand(shExe, forwardArgs...)
 	}
-	// Signal to the extension that it is being run by gh rather than standalone, so it can
-	// adjust things like usage strings.
-	externalCmd.Env = append(externalCmd.Environ(), "GH_EXTENSION=1")
+	// Tell the extension that gh dispatched it and provide a reliable path back to this executable.
+	externalCmd.Env = append(externalCmd.Environ(), "GH_EXTENSION=1", "GH_PATH="+m.ghPath)
 
 	externalCmd.Stdin = stdin
 	externalCmd.Stdout = stdout

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -271,7 +271,7 @@ func branchFunc(f *cmdutil.Factory) func() (string, error) {
 }
 
 func extensionManager(f *cmdutil.Factory) *extension.Manager {
-	em := extension.NewManager(f.IOStreams, f.GitClient)
+	em := extension.NewManager(f.IOStreams, f.GitClient, f.ExecutablePath)
 
 	cfg, err := f.Config()
 	if err != nil {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -99,9 +99,6 @@ var HelpTopics = []helpTopic{
 			When an extension is executed, gh checks for new versions for the executed extension once every 24 hours.
 			If a newer version was found, an upgrade notice is displayed on standard error.
 
-			%[1]sGH_EXTENSION%[1]s: set to %[1]s1%[1]s by gh when it invokes an extension, allowing an extension to
-			tell whether it was run as %[1]sgh <extension>%[1]s or directly as a standalone program.
-
 			%[1]sGH_CONFIG_DIR%[1]s: the directory where gh will store configuration files. If not specified,
 			the default value will be one of the following paths (in order of precedence):
 			  - %[1]s$XDG_CONFIG_HOME/gh%[1]s (if %[1]s$XDG_CONFIG_HOME%[1]s is set),

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -99,6 +99,9 @@ var HelpTopics = []helpTopic{
 			When an extension is executed, gh checks for new versions for the executed extension once every 24 hours.
 			If a newer version was found, an upgrade notice is displayed on standard error.
 
+			%[1]sGH_EXTENSION%[1]s: set to %[1]s1%[1]s by gh when it invokes an extension, allowing an extension to
+			tell whether it was run as %[1]sgh <extension>%[1]s or directly as a standalone program.
+
 			%[1]sGH_CONFIG_DIR%[1]s: the directory where gh will store configuration files. If not specified,
 			the default value will be one of the following paths (in order of precedence):
 			  - %[1]s$XDG_CONFIG_HOME/gh%[1]s (if %[1]s$XDG_CONFIG_HOME%[1]s is set),
@@ -108,7 +111,8 @@ var HelpTopics = []helpTopic{
 			%[1]sGH_PROMPT_DISABLED%[1]s: set to any value to disable interactive prompting in the terminal.
 
 			%[1]sGH_PATH%[1]s: set the path to the gh executable, useful for when gh can not properly determine
-			its own path such as in the cygwin terminal.
+			its own path such as in the cygwin terminal. gh also sets this when invoking extensions so they
+			can call back into the same gh executable.
 
 			%[1]sGH_MDWIDTH%[1]s: default maximum width for markdown render wrapping.  The max width of lines
 			wrapped on the terminal will be taken as the lesser of the terminal width, this value, or 120 if


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Fixes #14093

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

Extensions using `go-gh` retrieve keychain-backed credentials by invoking `gh auth token`. When the original `gh` executable is run by explicit path and is not otherwise on `PATH`, the extension cannot find it and authentication fails.

Pass the already-resolved executable path to extension processes through `GH_PATH`. This gives extensions a reliable path back to the same `gh` executable that dispatched them.

### How did you test this change?

<!--
Show how you exercised the change yourself, as a user of `gh` would.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios. For example:
   Given I am in a repo with no open pull requests
   When I run `gh pr list`
   Then I see "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

The recordings use a synthetic local `gh pathcheck` extension. When invoked, it replaces its own `PATH` with an empty directory, reports whether `GH_PATH` is set, and, when available, runs `"$GH_PATH" version`. This keeps the visible command and extension behavior identical while changing only the `gh` revision that dispatches it.

Given an extension needs to invoke the current `gh` executable after removing `gh` from `PATH`
When the extension is invoked as `gh pathcheck`
Then the baseline cannot locate `gh`, while this change supplies `GH_PATH` and lets the extension invoke the same executable successfully.

#### Before

![Before: extension cannot locate gh after clearing PATH](https://github.com/user-attachments/assets/5f81367f-050e-4268-94d9-4b60ef43d2c7)

#### After

![After: extension invokes gh successfully through GH_PATH](https://github.com/user-attachments/assets/c6af57c7-d9d5-48b1-b6d5-f3adcb407db0)

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

`GH_PATH` already supports an explicit user override and resolves stable installation paths such as Homebrew symlinks. Reusing the factory's resolved path avoids independently resolving the executable during extension dispatch.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `pkg/cmd/extension/manager.go`, then review the black-box scenario in `acceptance/testdata/extension/extension-env.txtar`.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.