### PR TITLE
Limit attachment batches to 50 files

### DIFF
--- a/internal/attachments/flags.go
+++ b/internal/attachments/flags.go
@@ -10,7 +10,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const flagName = "attach"
+const (
+	flagName       = "attach"
+	maxAttachments = 50
+)
 
 // errEmptyPath is reported for a --attach that named no file, whether the flag
 // held nothing else or the empty value sat beside a real one.
@@ -41,6 +44,9 @@ func (f *Flag) Changed() bool {
 func (f *Flag) UserAssets() ([]UserAsset, error) {
 	if !f.Changed() {
 		return nil, nil
+	}
+	if len(f.values) > maxAttachments {
+		return nil, fmt.Errorf("`--attach` accepts at most %d values per command", maxAttachments)
 	}
 	return userAssetsFromArgs(f.values)
 }

--- a/internal/attachments/flags_test.go
+++ b/internal/attachments/flags_test.go
@@ -1,8 +1,10 @@
 package attachments
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/shlex"
@@ -137,6 +139,11 @@ func TestFlagUserAssets(t *testing.T) {
 			wantPaths: []string{"./b.png", "./a.png"},
 		},
 		{
+			name:    "too many attachments are rejected before filesystem validation",
+			input:   strings.Repeat("--attach ./missing.txt ", maxAttachments+1),
+			wantErr: "`--attach` accepts at most 50 values per command",
+		},
+		{
 			name:      "a file that does not exist",
 			input:     "--attach ./gone.png",
 			wantErr:   "./gone.png: ",
@@ -262,4 +269,12 @@ func TestFlagUserAssets(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("maximum number of attachments", func(t *testing.T) {
+		names := make([]string, maxAttachments)
+		for i := range names {
+			names[i] = fmt.Sprintf("attachment-%d.png", i)
+		}
+		assert.Len(t, NewTestAssets(t, names...), maxAttachments)
+	})
 }

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -39,6 +39,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 			attached file, such as %[1]s![alt](./login.png)%[1]s, that reference is rewritten to point
 			at the uploaded asset. Any attached file the body does not reference is appended
 			to the end of the comment.
+			You can attach up to 50 files per command.
 
 			Alt text for an image follows the path after %[1]s#%[1]s, as in
 			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -83,6 +83,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			Use %[1]s--attach%[1]s to upload an image or video. The attachment is appended to the
 			body. If the body references an attached file, such as %[1]s![alt](./login.png)%[1]s, that
 			reference is rewritten to point at the uploaded asset instead.
+			You can attach up to 50 files per command.
 
 			Alt text for an image follows the path after %[1]s#%[1]s, as in
 			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -85,6 +85,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			flag the issue keeps the body it already has and the attachment is appended to it.
 			If the body references an attached file, such as %[1]s![alt](./login.png)%[1]s, that
 			reference is rewritten to point at the uploaded asset instead.
+			You can attach up to 50 files per command.
 
 			Alt text for an image follows the path after %[1]s#%[1]s, as in
 			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -37,6 +37,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 			attached file, such as %[1]s![alt](./login.png)%[1]s, that reference is rewritten to point
 			at the uploaded asset. Any attached file the body does not reference is appended
 			to the end of the comment.
+			You can attach up to 50 files per command.
 
 			Alt text for an image follows the path after %[1]s#%[1]s, as in
 			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -245,6 +245,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			Use %[1]s--attach%[1]s to upload an image or video. The attachment is appended to the
 			body. If the body references an attached file, such as %[1]s![alt](./login.png)%[1]s, that
 			reference is rewritten to point at the uploaded asset instead.
+			You can attach up to 50 files per command.
 
 			Alt text for an image follows the path after %[1]s#%[1]s, as in
 			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -76,6 +76,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			request keeps the body it already has and the attachment is appended to it. If the
 			body references an attached file, such as %[1]s![alt](./login.png)%[1]s, that reference
 			is rewritten to point at the uploaded asset instead.
+			You can attach up to 50 files per command.
 
 			Alt text for an image follows the path after %[1]s#%[1]s, as in
 			%[1]s--attach './login.png#The login error state'%[1]s. Without it the filename is used.

--- a/skills/gh/SKILL.md
+++ b/skills/gh/SKILL.md
@@ -100,6 +100,8 @@ blocked-by/blocking relationships.
 
 - Repeat `--attach` to upload multiple files:
   `gh issue comment 12 --attach ./before.png --attach ./after.png`.
+- Each command invocation accepts at most 50 `--attach` values total across
+  images and videos.
 - Supported files are `png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`, `mp4`,
   `mov`, and `webm`.
 - For an image, append alt text to the path after `#`. Quote the value so the


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

Related implementation: [Make commands own attachment flag policy](https://github.com/cli/cli/pull/14255)

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

The repeatable `--attach` flag currently has no per-command value limit. A
single command can therefore begin validating and uploading an arbitrarily
large batch of local files.

This caps each invocation at 50 attachment values in the shared flag resolver.
The check runs after command-owned conflicts and before attachment path
validation, uploads, or issue and pull request updates. It counts images and
videos together, including duplicate or invalid paths.

The six supported issue and pull request commands now document the limit in
their detailed help. The installable `gh` skill contains the same guidance.

### How did you test this change?

<!--
Report only actions you actually performed and results you actually observed, using factual
first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
hypothetical, inferred, or merely expected scenarios as testing.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

If you did not exercise the changed behavior, write `Not tested` and explain why.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
   Given I was in a repo with no open pull requests
   When I ran `gh pr list`
   Then I saw "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

I ran the local `gh issue create` implementation with 51 generated `--attach`
values that named missing files. It stopped before reporting a missing path and
printed:

```text
`--attach` accepts at most 50 values per command
```

I also rendered `gh issue create --help`. The detailed help said that a command
can attach up to 50 files, while the flag table retained its concise file-format
description.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- The unexported limit is enforced once for all six commands.
- The count combines images and videos and precedes file validation.
- Existing command-owned conflict errors keep their precedence.
- The limit applies only to one process invocation and adds no persistent state.
- Detailed command help carries the limit without expanding the shared flag row.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with the shared flag resolution and its 50 and 51 boundary cases. The six
command edits only add the same sentence to detailed help.

The placement preserves the command-owned policy boundary established in
[PR #14255](https://github.com/cli/cli/pull/14255).

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
