### PR TITLE
Fix issue/PR close --comment when already closed

### DIFF
--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -115,6 +115,9 @@ func closeRun(opts *CloseOptions) error {
 	}
 
 	if issue.State == "CLOSED" {
+		if err := addComment(opts, issue, baseRepo); err != nil {
+			return err
+		}
 		fmt.Fprintf(opts.IO.ErrOut, "%s Issue %s#%d (%s) is already closed\n", cs.Yellow("!"), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 		return nil
 	}
@@ -145,20 +148,8 @@ func closeRun(opts *CloseOptions) error {
 		duplicateIssueID = duplicateIssue.ID
 	}
 
-	if opts.Comment != "" {
-		commentOpts := &prShared.CommentableOptions{
-			Body:       opts.Comment,
-			HttpClient: opts.HttpClient,
-			InputType:  prShared.InputTypeInline,
-			Quiet:      true,
-			RetrieveCommentable: func() (prShared.Commentable, ghrepo.Interface, error) {
-				return issue, baseRepo, nil
-			},
-		}
-		err := prShared.CommentableRun(commentOpts)
-		if err != nil {
-			return err
-		}
+	if err := addComment(opts, issue, baseRepo); err != nil {
+		return err
 	}
 
 	err = apiClose(httpClient, baseRepo, issue, closeReason, duplicateIssueID)
@@ -169,6 +160,22 @@ func closeRun(opts *CloseOptions) error {
 	fmt.Fprintf(opts.IO.ErrOut, "%s Closed issue %s#%d (%s)\n", cs.SuccessIconWithColor(cs.Red), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 
 	return nil
+}
+
+func addComment(opts *CloseOptions, issue *api.Issue, baseRepo ghrepo.Interface) error {
+	if opts.Comment == "" {
+		return nil
+	}
+	commentOpts := &prShared.CommentableOptions{
+		Body:       opts.Comment,
+		HttpClient: opts.HttpClient,
+		InputType:  prShared.InputTypeInline,
+		Quiet:      true,
+		RetrieveCommentable: func() (prShared.Commentable, ghrepo.Interface, error) {
+			return issue, baseRepo, nil
+		},
+	}
+	return prShared.CommentableRun(commentOpts)
 }
 
 func apiClose(httpClient *http.Client, repo ghrepo.Interface, issue *api.Issue, reason string, duplicateIssueID string) error {

--- a/pkg/cmd/issue/close/close_test.go
+++ b/pkg/cmd/issue/close/close_test.go
@@ -352,6 +352,35 @@ func TestCloseRun(t *testing.T) {
 			wantStderr: "! Issue OWNER/REPO#13 (The title of the issue) is already closed\n",
 		},
 		{
+			name: "already closed issue with comment",
+			opts: &CloseOptions{
+				IssueNumber: 13,
+				Comment:     "closing comment",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query IssueByNumber\b`),
+					httpmock.StringResponse(`
+            { "data": { "repository": {
+              "hasIssuesEnabled": true,
+              "issue": { "id": "THE-ID", "number": 13, "title": "The title of the issue", "state": "CLOSED"}
+            } } }`),
+				)
+				reg.Register(
+					httpmock.GraphQL(`mutation CommentCreate\b`),
+					httpmock.GraphQLMutation(`
+            { "data": { "addComment": { "commentEdge": { "node": {
+              "url": "https://github.com/OWNER/REPO/issues/13#issuecomment-456"
+            } } } } }`,
+						func(inputs map[string]any) {
+							assert.Equal(t, "THE-ID", inputs["subjectId"])
+							assert.Equal(t, "closing comment", inputs["body"])
+						}),
+				)
+			},
+			wantStderr: "! Issue OWNER/REPO#13 (The title of the issue) is already closed\n",
+		},
+		{
 			name: "issues disabled",
 			opts: &CloseOptions{
 				IssueNumber: 13,

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -77,14 +77,6 @@ func closeRun(opts *CloseOptions) error {
 	if pr.State == "MERGED" {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d (%s) can't be closed because it was already merged\n", cs.FailureIcon(), ghrepo.FullName(baseRepo), pr.Number, pr.Title)
 		return cmdutil.SilentError
-	} else if !pr.IsOpen() {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d (%s) is already closed\n", cs.WarningIcon(), ghrepo.FullName(baseRepo), pr.Number, pr.Title)
-		return nil
-	}
-
-	httpClient, err := opts.HttpClient()
-	if err != nil {
-		return err
 	}
 
 	if opts.Comment != "" {
@@ -97,10 +89,19 @@ func closeRun(opts *CloseOptions) error {
 				return pr, baseRepo, nil
 			},
 		}
-		err := shared.CommentableRun(commentOpts)
-		if err != nil {
+		if err := shared.CommentableRun(commentOpts); err != nil {
 			return err
 		}
+	}
+
+	if !pr.IsOpen() {
+		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d (%s) is already closed\n", cs.WarningIcon(), ghrepo.FullName(baseRepo), pr.Number, pr.Title)
+		return nil
+	}
+
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
 	}
 
 	err = api.PullRequestClose(httpClient, baseRepo, pr.ID)

--- a/pkg/cmd/pr/close/close_test.go
+++ b/pkg/cmd/pr/close/close_test.go
@@ -141,6 +141,33 @@ func TestPrClose_alreadyClosed(t *testing.T) {
 	assert.Equal(t, "! Pull request OWNER/REPO#96 (The title of the PR) is already closed\n", output.Stderr())
 }
 
+func TestPrClose_alreadyClosed_withComment(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	baseRepo, pr := stubPR("OWNER/REPO", "OWNER/REPO:feature")
+	pr.State = "CLOSED"
+	pr.Title = "The title of the PR"
+	shared.StubFinderForRunCommandStyleTests(t, "96", pr, baseRepo)
+
+	http.Register(
+		httpmock.GraphQL(`mutation CommentCreate\b`),
+		httpmock.GraphQLMutation(`
+		{ "data": { "addComment": { "commentEdge": { "node": {
+			"url": "https://github.com/OWNER/REPO/issues/96#issuecomment-456"
+		} } } } }`,
+			func(inputs map[string]any) {
+				assert.Equal(t, "THE-ID", inputs["subjectId"])
+				assert.Equal(t, "closing comment", inputs["body"])
+			}),
+	)
+
+	output, err := runCommand(http, true, "96 --comment 'closing comment'")
+	assert.NoError(t, err)
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, "! Pull request OWNER/REPO#96 (The title of the PR) is already closed\n", output.Stderr())
+}
+
 func TestPrClose_deleteBranch_sameRepo(t *testing.T) {
 	http := &httpmock.Registry{}
 	defer http.Verify(t)


### PR DESCRIPTION
Fixes #14152

### Description

`gh issue close --comment` fetches the issue, then returns immediately if it is already closed. That skip happens before the `--comment` block, so the comment is never posted and the command still exits 0. `gh pr close --comment` has the same early return.

This change posts `--comment` first (the existing `CommentableRun` path). If the issue or PR is already closed, it then prints the current already-closed notice and skips the close mutation. With no `--comment`, already-closed remains a no-op. If the comment mutation fails, the error is returned and the already-closed notice is not printed.

Merged PRs are unchanged: they still error without posting a comment.

### How did you test this change?

Not tested against a live GitHub issue or pull request. I added httpmock coverage for already-closed + `--comment` (CommentCreate against the item id, already-closed notice, no close mutation) and kept the existing no-comment already-closed cases.

### Key points

- Close itself stays a no-op on an already-closed item; only the comment is applied.
- `gh pr close` gets the same comment-before-return shape as `gh issue close`.
- I did not comment on already-merged PRs; those still fail with the existing merged error.

### Notes for reviewers

Start in `pkg/cmd/issue/close/close.go` (`addComment` plus the already-closed return), then `pkg/cmd/pr/close/close.go` (comment block moved above the already-closed check). Tests: `already closed issue with comment` and `TestPrClose_alreadyClosed_withComment`.

#14160 attempted a similar issue-close fix and was closed unmerged. This keeps the no-comment already-closed test and adds a separate `--comment` regression instead of overwriting the existing case.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [x] Nobody has explicitly committed to replying.