### PR TITLE
feat(pr revert): add --branch and --base flags

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -827,9 +827,10 @@ func PullRequestRevert(client *Client, repo ghrepo.Interface, params githubv4.Re
 				ID githubv4.ID
 			}
 			RevertPullRequest struct {
-				ID     string
-				Number int
-				URL    string
+				ID          string
+				Number      int
+				URL         string
+				HeadRefName string
 			}
 		} `graphql:"revertPullRequest(input: $input)"`
 	}
@@ -843,9 +844,10 @@ func PullRequestRevert(client *Client, repo ghrepo.Interface, params githubv4.Re
 	}
 	pr := &mutation.RevertPullRequest.RevertPullRequest
 	revertPR := &PullRequest{
-		ID:     pr.ID,
-		Number: pr.Number,
-		URL:    pr.URL,
+		ID:          pr.ID,
+		Number:      pr.Number,
+		URL:         pr.URL,
+		HeadRefName: pr.HeadRefName,
 	}
 
 	return revertPR, nil

--- a/api/queries_revert.go
+++ b/api/queries_revert.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/shurcooL/githubv4"
+)
+
+// RenameBranch renames a branch in the repository via the REST API.
+// It returns the new branch name.
+func RenameBranch(client *Client, repo ghrepo.Interface, oldName, newName string) (string, error) {
+	input := map[string]string{"new_name": newName}
+	body := &bytes.Buffer{}
+	enc := json.NewEncoder(body)
+	if err := enc.Encode(input); err != nil {
+		return "", err
+	}
+
+	path := fmt.Sprintf("repos/%s/%s/branches/%s/rename",
+		repo.RepoOwner(), repo.RepoName(), url.PathEscape(oldName))
+
+	var result struct {
+		Name string `json:"name"`
+	}
+	err := client.REST(repo.RepoHost(), "POST", path, body, &result)
+	if err != nil {
+		return "", err
+	}
+	if result.Name == "" {
+		return "", fmt.Errorf("rename returned an empty branch name")
+	}
+	return result.Name, nil
+}
+
+// UpdatePullRequestBase changes the base branch of a pull request via the
+// GraphQL updatePullRequest mutation.
+func UpdatePullRequestBase(client *Client, repo ghrepo.Interface, prID, baseRefName string) error {
+	var mutation struct {
+		UpdatePullRequest struct {
+			ClientMutationID string
+		} `graphql:"updatePullRequest(input: $input)"`
+	}
+
+	variables := map[string]any{
+		"input": githubv4.UpdatePullRequestInput{
+			PullRequestID: githubv4.ID(prID),
+			BaseRefName:   githubv4.NewString(githubv4.String(baseRefName)),
+		},
+	}
+
+	return client.Mutate(repo.RepoHost(), "UpdatePullRequestBase", &mutation, variables)
+}

--- a/pkg/cmd/pr/revert/revert.go
+++ b/pkg/cmd/pr/revert/revert.go
@@ -25,6 +25,9 @@ type RevertOptions struct {
 	BodySet bool
 	Title   string
 	IsDraft bool
+
+	Branch string
+	Base   string
 }
 
 func NewCmdRevert(f *cmdutil.Factory, runF func(*RevertOptions) error) *cobra.Command {
@@ -79,6 +82,8 @@ func NewCmdRevert(f *cmdutil.Factory, runF func(*RevertOptions) error) *cobra.Co
 	cmd.Flags().StringVarP(&opts.Title, "title", "t", "", "Title for the revert pull request")
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Body for the revert pull request")
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
+	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Name of the branch to create for the revert pull request")
+	cmd.Flags().StringVarP(&opts.Base, "base", "B", "", "Base branch for the revert pull request")
 	return cmd
 }
 
@@ -126,7 +131,29 @@ func revertRun(opts *RevertOptions) error {
 	}
 
 	if revertPR != nil {
+		// Print the URL before the follow-up steps so the reference to the
+		// revert pull request is always available, even if one of them fails.
 		fmt.Fprintln(opts.IO.Out, revertPR.URL)
+
+		// Rename the branch that GitHub created for the revert, if requested.
+		if opts.Branch != "" {
+			if revertPR.HeadRefName == "" {
+				fmt.Fprintf(opts.IO.ErrOut, "%s could not rename branch: revert PR has no head branch name\n", cs.WarningIcon())
+			} else if _, err := api.RenameBranch(apiClient, baseRepo, revertPR.HeadRefName, opts.Branch); err != nil {
+				fmt.Fprintf(opts.IO.ErrOut, "%s Failed to rename branch %s to %s: %s\n", cs.FailureIcon(), revertPR.HeadRefName, opts.Branch, err)
+				return fmt.Errorf("branch rename failed: %w", err)
+			}
+		}
+
+		// Change the base branch of the revert pull request, if requested.
+		if opts.Base != "" {
+			if revertPR.ID == "" {
+				fmt.Fprintf(opts.IO.ErrOut, "%s could not change base branch: revert PR has no ID\n", cs.WarningIcon())
+			} else if err := api.UpdatePullRequestBase(apiClient, baseRepo, revertPR.ID, opts.Base); err != nil {
+				fmt.Fprintf(opts.IO.ErrOut, "%s Failed to change base branch to %s: %s\n", cs.FailureIcon(), opts.Base, err)
+				return fmt.Errorf("base branch update failed: %w", err)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/cmd/pr/revert/revert_test.go
+++ b/pkg/cmd/pr/revert/revert_test.go
@@ -216,6 +216,265 @@ func TestPRRevert_withDraft(t *testing.T) {
 	assert.Equal(t, "", output.Stderr())
 }
 
+func TestPRRevert_withBranch(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t, "123", &api.PullRequest{
+		ID:     "SOME-ID",
+		Number: 123,
+		State:  "MERGED",
+		Title:  "The title of the PR",
+	}, ghrepo.New("OWNER", "REPO"))
+
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestRevert\b`),
+		httpmock.GraphQLMutation(`
+			{ "data": { "revertPullRequest": { "pullRequest": {
+				"ID": "SOME-ID"
+			}, "revertPullRequest": {
+               "ID": "NEW-ID",
+               "Number": 456,
+               "URL": "https://github.com/OWNER/REPO/pull/456",
+               "HeadRefName": "revert-456-main"
+            } } } }
+			`,
+			func(inputs map[string]any) {
+				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
+			}),
+	)
+
+	// The branch GitHub created for the revert is renamed to the requested name.
+	http.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/branches/revert-456-main/rename"),
+		httpmock.RESTPayload(201, `{ "name": "custom-branch" }`,
+			func(payload map[string]any) {
+				assert.Equal(t, payload["new_name"], "custom-branch")
+			}),
+	)
+
+	output, err := runCommand(http, true, "123 --branch custom-branch")
+	// Revert PR created and its branch renamed.
+	assert.NoError(t, err)
+	// Only URL printed.
+	assert.Equal(t, "https://github.com/OWNER/REPO/pull/456\n", output.String())
+	assert.Equal(t, "", output.Stderr())
+}
+
+func TestPRRevert_withBase(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t, "123", &api.PullRequest{
+		ID:     "SOME-ID",
+		Number: 123,
+		State:  "MERGED",
+		Title:  "The title of the PR",
+	}, ghrepo.New("OWNER", "REPO"))
+
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestRevert\b`),
+		httpmock.GraphQLMutation(`
+			{ "data": { "revertPullRequest": { "pullRequest": {
+				"ID": "SOME-ID"
+			}, "revertPullRequest": {
+               "ID": "NEW-ID",
+               "Number": 456,
+               "URL": "https://github.com/OWNER/REPO/pull/456",
+               "HeadRefName": "revert-456-main"
+            } } } }
+			`,
+			func(inputs map[string]any) {
+				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
+			}),
+	)
+
+	// The base branch of the newly created revert PR is updated.
+	http.Register(
+		httpmock.GraphQL(`mutation UpdatePullRequestBase\b`),
+		httpmock.GraphQLMutation(`
+			{ "data": { "updatePullRequest": { "clientMutationId": "" } } }
+			`,
+			func(inputs map[string]any) {
+				assert.Equal(t, inputs["pullRequestId"], "NEW-ID")
+				assert.Equal(t, inputs["baseRefName"], "main")
+			}),
+	)
+
+	output, err := runCommand(http, true, "123 --base main")
+	// Revert PR created and re-based.
+	assert.NoError(t, err)
+	// Only URL printed.
+	assert.Equal(t, "https://github.com/OWNER/REPO/pull/456\n", output.String())
+	assert.Equal(t, "", output.Stderr())
+}
+
+func TestPRRevert_withBranchAndBase(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t, "123", &api.PullRequest{
+		ID:     "SOME-ID",
+		Number: 123,
+		State:  "MERGED",
+		Title:  "The title of the PR",
+	}, ghrepo.New("OWNER", "REPO"))
+
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestRevert\b`),
+		httpmock.GraphQLMutation(`
+			{ "data": { "revertPullRequest": { "pullRequest": {
+				"ID": "SOME-ID"
+			}, "revertPullRequest": {
+               "ID": "NEW-ID",
+               "Number": 456,
+               "URL": "https://github.com/OWNER/REPO/pull/456",
+               "HeadRefName": "revert-456-main"
+            } } } }
+			`,
+			func(inputs map[string]any) {
+				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
+			}),
+	)
+
+	http.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/branches/revert-456-main/rename"),
+		httpmock.RESTPayload(201, `{ "name": "custom-branch" }`,
+			func(payload map[string]any) {
+				assert.Equal(t, payload["new_name"], "custom-branch")
+			}),
+	)
+
+	http.Register(
+		httpmock.GraphQL(`mutation UpdatePullRequestBase\b`),
+		httpmock.GraphQLMutation(`
+			{ "data": { "updatePullRequest": { "clientMutationId": "" } } }
+			`,
+			func(inputs map[string]any) {
+				assert.Equal(t, inputs["pullRequestId"], "NEW-ID")
+				assert.Equal(t, inputs["baseRefName"], "trunk")
+			}),
+	)
+
+	output, err := runCommand(http, true, "123 --branch custom-branch --base trunk")
+	// Revert PR created, branch renamed and re-based.
+	assert.NoError(t, err)
+	// Only URL printed.
+	assert.Equal(t, "https://github.com/OWNER/REPO/pull/456\n", output.String())
+	assert.Equal(t, "", output.Stderr())
+}
+
+func TestPRRevert_withBranch_noHeadRefName(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t, "123", &api.PullRequest{
+		ID:     "SOME-ID",
+		Number: 123,
+		State:  "MERGED",
+		Title:  "The title of the PR",
+	}, ghrepo.New("OWNER", "REPO"))
+
+	// The API response carries no head branch name, so there is nothing to rename.
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestRevert\b`),
+		httpmock.GraphQLMutation(`
+			{ "data": { "revertPullRequest": { "pullRequest": {
+				"ID": "SOME-ID"
+			}, "revertPullRequest": {
+               "ID": "NEW-ID",
+               "Number": 456,
+               "URL": "https://github.com/OWNER/REPO/pull/456"
+            } } } }
+			`,
+			func(inputs map[string]any) {
+				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
+			}),
+	)
+
+	output, err := runCommand(http, true, "123 --branch custom-branch")
+	// The rename is skipped with a warning instead of failing.
+	assert.NoError(t, err)
+	assert.Equal(t, "https://github.com/OWNER/REPO/pull/456\n", output.String())
+	assert.Equal(t, "! could not rename branch: revert PR has no head branch name\n", output.Stderr())
+}
+
+func TestPRRevert_withBase_noPullRequestID(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t, "123", &api.PullRequest{
+		ID:     "SOME-ID",
+		Number: 123,
+		State:  "MERGED",
+		Title:  "The title of the PR",
+	}, ghrepo.New("OWNER", "REPO"))
+
+	// The API response carries no revert PR ID, so the base can't be updated.
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestRevert\b`),
+		httpmock.GraphQLMutation(`
+			{ "data": { "revertPullRequest": { "pullRequest": {
+				"ID": "SOME-ID"
+			}, "revertPullRequest": {
+               "Number": 456,
+               "URL": "https://github.com/OWNER/REPO/pull/456",
+               "HeadRefName": "revert-456-main"
+            } } } }
+			`,
+			func(inputs map[string]any) {
+				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
+			}),
+	)
+
+	output, err := runCommand(http, true, "123 --base trunk")
+	// The base update is skipped with a warning instead of failing.
+	assert.NoError(t, err)
+	assert.Equal(t, "https://github.com/OWNER/REPO/pull/456\n", output.String())
+	assert.Equal(t, "! could not change base branch: revert PR has no ID\n", output.Stderr())
+}
+
+func TestPRRevert_branchRenameFailurePrintsURL(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t, "123", &api.PullRequest{
+		ID:     "SOME-ID",
+		Number: 123,
+		State:  "MERGED",
+		Title:  "The title of the PR",
+	}, ghrepo.New("OWNER", "REPO"))
+
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestRevert\b`),
+		httpmock.GraphQLMutation(`
+			{ "data": { "revertPullRequest": { "pullRequest": {
+				"ID": "SOME-ID"
+			}, "revertPullRequest": {
+               "ID": "NEW-ID",
+               "Number": 456,
+               "URL": "https://github.com/OWNER/REPO/pull/456",
+               "HeadRefName": "revert-456-main"
+            } } } }
+			`,
+			func(inputs map[string]any) {
+				assert.Equal(t, inputs["pullRequestId"], "SOME-ID")
+			}),
+	)
+
+	http.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/branches/revert-456-main/rename"),
+		httpmock.StatusStringResponse(422, `{ "message": "Validation failed" }`),
+	)
+
+	output, err := runCommand(http, true, "123 --branch custom-branch")
+	// Rename failure is fatal, but the revert PR URL has already been printed.
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "branch rename failed:")
+	assert.Equal(t, "https://github.com/OWNER/REPO/pull/456\n", output.String())
+	assert.Contains(t, output.Stderr(), "X Failed to rename branch revert-456-main to custom-branch:")
+}
+
 func TestPRRevert_APIFailure(t *testing.T) {
 	http := &httpmock.Registry{}
 	defer http.Verify(t)


### PR DESCRIPTION
Closes #14281

### Description

`gh pr revert` currently creates the revert branch with the name GitHub picks (`revert-<number>-<head branch>`) and there is no way to override it. In repositories whose rulesets restrict branch creation, that default name is often rejected, so the revert cannot be created at all.

This PR adds two flags to `gh pr revert`:

- `--branch <name>` renames the branch GitHub created for the revert to the requested name, via `POST /repos/{owner}/{repo}/branches/{branch}/rename`. The revert commit GitHub generated is kept; only the branch name changes.
- `--base <name>` changes the base branch of the revert pull request via the `updatePullRequest` mutation, same as `gh pr edit --base`.

Default behaviour is unchanged: with no flags, the revert is created exactly as before. The shorthand for `--base` is `-B`, matching `gh pr create`, `gh pr edit` and `gh pr list`.

The revert PR URL is printed before the follow-up steps so the reference is always available even if one of them fails. If the API does not return a head branch name or PR ID, a warning is printed instead of silently ignoring the flag.

### How did you test this change?

I ran the existing test suite for the affected packages, plus new unit tests covering:

- `--branch` asserts the `revertPullRequest` mutation response includes `HeadRefName`, then that `POST /repos/OWNER/REPO/branches/revert-456-main/rename` is called with `new_name` set to the requested branch, and that only the PR URL is printed.
- `--base` asserts the `updatePullRequest` mutation is called with `pullRequestId` and `baseRefName`.
- `--branch` and `--base` combined.
- Edge cases: `--branch` when the API returns no head branch name, and `--base` when it returns no PR ID. Both print a warning and still print the URL; a rename API failure prints the URL and returns an error.

I ran `go build ./...`, `go test ./pkg/cmd/pr/revert/...` (all pass) and the full `go test ./...` suite. The only failing package is `internal/config` (`TestMigrationWriteErrors`), which also fails on a clean checkout of `trunk` and is unrelated to this change.

I did not run the command against a live repository, since a real revert would mutate an actual repository.

### Key points

- The rename is performed server-side so the revert commit GitHub generates is preserved, matching the approach proposed in the issue.
- `--branch` intentionally has no shorthand: `-b` is already taken by `--body` in this command.
- An alternative considered was computing the revert locally (`git revert` in a temporary worktree, push, `gh pr create`), but that requires a local clone and loses the "works from anywhere" property of the current implementation.

### Notes for reviewers

- `api/queries_revert.go` is new: it holds `RenameBranch` and `UpdatePullRequestBase`. The existing `PullRequestRevert` mutation in `api/queries_pr.go` now also requests `HeadRefName` from `revertPullRequest`.
- Review can start at `pkg/cmd/pr/revert/revert.go`, in `revertRun`, where the two flags are applied after the revert mutation.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @AlexisAMZ will read and reply directly.
- [ ] An agent will draft replies and @AlexisAMZ will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
