### PR TITLE
fix(gist): reject invalid UTF-8 contents

### DIFF
--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -229,6 +229,9 @@ func processFiles(stdin io.ReadCloser, filenameOverride string, filenames []stri
 			if err != nil {
 				return fs, fmt.Errorf("failed to read file %s: %w", f, err)
 			}
+			if shared.IsBinaryContents(content) {
+				return nil, fmt.Errorf("failed to upload %s: binary file not supported", f)
+			}
 
 			filename = filepath.Base(f)
 		}

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_processFiles(t *testing.T) {
@@ -32,6 +33,14 @@ func Test_processFiles(t *testing.T) {
 
 	assert.Equal(t, 1, len(files))
 	assert.Equal(t, "hey cool how is it going", files["gistfile0.txt"].Content)
+}
+
+func Test_processFilesRejectsInvalidUTF8(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "latin1.txt")
+	require.NoError(t, os.WriteFile(filename, []byte{0x63, 0x61, 0x66, 0xe9}, 0o600))
+
+	_, err := processFiles(io.NopCloser(strings.NewReader("")), "", []string{filename})
+	require.EqualError(t, err, "failed to upload "+filename+": binary file not supported")
 }
 
 func Test_guessGistName_stdin(t *testing.T) {

--- a/pkg/cmd/gist/shared/shared.go
+++ b/pkg/cmd/gist/shared/shared.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/prompter"
@@ -212,6 +213,10 @@ func IsBinaryFile(file string) (bool, error) {
 }
 
 func IsBinaryContents(contents []byte) bool {
+	if !utf8.Valid(contents) {
+		return true
+	}
+
 	isBinary := true
 	for mime := mimetype.Detect(contents); mime != nil; mime = mime.Parent() {
 		if mime.Is("text/plain") {

--- a/pkg/cmd/gist/shared/shared_test.go
+++ b/pkg/cmd/gist/shared/shared_test.go
@@ -76,6 +76,10 @@ func TestIsBinaryContents(t *testing.T) {
 			fileContent: []byte(nil),
 		},
 		{
+			want:        true,
+			fileContent: []byte{0x63, 0x61, 0x66, 0xe9},
+		},
+		{
 			want: true,
 			fileContent: []byte{239, 191, 189, 239, 191, 189, 239, 191, 189, 239,
 				191, 189, 239, 191, 189, 16, 74, 70, 73, 70, 239, 191, 189, 1, 1, 1,


### PR DESCRIPTION
Fixes #14216

## Summary
- reject invalid UTF-8 in gist content before it can be JSON-encoded as U+FFFD
- apply the same validation to file paths after reading their contents
- add regression coverage for stdin/content and file uploads

The related control-character detection issue (#9761) is intentionally outside this change.

## Validation
- go test ./pkg/cmd/gist/...
- go vet ./pkg/cmd/gist/...
- gofmt and git diff --check

The full make lint target could not run locally because golangci-lint is not installed.

This contribution was prepared with AI assistance and reviewed against the repository guidance.