### PR TITLE
Fix typos in codespace create test name and Homebrew releasing docs

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -26,7 +26,7 @@ What this does is:
 ## Bumping Homebrew
 
 Homebrew bumps are handled by [autobump](https://docs.brew.sh/Autobump), which runs periodically every 3 hours. In cases where a quicker rollout is required, a pull request can be opened manually with the following steps:
- 1. Replace the version number in the url to point ot the updated version.
+ 1. Replace the version number in the url to point to the updated version.
  2. Calculate and replace the sha256 value.
  3. Open the PR.
 

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -326,7 +326,7 @@ func TestApp_Create(t *testing.T) {
 			wantStderr: "  ✓ Codespaces usage for this repository is paid for by monalisa\n",
 		},
 		{
-			name: "create codespace with default branch does not show idle timeout notice if not conntected to terminal",
+			name: "create codespace with default branch does not show idle timeout notice if not connected to terminal",
 			fields: fields{
 				apiClient: apiCreateDefaults(&apiClientMock{
 					CreateCodespaceFunc: func(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error) {


### PR DESCRIPTION
Two unrelated typos spotted while reading the codespace create tests and the Homebrew releasing notes:

- `pkg/cmd/codespace/create_test.go`: the test case name said "not conntected to terminal" → "connected".
- `docs/releasing.md`: step 1 said "point ot the updated version" → "point to the updated version".

No behavior or docs-content change beyond the spelling.