### PR TITLE
Validate repository names during interactive creation

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -307,7 +307,7 @@ func createFromScratch(opts *CreateOptions) error {
 	host, _ := cfg.Authentication().DefaultHost()
 
 	if opts.Interactive {
-		opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, "")
+		opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, opts.IO, "")
 		if err != nil {
 			return err
 		}
@@ -448,7 +448,7 @@ func createFromTemplate(opts *CreateOptions) error {
 
 	host, _ := cfg.Authentication().DefaultHost()
 
-	opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, "")
+	opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, opts.IO, "")
 	if err != nil {
 		return err
 	}
@@ -592,7 +592,7 @@ func createFromLocal(opts *CreateOptions) error {
 	}
 
 	if opts.Interactive {
-		opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, filepath.Base(absPath))
+		opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, opts.IO, filepath.Base(absPath))
 		if err != nil {
 			return err
 		}
@@ -893,8 +893,8 @@ func interactiveLicense(client *http.Client, hostname string, prompter iprompter
 }
 
 // name, description, and visibility
-func interactiveRepoInfo(client *http.Client, hostname string, prompter iprompter, defaultName string) (string, string, string, error) {
-	name, owner, err := interactiveRepoNameAndOwner(client, hostname, prompter, defaultName)
+func interactiveRepoInfo(client *http.Client, hostname string, prompter iprompter, io *iostreams.IOStreams, defaultName string) (string, string, string, error) {
+	name, owner, err := interactiveRepoNameAndOwner(client, hostname, prompter, io, defaultName)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -925,10 +925,17 @@ func getRepoVisibilityOptions(owner string) []string {
 	return visibilityOptions
 }
 
-func interactiveRepoNameAndOwner(client *http.Client, hostname string, prompter iprompter, defaultName string) (string, string, error) {
-	name, err := prompter.Input("Repository name", defaultName)
-	if err != nil {
-		return "", "", err
+func interactiveRepoNameAndOwner(client *http.Client, hostname string, prompter iprompter, io *iostreams.IOStreams, defaultName string) (string, string, error) {
+	var name string
+	for strings.TrimSpace(name) == "" {
+		var err error
+		name, err = prompter.Input("Repository name", defaultName)
+		if err != nil {
+			return "", "", err
+		}
+		if strings.TrimSpace(name) == "" {
+			fmt.Fprintf(io.ErrOut, "%s Repository name cannot be blank\n", io.ColorScheme().FailureIcon())
+		}
 	}
 
 	name, owner, err := splitNameAndOwner(name)

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -307,7 +307,7 @@ func createFromScratch(opts *CreateOptions) error {
 	host, _ := cfg.Authentication().DefaultHost()
 
 	if opts.Interactive {
-		opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, opts.IO, "")
+		opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, "")
 		if err != nil {
 			return err
 		}
@@ -448,7 +448,7 @@ func createFromTemplate(opts *CreateOptions) error {
 
 	host, _ := cfg.Authentication().DefaultHost()
 
-	opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, opts.IO, "")
+	opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, "")
 	if err != nil {
 		return err
 	}
@@ -592,7 +592,7 @@ func createFromLocal(opts *CreateOptions) error {
 	}
 
 	if opts.Interactive {
-		opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, opts.IO, filepath.Base(absPath))
+		opts.Name, opts.Description, opts.Visibility, err = interactiveRepoInfo(httpClient, host, opts.Prompter, filepath.Base(absPath))
 		if err != nil {
 			return err
 		}
@@ -893,8 +893,8 @@ func interactiveLicense(client *http.Client, hostname string, prompter iprompter
 }
 
 // name, description, and visibility
-func interactiveRepoInfo(client *http.Client, hostname string, prompter iprompter, io *iostreams.IOStreams, defaultName string) (string, string, string, error) {
-	name, owner, err := interactiveRepoNameAndOwner(client, hostname, prompter, io, defaultName)
+func interactiveRepoInfo(client *http.Client, hostname string, prompter iprompter, defaultName string) (string, string, string, error) {
+	name, owner, err := interactiveRepoNameAndOwner(client, hostname, prompter, defaultName)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -925,17 +925,13 @@ func getRepoVisibilityOptions(owner string) []string {
 	return visibilityOptions
 }
 
-func interactiveRepoNameAndOwner(client *http.Client, hostname string, prompter iprompter, io *iostreams.IOStreams, defaultName string) (string, string, error) {
-	var name string
-	for strings.TrimSpace(name) == "" {
-		var err error
-		name, err = prompter.Input("Repository name", defaultName)
-		if err != nil {
-			return "", "", err
-		}
-		if strings.TrimSpace(name) == "" {
-			fmt.Fprintf(io.ErrOut, "%s Repository name cannot be blank\n", io.ColorScheme().FailureIcon())
-		}
+func interactiveRepoNameAndOwner(client *http.Client, hostname string, prompter iprompter, defaultName string) (string, string, error) {
+	name, err := prompter.Input("Repository name", defaultName)
+	if err != nil {
+		return "", "", err
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", "", errors.New("repository name cannot be blank")
 	}
 
 	name, owner, err := splitNameAndOwner(name)

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -186,6 +186,24 @@ func TestNewCmdCreate(t *testing.T) {
 	}
 }
 
+func Test_interactiveRepoNameAndOwner_repromptsForBlankName(t *testing.T) {
+	pm := prompter.NewMockPrompter(t)
+	pm.RegisterInput("Repository name", func(string, string) (string, error) {
+		return " ", nil
+	})
+	pm.RegisterInput("Repository name", func(string, string) (string, error) {
+		return "OWNER/REPO", nil
+	})
+	ios, _, _, stderr := iostreams.Test()
+
+	name, owner, err := interactiveRepoNameAndOwner(nil, "github.com", pm, ios, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, "REPO", name)
+	assert.Equal(t, "OWNER", owner)
+	assert.Equal(t, "X Repository name cannot be blank\n", stderr.String())
+}
+
 func Test_createRun(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -186,24 +186,6 @@ func TestNewCmdCreate(t *testing.T) {
 	}
 }
 
-func Test_interactiveRepoNameAndOwner_repromptsForBlankName(t *testing.T) {
-	pm := prompter.NewMockPrompter(t)
-	pm.RegisterInput("Repository name", func(string, string) (string, error) {
-		return " ", nil
-	})
-	pm.RegisterInput("Repository name", func(string, string) (string, error) {
-		return "OWNER/REPO", nil
-	})
-	ios, _, _, stderr := iostreams.Test()
-
-	name, owner, err := interactiveRepoNameAndOwner(nil, "github.com", pm, ios, "")
-
-	require.NoError(t, err)
-	assert.Equal(t, "REPO", name)
-	assert.Equal(t, "OWNER", owner)
-	assert.Equal(t, "X Repository name cannot be blank\n", stderr.String())
-}
-
 func Test_createRun(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -216,6 +198,52 @@ func Test_createRun(t *testing.T) {
 		wantErr     bool
 		errMsg      string
 	}{
+		{
+			name: "interactive create from scratch with empty name",
+			opts: &CreateOptions{Interactive: true},
+			tty:  true,
+			promptStubs: func(p *prompter.PrompterMock) {
+				p.InputFunc = func(message, defaultValue string) (string, error) {
+					if message != "Repository name" || len(p.InputCalls()) != 1 {
+						return "", fmt.Errorf("unexpected input prompt: %s", message)
+					}
+					return "", nil
+				}
+				p.SelectFunc = func(message, defaultValue string, options []string) (int, error) {
+					switch message {
+					case "What would you like to do?":
+						return prompter.IndexFor(options, "Create a new repository on github.com from scratch")
+					default:
+						return 0, fmt.Errorf("unexpected select prompt: %s", message)
+					}
+				}
+			},
+			wantErr: true,
+			errMsg:  "repository name cannot be blank",
+		},
+		{
+			name: "interactive create from scratch with whitespace-only name",
+			opts: &CreateOptions{Interactive: true},
+			tty:  true,
+			promptStubs: func(p *prompter.PrompterMock) {
+				p.InputFunc = func(message, defaultValue string) (string, error) {
+					if message != "Repository name" || len(p.InputCalls()) != 1 {
+						return "", fmt.Errorf("unexpected input prompt: %s", message)
+					}
+					return " \t ", nil
+				}
+				p.SelectFunc = func(message, defaultValue string, options []string) (int, error) {
+					switch message {
+					case "What would you like to do?":
+						return prompter.IndexFor(options, "Create a new repository on github.com from scratch")
+					default:
+						return 0, fmt.Errorf("unexpected select prompt: %s", message)
+					}
+				}
+			},
+			wantErr: true,
+			errMsg:  "repository name cannot be blank",
+		},
 		{
 			name:       "interactive create from scratch with gitignore and license",
 			opts:       &CreateOptions{Interactive: true},
@@ -1095,9 +1123,9 @@ func Test_createRun(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)
-				return
+			} else {
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
 			assert.Equal(t, tt.wantStdout, stdout.String())
 			assert.Equal(t, "", stderr.String())
 		})


### PR DESCRIPTION
Fixes #14297

### Description

Interactive `gh repo create` accepted an empty repository name and continued through every remaining prompt. The command only failed after confirmation, when it tried to parse the incomplete `OWNER/` repository reference. Users then had to restart the full creation flow.

This change validates the repository name immediately after input. Empty and whitespace-only values now stop the interactive flow with `repository name cannot be blank`, before owner, description, visibility, initialization, or confirmation prompts are shown.

Validation remains centralized beside repository-name parsing, so creating from scratch, from a template, and from a local repository all reject blank names consistently without additional I/O plumbing.

### How did you test this change?

```
$ bin/gh repo create
? What would you like to do? Create a new repository on github.com from scratch
? Repository name
repository name cannot be blank
```

Added `Test_createRun` cases for empty and whitespace-only names. Both verify that validation fails immediately and produces no command output before the returned error is rendered by the command layer.

### Key points

Blank-name validation runs immediately after the repository-name prompt and before owner parsing or later interactive prompts.

Whitespace-only input is treated as blank. Valid input is otherwise preserved and passed to existing parsing unchanged.

### Notes for reviewers

Start with `interactiveRepoNameAndOwner` in `pkg/cmd/repo/create/create.go`, then review the `interactive create from scratch with empty name` and `interactive create from scratch with whitespace-only name` cases in `pkg/cmd/repo/create/create_test.go`.

The tests cover both invalid forms, immediate termination, the returned error, and empty stdout and stderr at the `createRun` layer.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @sergiou87 will read and reply directly.
- [ ] An agent will draft replies and @sergiou87 will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.