### PR TITLE
Fetch only required pull request state in `gh pr edit`, so the command works with minimal permissions

### DIFF
--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -295,26 +295,58 @@ func editRun(opts *EditOptions) error {
 		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
 	}
 
-	findOptions := shared.FindOptions{
-		Selector: opts.SelectorArg,
-		Fields:   []string{"id", "author", "url", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone"},
-		Detector: opts.Detector,
-	}
-
-	if len(opts.Assets) > 0 {
-		findOptions.Fields = append(findOptions.Fields, "repository")
-	}
-
 	issueFeatures, err := opts.Detector.IssueFeatures()
 	if err != nil {
 		return err
 	}
 
-	// TODO ApiActorsSupported
-	if issueFeatures.ApiActorsSupported {
-		findOptions.Fields = append(findOptions.Fields, "assignedActors")
-	} else {
-		findOptions.Fields = append(findOptions.Fields, "assignees")
+	editable := opts.Editable
+	editable.Reviewers.Selectable = true
+
+	findOptions := shared.FindOptions{
+		Selector: opts.SelectorArg,
+		Fields:   []string{"id", "url"},
+		Detector: opts.Detector,
+	}
+	if opts.Interactive {
+		findOptions.Fields = append(findOptions.Fields, "author", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone")
+		// TODO ApiActorsSupported
+		if issueFeatures.ApiActorsSupported {
+			findOptions.Fields = append(findOptions.Fields, "assignedActors")
+		} else {
+			findOptions.Fields = append(findOptions.Fields, "assignees")
+		}
+	} else if editable.Title.Edited {
+		findOptions.Fields = append(findOptions.Fields, "title")
+	}
+	if !opts.Interactive && (editable.Body.Edited || len(opts.Assets) > 0) {
+		findOptions.Fields = append(findOptions.Fields, "body")
+	}
+	if !opts.Interactive && editable.Base.Edited {
+		findOptions.Fields = append(findOptions.Fields, "baseRefName")
+	}
+	if !opts.Interactive && editable.Reviewers.Edited {
+		findOptions.Fields = append(findOptions.Fields, "reviewRequests")
+	}
+	if !opts.Interactive && editable.Assignees.Edited {
+		// TODO ApiActorsSupported
+		if issueFeatures.ApiActorsSupported {
+			findOptions.Fields = append(findOptions.Fields, "assignedActors")
+		} else {
+			findOptions.Fields = append(findOptions.Fields, "assignees")
+		}
+	}
+	if !opts.Interactive && editable.Labels.Edited {
+		findOptions.Fields = append(findOptions.Fields, "labels")
+	}
+	if !opts.Interactive && editable.Projects.Edited {
+		findOptions.Fields = append(findOptions.Fields, "projectCards", "projectItems")
+	}
+	if !opts.Interactive && editable.Milestone.Edited {
+		findOptions.Fields = append(findOptions.Fields, "milestone")
+	}
+	if len(opts.Assets) > 0 {
+		findOptions.Fields = append(findOptions.Fields, "repository")
 	}
 
 	pr, repo, err := opts.Finder.Find(findOptions)
@@ -339,8 +371,6 @@ func editRun(opts *EditOptions) error {
 		}
 	}
 
-	editable := opts.Editable
-	editable.Reviewers.Selectable = true
 	editable.Title.Default = pr.Title
 	editable.Body.Default = pr.Body
 	editable.Base.Default = pr.BaseRefName

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -305,48 +305,13 @@ func editRun(opts *EditOptions) error {
 
 	findOptions := shared.FindOptions{
 		Selector: opts.SelectorArg,
-		Fields:   []string{"id", "url"},
+		Fields: pullRequestLookupFields(
+			editable,
+			opts.Interactive,
+			len(opts.Assets) > 0,
+			issueFeatures.ApiActorsSupported,
+		),
 		Detector: opts.Detector,
-	}
-	if opts.Interactive {
-		findOptions.Fields = append(findOptions.Fields, "author", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone")
-		// TODO ApiActorsSupported
-		if issueFeatures.ApiActorsSupported {
-			findOptions.Fields = append(findOptions.Fields, "assignedActors")
-		} else {
-			findOptions.Fields = append(findOptions.Fields, "assignees")
-		}
-	} else if editable.Title.Edited {
-		findOptions.Fields = append(findOptions.Fields, "title")
-	}
-	if !opts.Interactive && (editable.Body.Edited || len(opts.Assets) > 0) {
-		findOptions.Fields = append(findOptions.Fields, "body")
-	}
-	if !opts.Interactive && editable.Base.Edited {
-		findOptions.Fields = append(findOptions.Fields, "baseRefName")
-	}
-	if !opts.Interactive && editable.Reviewers.Edited {
-		findOptions.Fields = append(findOptions.Fields, "reviewRequests")
-	}
-	if !opts.Interactive && editable.Assignees.Edited {
-		// TODO ApiActorsSupported
-		if issueFeatures.ApiActorsSupported {
-			findOptions.Fields = append(findOptions.Fields, "assignedActors")
-		} else {
-			findOptions.Fields = append(findOptions.Fields, "assignees")
-		}
-	}
-	if !opts.Interactive && editable.Labels.Edited {
-		findOptions.Fields = append(findOptions.Fields, "labels")
-	}
-	if !opts.Interactive && editable.Projects.Edited {
-		findOptions.Fields = append(findOptions.Fields, "projectCards", "projectItems")
-	}
-	if !opts.Interactive && editable.Milestone.Edited {
-		findOptions.Fields = append(findOptions.Fields, "milestone")
-	}
-	if len(opts.Assets) > 0 {
-		findOptions.Fields = append(findOptions.Fields, "repository")
 	}
 
 	pr, repo, err := opts.Finder.Find(findOptions)
@@ -479,6 +444,56 @@ func editRun(opts *EditOptions) error {
 	fmt.Fprintln(opts.IO.Out, pr.URL)
 
 	return uploadErr
+}
+
+func pullRequestLookupFields(editable shared.Editable, interactive, hasAssets, apiActorsSupported bool) []string {
+	fields := []string{"id", "url"}
+
+	if interactive {
+		fields = append(fields, "author", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone")
+		// TODO ApiActorsSupported
+		if apiActorsSupported {
+			fields = append(fields, "assignedActors")
+		} else {
+			fields = append(fields, "assignees")
+		}
+	} else {
+		if editable.Title.Edited {
+			fields = append(fields, "title")
+		}
+		if editable.Body.Edited || hasAssets {
+			fields = append(fields, "body")
+		}
+		if editable.Base.Edited {
+			fields = append(fields, "baseRefName")
+		}
+		if editable.Reviewers.Edited {
+			fields = append(fields, "reviewRequests")
+		}
+		if editable.Assignees.Edited {
+			// TODO ApiActorsSupported
+			if apiActorsSupported {
+				fields = append(fields, "assignedActors")
+			} else {
+				fields = append(fields, "assignees")
+			}
+		}
+		if editable.Labels.Edited {
+			fields = append(fields, "labels")
+		}
+		if editable.Projects.Edited {
+			fields = append(fields, "projectCards", "projectItems")
+		}
+		if editable.Milestone.Edited {
+			fields = append(fields, "milestone")
+		}
+	}
+
+	if hasAssets {
+		fields = append(fields, "repository")
+	}
+
+	return fields
 }
 
 // reviewerSearchFunc is intended to be an arg for MultiSelectWithSearch

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -310,6 +310,7 @@ func editRun(opts *EditOptions) error {
 			opts.Interactive,
 			len(opts.Assets) > 0,
 			issueFeatures.ApiActorsSupported,
+			opts.Detector.ProjectsV1() == gh.ProjectsV1Supported,
 		),
 		Detector: opts.Detector,
 	}
@@ -446,11 +447,15 @@ func editRun(opts *EditOptions) error {
 	return uploadErr
 }
 
-func pullRequestLookupFields(editable shared.Editable, interactive, hasAssets, apiActorsSupported bool) []string {
+func pullRequestLookupFields(editable shared.Editable, interactive, hasAssets, apiActorsSupported, projectsV1Supported bool) []string {
 	fields := []string{"id", "url"}
 
 	if interactive {
-		fields = append(fields, "author", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone")
+		fields = append(fields, "author", "title", "body", "baseRefName", "reviewRequests", "labels")
+		if projectsV1Supported {
+			fields = append(fields, "projectCards")
+		}
+		fields = append(fields, "projectItems", "milestone")
 		// TODO ApiActorsSupported
 		if apiActorsSupported {
 			fields = append(fields, "assignedActors")
@@ -458,14 +463,8 @@ func pullRequestLookupFields(editable shared.Editable, interactive, hasAssets, a
 			fields = append(fields, "assignees")
 		}
 	} else {
-		if editable.Title.Edited {
-			fields = append(fields, "title")
-		}
-		if editable.Body.Edited || hasAssets {
+		if hasAssets && !editable.Body.Edited {
 			fields = append(fields, "body")
-		}
-		if editable.Base.Edited {
-			fields = append(fields, "baseRefName")
 		}
 		if editable.Reviewers.Edited {
 			fields = append(fields, "reviewRequests")
@@ -478,14 +477,13 @@ func pullRequestLookupFields(editable shared.Editable, interactive, hasAssets, a
 				fields = append(fields, "assignees")
 			}
 		}
-		if editable.Labels.Edited {
-			fields = append(fields, "labels")
-		}
 		if editable.Projects.Edited {
-			fields = append(fields, "projectCards", "projectItems")
-		}
-		if editable.Milestone.Edited {
-			fields = append(fields, "milestone")
+			if projectsV1Supported {
+				fields = append(fields, "projectCards")
+			}
+			if len(editable.Projects.Remove) > 0 {
+				fields = append(fields, "projectItems")
+			}
 		}
 	}
 

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -1697,6 +1697,114 @@ func Test_editRun(t *testing.T) {
 	}
 }
 
+func Test_pullRequestLookupFields(t *testing.T) {
+	tests := []struct {
+		name               string
+		editable           shared.Editable
+		interactive        bool
+		hasAssets          bool
+		apiActorsSupported bool
+		want               []string
+	}{
+		{
+			name: "title",
+			editable: shared.Editable{
+				Title: shared.EditableString{Edited: true},
+			},
+			want: []string{"id", "url", "title"},
+		},
+		{
+			name: "body",
+			editable: shared.Editable{
+				Body: shared.EditableString{Edited: true},
+			},
+			want: []string{"id", "url", "body"},
+		},
+		{
+			name: "base",
+			editable: shared.Editable{
+				Base: shared.EditableString{Edited: true},
+			},
+			want: []string{"id", "url", "baseRefName"},
+		},
+		{
+			name: "reviewers",
+			editable: shared.Editable{
+				Reviewers: shared.EditableReviewers{
+					EditableSlice: shared.EditableSlice{Edited: true},
+				},
+			},
+			want: []string{"id", "url", "reviewRequests"},
+		},
+		{
+			name: "assignees with actors",
+			editable: shared.Editable{
+				Assignees: shared.EditableAssignees{
+					EditableSlice: shared.EditableSlice{Edited: true},
+				},
+			},
+			apiActorsSupported: true,
+			want:               []string{"id", "url", "assignedActors"},
+		},
+		{
+			name: "assignees without actors",
+			editable: shared.Editable{
+				Assignees: shared.EditableAssignees{
+					EditableSlice: shared.EditableSlice{Edited: true},
+				},
+			},
+			want: []string{"id", "url", "assignees"},
+		},
+		{
+			name: "labels",
+			editable: shared.Editable{
+				Labels: shared.EditableSlice{Edited: true},
+			},
+			want: []string{"id", "url", "labels"},
+		},
+		{
+			name: "projects",
+			editable: shared.Editable{
+				Projects: shared.EditableProjects{
+					EditableSlice: shared.EditableSlice{Edited: true},
+				},
+			},
+			want: []string{"id", "url", "projectCards", "projectItems"},
+		},
+		{
+			name: "milestone",
+			editable: shared.Editable{
+				Milestone: shared.EditableString{Edited: true},
+			},
+			want: []string{"id", "url", "milestone"},
+		},
+		{
+			name:      "attachment",
+			hasAssets: true,
+			want:      []string{"id", "url", "body", "repository"},
+		},
+		{
+			name:               "interactive with actors",
+			interactive:        true,
+			apiActorsSupported: true,
+			want:               []string{"id", "url", "author", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone", "assignedActors"},
+		},
+		{
+			name:        "interactive without actors and with attachment",
+			interactive: true,
+			hasAssets:   true,
+			want:        []string{"id", "url", "author", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone", "assignees", "repository"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pullRequestLookupFields(tt.editable, tt.interactive, tt.hasAssets, tt.apiActorsSupported)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // fieldCapturingFinder records the fields a run asks the pull request lookup
 // for, then delegates to the finder it wraps.
 type fieldCapturingFinder struct {

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -1603,7 +1603,7 @@ func Test_editRun(t *testing.T) {
 			stdout: "https://github.com/OWNER/REPO/pull/123\n",
 		},
 		{
-			name: "the lookup does not ask for the repository id without an attachment",
+			name: "title-only lookup avoids unrelated fields",
 			input: &EditOptions{
 				Detector:    &fd.EnabledDetectorMock{},
 				SelectorArg: "123",
@@ -1623,7 +1623,8 @@ func Test_editRun(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockPullRequestUpdate(reg)
 			},
-			wantNoLookupFields: []string{"repository"},
+			wantLookupFields:   []string{"id", "url", "title"},
+			wantNoLookupFields: []string{"author", "body", "baseRefName", "reviewRequests", "assignedActors", "assignees", "labels", "projectCards", "projectItems", "milestone", "repository"},
 			stdout:             "https://github.com/OWNER/REPO/pull/123\n",
 		},
 	}
@@ -1985,6 +1986,11 @@ func TestProjectsV1Deprecation(t *testing.T) {
 			Finder: shared.NewFinder(f),
 
 			SelectorArg: "https://github.com/cli/cli/pull/123",
+			Editable: shared.Editable{
+				Projects: shared.EditableProjects{
+					EditableSlice: shared.EditableSlice{Edited: true},
+				},
+			},
 		})
 
 		// Verify that our request contained projectCards
@@ -2016,6 +2022,11 @@ func TestProjectsV1Deprecation(t *testing.T) {
 			Finder: shared.NewFinder(f),
 
 			SelectorArg: "https://github.com/cli/cli/pull/123",
+			Editable: shared.Editable{
+				Projects: shared.EditableProjects{
+					EditableSlice: shared.EditableSlice{Edited: true},
+				},
+			},
 		})
 
 		// Verify that our request did not contain projectCards

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -1623,8 +1623,8 @@ func Test_editRun(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockPullRequestUpdate(reg)
 			},
-			wantLookupFields:   []string{"id", "url", "title"},
-			wantNoLookupFields: []string{"author", "body", "baseRefName", "reviewRequests", "assignedActors", "assignees", "labels", "projectCards", "projectItems", "milestone", "repository"},
+			wantLookupFields:   []string{"id", "url"},
+			wantNoLookupFields: []string{"author", "title", "body", "baseRefName", "reviewRequests", "assignedActors", "assignees", "labels", "projectCards", "projectItems", "milestone", "repository"},
 			stdout:             "https://github.com/OWNER/REPO/pull/123\n",
 		},
 	}
@@ -1699,33 +1699,34 @@ func Test_editRun(t *testing.T) {
 
 func Test_pullRequestLookupFields(t *testing.T) {
 	tests := []struct {
-		name               string
-		editable           shared.Editable
-		interactive        bool
-		hasAssets          bool
-		apiActorsSupported bool
-		want               []string
+		name                string
+		editable            shared.Editable
+		interactive         bool
+		hasAssets           bool
+		apiActorsSupported  bool
+		projectsV1Supported bool
+		want                []string
 	}{
 		{
 			name: "title",
 			editable: shared.Editable{
 				Title: shared.EditableString{Edited: true},
 			},
-			want: []string{"id", "url", "title"},
+			want: []string{"id", "url"},
 		},
 		{
 			name: "body",
 			editable: shared.Editable{
 				Body: shared.EditableString{Edited: true},
 			},
-			want: []string{"id", "url", "body"},
+			want: []string{"id", "url"},
 		},
 		{
 			name: "base",
 			editable: shared.Editable{
 				Base: shared.EditableString{Edited: true},
 			},
-			want: []string{"id", "url", "baseRefName"},
+			want: []string{"id", "url"},
 		},
 		{
 			name: "reviewers",
@@ -1760,23 +1761,52 @@ func Test_pullRequestLookupFields(t *testing.T) {
 			editable: shared.Editable{
 				Labels: shared.EditableSlice{Edited: true},
 			},
-			want: []string{"id", "url", "labels"},
+			want: []string{"id", "url"},
 		},
 		{
-			name: "projects",
+			name: "projects v1 add",
 			editable: shared.Editable{
 				Projects: shared.EditableProjects{
-					EditableSlice: shared.EditableSlice{Edited: true},
+					EditableSlice: shared.EditableSlice{Add: []string{"Roadmap"}, Edited: true},
 				},
 			},
-			want: []string{"id", "url", "projectCards", "projectItems"},
+			projectsV1Supported: true,
+			want:                []string{"id", "url", "projectCards"},
+		},
+		{
+			name: "projects v2 add",
+			editable: shared.Editable{
+				Projects: shared.EditableProjects{
+					EditableSlice: shared.EditableSlice{Add: []string{"Roadmap"}, Edited: true},
+				},
+			},
+			want: []string{"id", "url"},
+		},
+		{
+			name: "projects v2 remove",
+			editable: shared.Editable{
+				Projects: shared.EditableProjects{
+					EditableSlice: shared.EditableSlice{Remove: []string{"Roadmap"}, Edited: true},
+				},
+			},
+			want: []string{"id", "url", "projectItems"},
+		},
+		{
+			name: "projects v1 remove",
+			editable: shared.Editable{
+				Projects: shared.EditableProjects{
+					EditableSlice: shared.EditableSlice{Remove: []string{"Roadmap"}, Edited: true},
+				},
+			},
+			projectsV1Supported: true,
+			want:                []string{"id", "url", "projectCards", "projectItems"},
 		},
 		{
 			name: "milestone",
 			editable: shared.Editable{
 				Milestone: shared.EditableString{Edited: true},
 			},
-			want: []string{"id", "url", "milestone"},
+			want: []string{"id", "url"},
 		},
 		{
 			name:      "attachment",
@@ -1784,22 +1814,31 @@ func Test_pullRequestLookupFields(t *testing.T) {
 			want:      []string{"id", "url", "body", "repository"},
 		},
 		{
-			name:               "interactive with actors",
-			interactive:        true,
-			apiActorsSupported: true,
-			want:               []string{"id", "url", "author", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone", "assignedActors"},
+			name: "attachment with replacement body",
+			editable: shared.Editable{
+				Body: shared.EditableString{Edited: true},
+			},
+			hasAssets: true,
+			want:      []string{"id", "url", "repository"},
+		},
+		{
+			name:                "interactive with actors",
+			interactive:         true,
+			apiActorsSupported:  true,
+			projectsV1Supported: true,
+			want:                []string{"id", "url", "author", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone", "assignedActors"},
 		},
 		{
 			name:        "interactive without actors and with attachment",
 			interactive: true,
 			hasAssets:   true,
-			want:        []string{"id", "url", "author", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone", "assignees", "repository"},
+			want:        []string{"id", "url", "author", "title", "body", "baseRefName", "reviewRequests", "labels", "projectItems", "milestone", "assignees", "repository"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := pullRequestLookupFields(tt.editable, tt.interactive, tt.hasAssets, tt.apiActorsSupported)
+			got := pullRequestLookupFields(tt.editable, tt.interactive, tt.hasAssets, tt.apiActorsSupported, tt.projectsV1Supported)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Fixes #14317

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

`gh pr edit` previously requested reviewer, assignee, label, project, and milestone data during every pull request lookup. As a result, a simple update such as `gh pr edit --title` could fail when the token could update the pull request but lacked permission to read review requests.

This changes non-interactive edits to fetch existing pull request state only when it is needed to construct the update:

- Direct replacements such as title, body, base branch, labels, and milestone need only the pull request ID and URL.
- Reviewer and assignee edits fetch their current sets because their mutations replace the complete set.
- Project v1 edits fetch current project cards because the mutation replaces the complete set.
- Project v2 removals fetch item IDs, while additions do not need current project state.
- Attachments fetch the current body only when appending without an explicit replacement body.

### How did you test this change?

<!--
Report only actions you actually performed and results you actually observed, using factual
first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
hypothetical, inferred, or merely expected scenarios as testing.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

If you did not exercise the changed behavior, write `Not tested` and explain why.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
   Given I was in a repo with no open pull requests
   When I ran `gh pr list`
   Then I saw "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

I tested the latest released CLI and a local build of this branch end to end against the same open organization pull request. The pull request was authored by me, had a requested team reviewer, and was accessed using an organization-scoped fine-grained PAT. I passed its existing title back to `--title` to exercise the real update path without changing its visible content.

1. With the latest released CLI, `gh 2.99.0`, `gh pr edit --title <current title>` exited non-zero with:

   ```text
   GraphQL: Resource not accessible by personal access token (repository.pullRequest.reviewRequests.nodes.0.requestedReviewer)
   ```

   `GH_DEBUG=api` confirmed that the lookup requested `reviewRequests(first: 100)` and attempted to resolve user, bot, team, and team organization details.

2. With a local build of this branch at `b4898bc`, the same command succeeded using the same token and pull request. API debug output confirmed that the command completed the minimal pull request lookup and issued the real `PullRequestUpdate` mutation.
3. A subsequent API read confirmed that the pull request title remained unchanged, as intended.

I separately validated the token restrictions against a private repository: listing pull requests succeeded, while listing issues failed with `403 Resource not accessible by personal access token`. I also ran control tests against temporary pull requests with no reviewer and with a requested user reviewer; stock `gh 2.99.0` succeeded in both cases. This isolates the reproduced failure to resolving the requested team reviewer and proves that this branch fixes the complete `gh pr edit --title` flow, not only the lookup query.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

Interactive editing keeps its existing eager lookup because the fields are chosen after the pull request is fetched. This also preserves the existing attachment behavior where authorization is checked before prompting.

The field-selection helper has exact table-driven coverage for every edit mode, including GitHub.com and GHES assignees, project v1 and v2 additions and removals, interactive editing, and attachments.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `pullRequestLookupFields` in `pkg/cmd/pr/edit/edit.go`, then review its table-driven coverage in `pkg/cmd/pr/edit/edit_test.go`.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @timrogers will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
