### PR TITLE
Fix discussion acceptance test flags

### DIFF
--- a/acceptance/testdata/discussion/discussion-comment.txtar
+++ b/acceptance/testdata/discussion/discussion-comment.txtar
@@ -24,7 +24,7 @@ exec gh discussion comment $DISCUSSION_URL --body-file $WORK/comment-body.txt
 stdout 'discussioncomment'
 
 # Verify comments appear in view
-exec gh discussion view $DISCUSSION_URL --comments --order oldest --json comments
+exec gh discussion view $DISCUSSION_URL --order oldest --json comments
 stdout2env COMMENTS_JSON
 jq-assert COMMENTS_JSON '.comments.nodes | length' '^2$'
 jq-assert COMMENTS_JSON '.comments.nodes[0].body' 'Comment from flag'
@@ -72,7 +72,7 @@ exec gh discussion comment $SECOND_REPLY_ID --edit --body-file $WORK/edit-reply-
 stdout 'discussioncomment'
 
 # Verify edits appear
-exec gh discussion view $DISCUSSION_URL --comments --order oldest --json comments
+exec gh discussion view $DISCUSSION_URL --order oldest --json comments
 stdout2env EDITED_COMMENTS_JSON
 jq-assert EDITED_COMMENTS_JSON '.comments.nodes[0].body' 'Edited first comment'
 jq-assert EDITED_COMMENTS_JSON '.comments.nodes[0].replies.nodes[0].body' 'Edited first reply'
@@ -91,7 +91,7 @@ exec gh discussion comment $SECOND_COMMENT_ID --delete --yes
 exec gh discussion comment $SECOND_REPLY_ID --delete --yes
 
 # Verify deletion
-exec gh discussion view $DISCUSSION_URL --comments --order oldest --json comments
+exec gh discussion view $DISCUSSION_URL --order oldest --json comments
 stdout2env DELETED_COMMENTS_JSON
 jq-assert DELETED_COMMENTS_JSON '.comments.nodes | length' '^1$'
 jq-assert DELETED_COMMENTS_JSON '.comments.nodes[0].body' 'Edited first comment'

--- a/acceptance/testdata/discussion/discussion-list.txtar
+++ b/acceptance/testdata/discussion/discussion-list.txtar
@@ -35,7 +35,7 @@ exec gh discussion create --title 'Second Discussion' --body 'Second body' --cat
 exec gh discussion create --title 'QA Discussion' --body 'QA body' --category 'Q&A'
 stdout2env QA_URL
 exec gh discussion comment $QA_URL --body 'This is the answer'
-exec gh discussion view $QA_URL --comments --json comments --jq '.comments.nodes[0].id'
+exec gh discussion view $QA_URL --json comments --jq '.comments.nodes[0].id'
 stdout2env QA_COMMENT_ID
 exec gh api graphql -f query='mutation { markDiscussionCommentAsAnswer(input: {id: "'$QA_COMMENT_ID'"}) { discussion { id } } }'
 


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Follow-up to https://github.com/cli/cli/pull/14215

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

PR #14215 made `--comments` and `--json` mutually exclusive for discussion views, but four discussion acceptance-test commands still passed both flags. Remove `--comments` from those JSON assertions because requesting the `comments` JSON field already fetches the full comment data.

### How did you test this change?

<!--
Report only actions you actually performed and results you actually observed, using factual
first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
hypothetical, inferred, or merely expected scenarios as testing.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

If you did not exercise the changed behavior, write `Not tested` and explain why.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
   Given I was in a repo with no open pull requests
   When I ran `gh pr list`
   Then I saw "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

```
➜  williammartin-psychic-doodle git:(williammartin-psychic-doodle) GH_ACCEPTANCE_HOST=github.com \
GH_ACCEPTANCE_ORG=gh-acceptance-testing \
GH_ACCEPTANCE_TOKEN="$(gh auth token --hostname github.com)" \
go test -tags=acceptance ./acceptance -run '^TestDiscussions$'
ok      github.com/cli/cli/v2/acceptance        56.809s
```

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

The standalone `--comments` acceptance case remains unchanged so human-readable comment output is still covered.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `acceptance/testdata/discussion/discussion-comment.txtar`. PR #14215 introduced the mutual exclusion that exposed these stale commands.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
