### PR TITLE
Clarify supported GHES versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![screenshot of gh pr status](https://user-images.githubusercontent.com/98482/84171218-327e7a80-aa40-11ea-8cd1-5177fc2d0e72.png)
 
-GitHub CLI is supported for users on GitHub.com, GitHub Enterprise Cloud, and [versions of GitHub Enterprise Server that are supported by GitHub](https://docs.github.com/en/enterprise-server/admin/all-releases), with support for macOS, Windows, and Linux.
+GitHub CLI is supported for users on GitHub.com, GitHub Enterprise Cloud, and [supported GitHub Enterprise Server versions](https://docs.github.com/en/enterprise-server/admin/all-releases), with support for macOS, Windows, and Linux.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![screenshot of gh pr status](https://user-images.githubusercontent.com/98482/84171218-327e7a80-aa40-11ea-8cd1-5177fc2d0e72.png)
 
-GitHub CLI is supported for users on GitHub.com, GitHub Enterprise Cloud, and GitHub Enterprise Server 2.20+ with support for macOS, Windows, and Linux.
+GitHub CLI is supported for users on GitHub.com, GitHub Enterprise Cloud, and [versions of GitHub Enterprise Server that are supported by GitHub](https://docs.github.com/en/enterprise-server@latest/admin/all-releases), with support for macOS, Windows, and Linux.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![screenshot of gh pr status](https://user-images.githubusercontent.com/98482/84171218-327e7a80-aa40-11ea-8cd1-5177fc2d0e72.png)
 
-GitHub CLI is supported for users on GitHub.com, GitHub Enterprise Cloud, and [versions of GitHub Enterprise Server that are supported by GitHub](https://docs.github.com/en/enterprise-server@latest/admin/all-releases), with support for macOS, Windows, and Linux.
+GitHub CLI is supported for users on GitHub.com, GitHub Enterprise Cloud, and [versions of GitHub Enterprise Server that are supported by GitHub](https://docs.github.com/en/enterprise-server/admin/all-releases), with support for macOS, Windows, and Linux.
 
 ## Documentation
 


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

The README currently says that GitHub CLI supports GitHub Enterprise Server 2.20 and later. That static version floor is stale and does not reflect the project's policy of supporting GHES versions that GitHub currently supports.

This replaces the fixed version with a link to GitHub's authoritative GHES release and support table.

### How did you test this change?

Not tested because this is a documentation-only wording and link change.

### Key points

The README now follows GitHub's support window without requiring future edits whenever an older GHES release reaches its closing-down date.

### Notes for reviewers

Review `README.md`. [Issue #6006](https://github.com/cli/cli/issues/6006#issuecomment-1289104263) records the existing policy that GitHub CLI supports the GHES versions supported by GitHub.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.