### PR TITLE
Fix #14064: allow deleting SSH signing keys

### DIFF
--- a/pkg/cmd/ssh-key/delete/delete.go
+++ b/pkg/cmd/ssh-key/delete/delete.go
@@ -1,11 +1,13 @@
 package delete
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/ssh-key/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
@@ -17,6 +19,7 @@ type DeleteOptions struct {
 	HttpClient func() (*http.Client, error)
 
 	KeyID     string
+	Type      string
 	Confirmed bool
 	Prompter  prompter.Prompter
 }
@@ -32,7 +35,12 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "delete <id>",
 		Short: "Delete an SSH key from your GitHub account",
-		Args:  cmdutil.ExactArgs(1, "cannot delete: key id required"),
+		Long: `Delete an SSH key from your GitHub account by ID.
+
+Authentication and signing keys are looked up automatically. If the same ID
+exists in both namespaces, pass --type to choose which key to delete.
+`,
+		Args: cmdutil.ExactArgs(1, "cannot delete: key id required"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.KeyID = args[0]
 
@@ -48,6 +56,8 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 		},
 	}
 
+	typeEnums := []string{shared.AuthenticationKey, shared.SigningKey}
+	cmdutil.StringEnumFlag(cmd, &opts.Type, "type", "", "", typeEnums, "Type of the ssh key (required only when the ID exists as both authentication and signing)")
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "Skip the confirmation prompt")
 	_ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
 	cmd.Flags().BoolVarP(&opts.Confirmed, "yes", "y", false, "Skip the confirmation prompt")
@@ -67,18 +77,30 @@ func deleteRun(opts *DeleteOptions) error {
 	}
 
 	host, _ := cfg.Authentication().DefaultHost()
-	key, err := getSSHKey(httpClient, host, opts.KeyID)
+	key, err := resolveSSHKey(httpClient, host, opts.KeyID, opts.Type)
 	if err != nil {
-		return err
-	}
-
-	if !opts.Confirmed {
-		if err := opts.Prompter.ConfirmDeletion(key.Title); err != nil {
+		var ambiguous ambiguousKeyError
+		if errors.As(err, &ambiguous) {
+			key, err = disambiguateKey(opts, ambiguous)
+			if err != nil {
+				return err
+			}
+		} else {
 			return err
 		}
 	}
 
-	err = deleteSSHKey(httpClient, host, opts.KeyID)
+	if !opts.Confirmed {
+		confirmLabel := key.Title
+		if key.Type != "" {
+			confirmLabel = fmt.Sprintf("%s (%s)", key.Title, key.Type)
+		}
+		if err := opts.Prompter.ConfirmDeletion(confirmLabel); err != nil {
+			return err
+		}
+	}
+
+	err = deleteSSHKey(httpClient, host, opts.KeyID, key.Type)
 	if err != nil {
 		return err
 	}
@@ -88,4 +110,32 @@ func deleteRun(opts *DeleteOptions) error {
 		fmt.Fprintf(opts.IO.Out, "%s SSH key %q (%s) deleted from your account\n", cs.SuccessIcon(), key.Title, opts.KeyID)
 	}
 	return nil
+}
+
+func disambiguateKey(opts *DeleteOptions, ambiguous ambiguousKeyError) (*sshKey, error) {
+	if !opts.IO.CanPrompt() {
+		return nil, ambiguous
+	}
+
+	options := []string{
+		fmt.Sprintf("%s (%s)", ambiguous.AuthTitle, shared.AuthenticationKey),
+		fmt.Sprintf("%s (%s)", ambiguous.SigningTitle, shared.SigningKey),
+	}
+	idx, err := opts.Prompter.Select(
+		fmt.Sprintf("SSH key ID %s matches both an authentication and a signing key. Which one should be deleted?", ambiguous.KeyID),
+		"",
+		options,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	switch idx {
+	case 0:
+		return &sshKey{Title: ambiguous.AuthTitle, Type: shared.AuthenticationKey}, nil
+	case 1:
+		return &sshKey{Title: ambiguous.SigningTitle, Type: shared.SigningKey}, nil
+	default:
+		return nil, fmt.Errorf("invalid selection")
+	}
 }

--- a/pkg/cmd/ssh-key/delete/delete_test.go
+++ b/pkg/cmd/ssh-key/delete/delete_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/ssh-key/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -43,6 +44,25 @@ func TestNewCmdDelete(t *testing.T) {
 			tty:    true,
 			input:  "123 -y",
 			output: DeleteOptions{KeyID: "123", Confirmed: true},
+		},
+		{
+			name:   "type authentication",
+			tty:    true,
+			input:  "123 --type authentication --yes",
+			output: DeleteOptions{KeyID: "123", Type: shared.AuthenticationKey, Confirmed: true},
+		},
+		{
+			name:   "type signing",
+			tty:    true,
+			input:  "123 --type signing --yes",
+			output: DeleteOptions{KeyID: "123", Type: shared.SigningKey, Confirmed: true},
+		},
+		{
+			name:       "invalid type",
+			tty:        true,
+			input:      "123 --type bogus --yes",
+			wantErr:    true,
+			wantErrMsg: "invalid argument \"bogus\" for \"--type\" flag: valid values are {authentication|signing}",
 		},
 		{
 			name:       "no tty",
@@ -104,12 +124,14 @@ func TestNewCmdDelete(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.output.KeyID, cmdOpts.KeyID)
 			assert.Equal(t, tt.output.Confirmed, cmdOpts.Confirmed)
+			assert.Equal(t, tt.output.Type, cmdOpts.Type)
 		})
 	}
 }
 
 func Test_deleteRun(t *testing.T) {
-	keyResp := "{\"title\":\"My Key\"}"
+	authKeyResp := `{"title":"My Auth Key"}`
+	signingKeyResp := `{"title":"My Signing Key"}`
 	tests := []struct {
 		name          string
 		tty           bool
@@ -121,7 +143,7 @@ func Test_deleteRun(t *testing.T) {
 		wantErrMsg    string
 	}{
 		{
-			name: "delete tty",
+			name: "delete authentication key tty",
 			tty:  true,
 			opts: DeleteOptions{KeyID: "123"},
 			prompterStubs: func(pm *prompter.PrompterMock) {
@@ -130,20 +152,84 @@ func Test_deleteRun(t *testing.T) {
 				}
 			},
 			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(200, keyResp))
+				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(200, authKeyResp))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, ""))
 				reg.Register(httpmock.REST("DELETE", "user/keys/123"), httpmock.StatusStringResponse(204, ""))
 			},
-			wantStdout: "✓ SSH key \"My Key\" (123) deleted from your account\n",
+			wantStdout: "✓ SSH key \"My Auth Key\" (123) deleted from your account\n",
+		},
+		{
+			name: "delete signing key tty",
+			tty:  true,
+			opts: DeleteOptions{KeyID: "456"},
+			prompterStubs: func(pm *prompter.PrompterMock) {
+				pm.ConfirmDeletionFunc = func(prompt string) error {
+					assert.Equal(t, "My Signing Key (signing)", prompt)
+					return nil
+				}
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/keys/456"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/456"), httpmock.StatusStringResponse(200, signingKeyResp))
+				reg.Register(httpmock.REST("DELETE", "user/ssh_signing_keys/456"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "✓ SSH key \"My Signing Key\" (456) deleted from your account\n",
 		},
 		{
 			name: "delete with confirm flag tty",
 			tty:  true,
 			opts: DeleteOptions{KeyID: "123", Confirmed: true},
 			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(200, keyResp))
+				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(200, authKeyResp))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, ""))
 				reg.Register(httpmock.REST("DELETE", "user/keys/123"), httpmock.StatusStringResponse(204, ""))
 			},
-			wantStdout: "✓ SSH key \"My Key\" (123) deleted from your account\n",
+			wantStdout: "✓ SSH key \"My Auth Key\" (123) deleted from your account\n",
+		},
+		{
+			name: "delete signing key with --type",
+			tty:  true,
+			opts: DeleteOptions{KeyID: "456", Type: shared.SigningKey, Confirmed: true},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/456"), httpmock.StatusStringResponse(200, signingKeyResp))
+				reg.Register(httpmock.REST("DELETE", "user/ssh_signing_keys/456"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "✓ SSH key \"My Signing Key\" (456) deleted from your account\n",
+		},
+		{
+			name: "ambiguous id prompts for type tty",
+			tty:  true,
+			opts: DeleteOptions{KeyID: "123"},
+			prompterStubs: func(pm *prompter.PrompterMock) {
+				pm.SelectFunc = func(prompt, _ string, options []string) (int, error) {
+					assert.Contains(t, prompt, "123")
+					assert.Equal(t, []string{
+						"My Auth Key (authentication)",
+						"My Signing Key (signing)",
+					}, options)
+					return 1, nil
+				}
+				pm.ConfirmDeletionFunc = func(_ string) error {
+					return nil
+				}
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(200, authKeyResp))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(200, signingKeyResp))
+				reg.Register(httpmock.REST("DELETE", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "✓ SSH key \"My Signing Key\" (123) deleted from your account\n",
+		},
+		{
+			name: "ambiguous id without tty requires --type",
+			opts: DeleteOptions{KeyID: "123", Confirmed: true},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(200, authKeyResp))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(200, signingKeyResp))
+			},
+			wantErr: true,
+			wantErrMsg: "SSH key ID 123 matches both an authentication key (\"My Auth Key\") and a signing key (\"My Signing Key\"); " +
+				"re-run with --type authentication or --type signing",
 		},
 		{
 			name: "not found tty",
@@ -151,16 +237,28 @@ func Test_deleteRun(t *testing.T) {
 			opts: DeleteOptions{KeyID: "123"},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, ""))
 			},
 			wantErr:    true,
-			wantErrMsg: "HTTP 404 (https://api.github.com/user/keys/123)",
+			wantErrMsg: "SSH key not found: 123",
 		},
 		{
-			name: "delete no tty",
+			name: "delete authentication key no tty",
 			opts: DeleteOptions{KeyID: "123", Confirmed: true},
 			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(200, keyResp))
+				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(200, authKeyResp))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, ""))
 				reg.Register(httpmock.REST("DELETE", "user/keys/123"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "",
+		},
+		{
+			name: "delete signing key no tty",
+			opts: DeleteOptions{KeyID: "456", Confirmed: true},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/keys/456"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/456"), httpmock.StatusStringResponse(200, signingKeyResp))
+				reg.Register(httpmock.REST("DELETE", "user/ssh_signing_keys/456"), httpmock.StatusStringResponse(204, ""))
 			},
 			wantStdout: "",
 		},
@@ -169,9 +267,10 @@ func Test_deleteRun(t *testing.T) {
 			opts: DeleteOptions{KeyID: "123", Confirmed: true},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "user/keys/123"), httpmock.StatusStringResponse(404, ""))
+				reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/123"), httpmock.StatusStringResponse(404, ""))
 			},
 			wantErr:    true,
-			wantErrMsg: "HTTP 404 (https://api.github.com/user/keys/123)",
+			wantErrMsg: "SSH key not found: 123",
 		},
 	}
 
@@ -220,7 +319,23 @@ func TestDeleteSSHKeyHTTPError(t *testing.T) {
 		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
 	)
 
-	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
+	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "1234", shared.AuthenticationKey)
+
+	var httpErr api.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+func TestDeleteSigningSSHKeyHTTPError(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("DELETE", "user/ssh_signing_keys/1234"),
+		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+	)
+
+	err := deleteSSHKey(&http.Client{Transport: reg}, "github.com", "1234", shared.SigningKey)
 
 	var httpErr api.HTTPError
 	require.ErrorAs(t, err, &httpErr)
@@ -236,11 +351,60 @@ func TestGetSSHKeyHTTPError(t *testing.T) {
 		httpmock.StatusStringResponse(http.StatusNotFound, `{"message":"Not Found"}`),
 	)
 
-	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "1234")
+	key, err := getSSHKey(&http.Client{Transport: reg}, "github.com", "1234", shared.AuthenticationKey)
 
 	assert.Nil(t, key)
 	var httpErr api.HTTPError
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
 	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+func TestResolveSSHKey(t *testing.T) {
+	t.Run("authentication only", func(t *testing.T) {
+		reg := &httpmock.Registry{}
+		defer reg.Verify(t)
+		reg.Register(httpmock.REST("GET", "user/keys/1"), httpmock.StatusStringResponse(200, `{"title":"auth"}`))
+		reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/1"), httpmock.StatusStringResponse(404, ""))
+
+		key, err := resolveSSHKey(&http.Client{Transport: reg}, "github.com", "1", "")
+		require.NoError(t, err)
+		assert.Equal(t, "auth", key.Title)
+		assert.Equal(t, shared.AuthenticationKey, key.Type)
+	})
+
+	t.Run("signing only", func(t *testing.T) {
+		reg := &httpmock.Registry{}
+		defer reg.Verify(t)
+		reg.Register(httpmock.REST("GET", "user/keys/2"), httpmock.StatusStringResponse(404, ""))
+		reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/2"), httpmock.StatusStringResponse(200, `{"title":"sign"}`))
+
+		key, err := resolveSSHKey(&http.Client{Transport: reg}, "github.com", "2", "")
+		require.NoError(t, err)
+		assert.Equal(t, "sign", key.Title)
+		assert.Equal(t, shared.SigningKey, key.Type)
+	})
+
+	t.Run("explicit signing type", func(t *testing.T) {
+		reg := &httpmock.Registry{}
+		defer reg.Verify(t)
+		reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/3"), httpmock.StatusStringResponse(200, `{"title":"sign"}`))
+
+		key, err := resolveSSHKey(&http.Client{Transport: reg}, "github.com", "3", shared.SigningKey)
+		require.NoError(t, err)
+		assert.Equal(t, shared.SigningKey, key.Type)
+	})
+
+	t.Run("ambiguous", func(t *testing.T) {
+		reg := &httpmock.Registry{}
+		defer reg.Verify(t)
+		reg.Register(httpmock.REST("GET", "user/keys/4"), httpmock.StatusStringResponse(200, `{"title":"auth"}`))
+		reg.Register(httpmock.REST("GET", "user/ssh_signing_keys/4"), httpmock.StatusStringResponse(200, `{"title":"sign"}`))
+
+		key, err := resolveSSHKey(&http.Client{Transport: reg}, "github.com", "4", "")
+		assert.Nil(t, key)
+		var ambiguous ambiguousKeyError
+		require.ErrorAs(t, err, &ambiguous)
+		assert.Equal(t, "4", ambiguous.KeyID)
+	})
 }

--- a/pkg/cmd/ssh-key/delete/http.go
+++ b/pkg/cmd/ssh-key/delete/http.go
@@ -1,18 +1,22 @@
 package delete
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/safeurl"
+	"github.com/cli/cli/v2/pkg/cmd/ssh-key/shared"
 )
 
 type sshKey struct {
 	Title string
+	Type  string
 }
 
-func deleteSSHKey(httpClient *http.Client, host string, keyID string) error {
-	path, err := safeurl.JoinPath("user", "keys", keyID)
+func deleteSSHKey(httpClient *http.Client, host, keyID, keyType string) error {
+	path, err := keyAPIPath(keyType, keyID)
 	if err != nil {
 		return err
 	}
@@ -22,9 +26,9 @@ func deleteSSHKey(httpClient *http.Client, host string, keyID string) error {
 	return api.NewClientFromHTTP(httpClient).REST(host, http.MethodDelete, path.String(), nil, nil)
 }
 
-func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, error) {
+func getSSHKey(httpClient *http.Client, host, keyID, keyType string) (*sshKey, error) {
 	var key sshKey
-	path, err := safeurl.JoinPath("user", "keys", keyID)
+	path, err := keyAPIPath(keyType, keyID)
 	if err != nil {
 		return nil, err
 	}
@@ -35,6 +39,70 @@ func getSSHKey(httpClient *http.Client, host string, keyID string) (*sshKey, err
 	if err != nil {
 		return nil, err
 	}
-
+	key.Type = keyType
 	return &key, nil
+}
+
+// resolveSSHKey finds an SSH key by ID.
+//
+// Authentication and signing keys use independent ID namespaces. When keyType is
+// empty, both endpoints are checked. If the ID exists in only one namespace that
+// key is returned. If it exists in both, ambiguousKeyError is returned so the
+// caller can ask the user to disambiguate (or require --type).
+func resolveSSHKey(httpClient *http.Client, host, keyID, keyType string) (*sshKey, error) {
+	if keyType != "" {
+		return getSSHKey(httpClient, host, keyID, keyType)
+	}
+
+	authKey, authErr := getSSHKey(httpClient, host, keyID, shared.AuthenticationKey)
+	signingKey, signingErr := getSSHKey(httpClient, host, keyID, shared.SigningKey)
+
+	authFound := authErr == nil
+	signingFound := signingErr == nil
+
+	switch {
+	case authFound && signingFound:
+		return nil, ambiguousKeyError{KeyID: keyID, AuthTitle: authKey.Title, SigningTitle: signingKey.Title}
+	case authFound:
+		return authKey, nil
+	case signingFound:
+		return signingKey, nil
+	}
+
+	if isNotFound(authErr) && isNotFound(signingErr) {
+		return nil, fmt.Errorf("SSH key not found: %s", keyID)
+	}
+	if !isNotFound(authErr) {
+		return nil, authErr
+	}
+	return nil, signingErr
+}
+
+func keyAPIPath(keyType, keyID string) (*safeurl.MutableSafeURL, error) {
+	switch keyType {
+	case shared.SigningKey:
+		return safeurl.JoinPath("user", "ssh_signing_keys", keyID)
+	case shared.AuthenticationKey, "":
+		return safeurl.JoinPath("user", "keys", keyID)
+	default:
+		return nil, fmt.Errorf("invalid SSH key type: %q", keyType)
+	}
+}
+
+func isNotFound(err error) bool {
+	var httpErr api.HTTPError
+	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound
+}
+
+type ambiguousKeyError struct {
+	KeyID        string
+	AuthTitle    string
+	SigningTitle string
+}
+
+func (e ambiguousKeyError) Error() string {
+	return fmt.Sprintf(
+		"SSH key ID %s matches both an authentication key (%q) and a signing key (%q); re-run with --type authentication or --type signing",
+		e.KeyID, e.AuthTitle, e.SigningTitle,
+	)
 }


### PR DESCRIPTION
Fixes #14064

## Description
`gh ssh-key delete` only hit `/user/keys/{id}`, so signing keys created with `gh ssh-key add --type signing` (and shown by `gh ssh-key list`) could not be deleted.

This change:
- Resolves the key ID against both authentication and signing endpoints
- Deletes via the matching endpoint
- Adds optional `--type` for the rare case where the same numeric ID exists in both namespaces (interactive prompt when a TTY is available)
- Extends unit tests for signing keys, dual lookup, ambiguity, and `--type`

## Testing
- [x] `go test ./pkg/cmd/ssh-key/delete/`
