### PR TITLE
Add webhook as an official extension

### DIFF
--- a/pkg/extensions/official.go
+++ b/pkg/extensions/official.go
@@ -25,6 +25,7 @@ func (e *OfficialExtension) Repository() ghrepo.Interface {
 var OfficialExtensions = []OfficialExtension{
 	{Name: "aw", Owner: "github", Repo: "gh-aw"},
 	{Name: "stack", Owner: "github", Repo: "gh-stack"},
+	{Name: "webhook", Owner: "cli", Repo: "gh-webhook"},
 }
 
 // IsOfficial reports whether the given extension command name and owner

--- a/pkg/extensions/official_test.go
+++ b/pkg/extensions/official_test.go
@@ -28,6 +28,12 @@ func TestIsOfficial(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "known official extension owned by cli matches",
+			extName:  "webhook",
+			extOwner: "cli",
+			want:     true,
+		},
+		{
 			name:     "official name with different owner is not official",
 			extName:  "stack",
 			extOwner: "williammartin",


### PR DESCRIPTION
N/A

### Description

Adds `cli/gh-webhook` to the registry of official GitHub CLI extensions. This allows `gh` to recognize the `webhook` command as official and offer to install it when invoked but not yet installed.

### How did you test this change?

Not tested manually. This registry-only change has no distinct user-visible behavior that can be exercised without publishing and installing the extension.

### Key points

The extension is owned by the `cli` organization rather than `github`, so both the command name and owner are registered explicitly.

### Notes for reviewers

Start with `pkg/extensions/official.go`, then review the matching lookup case in `pkg/extensions/official_test.go`.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
