### PR TITLE
chore: bump toolchain to go1.26.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cli/cli/v2
 
 go 1.26.0
 
-toolchain go1.26.7
+toolchain go1.26.8
 
 require (
 	charm.land/bubbles/v2 v2.2.1


### PR DESCRIPTION
### Description

This PR bumps Go toolchain to the latest patch (1.26.8).

### How did you test this change?

N/A

### Key points

N/A

### Notes for reviewers

N/A

### Authorship and follow-up

Who wrote this:

- [x] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @babakks will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
