### PR TITLE
Add GitHub request ID telemetry

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
@@ -329,9 +330,10 @@ func TestHTTPHeaders(t *testing.T) {
 
 	ios, _, _, stderr := iostreams.Test()
 	httpClient, err := NewHTTPClient(HTTPClientOptions{
-		AppVersion: "v1.2.3",
-		Config:     tinyConfig{serverHostname(t, ts.URL) + ":oauth_token": "MYTOKEN"},
-		Log:        ios.ErrOut,
+		AppVersion:          "v1.2.3",
+		Config:              tinyConfig{serverHostname(t, ts.URL) + ":oauth_token": "MYTOKEN"},
+		Log:                 ios.ErrOut,
+		APIRequestTelemetry: &telemetry.NoOpService{},
 	})
 	assert.NoError(t, err)
 	client := NewClientFromHTTP(httpClient)

--- a/api/http_client.go
+++ b/api/http_client.go
@@ -29,7 +29,7 @@ type HTTPClientOptions struct {
 	Log                io.Writer
 	LogColorize        bool
 	LogVerboseHTTP     bool
-	RequestIDRecorder  ghtelemetry.RequestIDRecorder
+	APIRequestRecorder ghtelemetry.APIRequestRecorder
 	SkipDefaultHeaders bool
 	TelemetryDisabler  ghtelemetry.Disabler
 	Transport          http.RoundTripper
@@ -47,14 +47,14 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 	if opts.Transport != nil {
 		clientOpts.Transport = opts.Transport
 	}
-	if opts.RequestIDRecorder != nil {
+	if opts.APIRequestRecorder != nil {
 		transport := clientOpts.Transport
 		if transport == nil {
 			transport = http.DefaultTransport
 		}
 		clientOpts.Transport = requestIDTransport{
 			wrappedTransport: transport,
-			recorder:         opts.RequestIDRecorder,
+			recorder:         opts.APIRequestRecorder,
 		}
 	}
 
@@ -248,13 +248,15 @@ type telemetryDisablerTransport struct {
 
 type requestIDTransport struct {
 	wrappedTransport http.RoundTripper
-	recorder         ghtelemetry.RequestIDRecorder
+	recorder         ghtelemetry.APIRequestRecorder
 }
 
 func (t requestIDTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	res, err := t.wrappedTransport.RoundTrip(req)
 	if err == nil && res != nil {
-		t.recorder.RecordRequestID(res.Header.Get("X-GitHub-Request-Id"))
+		if requestID := strings.TrimSpace(res.Header.Get("X-GitHub-Request-Id")); requestID != "" {
+			t.recorder.RecordAPIRequest(ghtelemetry.APIRequest{RequestID: requestID})
+		}
 	}
 	return res, err
 }

--- a/api/http_client.go
+++ b/api/http_client.go
@@ -22,14 +22,17 @@ type config interface {
 type HTTPClientOptions struct {
 	AppVersion         string
 	InvokingAgent      string
+	CacheDir           string
 	CacheTTL           time.Duration
 	Config             config
 	EnableCache        bool
 	Log                io.Writer
 	LogColorize        bool
 	LogVerboseHTTP     bool
+	RequestIDRecorder  ghtelemetry.RequestIDRecorder
 	SkipDefaultHeaders bool
 	TelemetryDisabler  ghtelemetry.Disabler
+	Transport          http.RoundTripper
 }
 
 func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
@@ -40,6 +43,19 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 		AuthToken:          "none",
 		LogIgnoreEnv:       true,
 		SkipDefaultHeaders: opts.SkipDefaultHeaders,
+	}
+	if opts.Transport != nil {
+		clientOpts.Transport = opts.Transport
+	}
+	if opts.RequestIDRecorder != nil {
+		transport := clientOpts.Transport
+		if transport == nil {
+			transport = http.DefaultTransport
+		}
+		clientOpts.Transport = requestIDTransport{
+			wrappedTransport: transport,
+			recorder:         opts.RequestIDRecorder,
+		}
 	}
 
 	debugEnabled, debugValue := utils.IsDebugEnabled()
@@ -66,6 +82,7 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 
 	if opts.EnableCache {
 		clientOpts.EnableCache = opts.EnableCache
+		clientOpts.CacheDir = opts.CacheDir
 		clientOpts.CacheTTL = opts.CacheTTL
 	}
 
@@ -227,6 +244,19 @@ func getHostname(r *http.Request) string {
 type telemetryDisablerTransport struct {
 	wrappedTransport  http.RoundTripper
 	telemetryDisabler ghtelemetry.Disabler
+}
+
+type requestIDTransport struct {
+	wrappedTransport http.RoundTripper
+	recorder         ghtelemetry.RequestIDRecorder
+}
+
+func (t requestIDTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	res, err := t.wrappedTransport.RoundTrip(req)
+	if err == nil && res != nil {
+		t.recorder.RecordRequestID(res.Header.Get("X-GitHub-Request-Id"))
+	}
+	return res, err
 }
 
 func (t telemetryDisablerTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/api/http_client.go
+++ b/api/http_client.go
@@ -20,19 +20,16 @@ type config interface {
 }
 
 type HTTPClientOptions struct {
-	AppVersion         string
-	InvokingAgent      string
-	CacheDir           string
-	CacheTTL           time.Duration
-	Config             config
-	EnableCache        bool
-	Log                io.Writer
-	LogColorize        bool
-	LogVerboseHTTP     bool
-	APIRequestRecorder ghtelemetry.APIRequestRecorder
-	SkipDefaultHeaders bool
-	TelemetryDisabler  ghtelemetry.Disabler
-	Transport          http.RoundTripper
+	AppVersion          string
+	InvokingAgent       string
+	CacheTTL            time.Duration
+	Config              config
+	EnableCache         bool
+	Log                 io.Writer
+	LogColorize         bool
+	LogVerboseHTTP      bool
+	APIRequestTelemetry ghtelemetry.APIRequestTelemetry
+	SkipDefaultHeaders  bool
 }
 
 func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
@@ -44,18 +41,9 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 		LogIgnoreEnv:       true,
 		SkipDefaultHeaders: opts.SkipDefaultHeaders,
 	}
-	if opts.Transport != nil {
-		clientOpts.Transport = opts.Transport
-	}
-	if opts.APIRequestRecorder != nil {
-		transport := clientOpts.Transport
-		if transport == nil {
-			transport = http.DefaultTransport
-		}
-		clientOpts.Transport = requestIDTransport{
-			wrappedTransport: transport,
-			recorder:         opts.APIRequestRecorder,
-		}
+	clientOpts.Transport = requestIDTransport{
+		wrappedTransport: http.DefaultTransport,
+		recorder:         opts.APIRequestTelemetry,
 	}
 
 	debugEnabled, debugValue := utils.IsDebugEnabled()
@@ -82,7 +70,6 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 
 	if opts.EnableCache {
 		clientOpts.EnableCache = opts.EnableCache
-		clientOpts.CacheDir = opts.CacheDir
 		clientOpts.CacheTTL = opts.CacheTTL
 	}
 
@@ -95,11 +82,9 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 		client.Transport = AddAuthTokenHeader(client.Transport, opts.Config)
 	}
 
-	if opts.TelemetryDisabler != nil {
-		client.Transport = telemetryDisablerTransport{
-			wrappedTransport:  client.Transport,
-			telemetryDisabler: opts.TelemetryDisabler,
-		}
+	client.Transport = telemetryDisablerTransport{
+		wrappedTransport:  client.Transport,
+		telemetryDisabler: opts.APIRequestTelemetry,
 	}
 
 	return client, nil

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -242,12 +242,13 @@ func TestNewHTTPClient(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ios, _, _, stderr := iostreams.Test()
 			client, err := NewHTTPClient(HTTPClientOptions{
-				AppVersion:         tt.args.appVersion,
-				InvokingAgent:      tt.args.invokingAgent,
-				Config:             tt.args.config,
-				Log:                ios.ErrOut,
-				LogVerboseHTTP:     tt.args.logVerboseHTTP,
-				SkipDefaultHeaders: tt.args.skipDefaultHeaders,
+				AppVersion:          tt.args.appVersion,
+				InvokingAgent:       tt.args.invokingAgent,
+				Config:              tt.args.config,
+				Log:                 ios.ErrOut,
+				LogVerboseHTTP:      tt.args.logVerboseHTTP,
+				SkipDefaultHeaders:  tt.args.skipDefaultHeaders,
+				APIRequestTelemetry: &telemetry.NoOpService{},
 			})
 			require.NoError(t, err)
 
@@ -351,7 +352,7 @@ func TestHTTPClientSanitizeJSONControlCharactersC0(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewHTTPClient(HTTPClientOptions{})
+	client, err := NewHTTPClient(HTTPClientOptions{APIRequestTelemetry: &telemetry.NoOpService{}})
 	require.NoError(t, err)
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	require.NoError(t, err)
@@ -387,7 +388,7 @@ func TestHTTPClientSanitizeControlCharactersC1(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewHTTPClient(HTTPClientOptions{})
+	client, err := NewHTTPClient(HTTPClientOptions{APIRequestTelemetry: &telemetry.NoOpService{}})
 	require.NoError(t, err)
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	require.NoError(t, err)
@@ -405,7 +406,7 @@ func TestHTTPClientSanitizeControlCharactersC1(t *testing.T) {
 	assert.Equal(t, "monalisa¡", issue.Author.Login)
 }
 
-func TestNewHTTPClientTelemetryDisabler(t *testing.T) {
+func TestNewHTTPClientDisablesTelemetry(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -435,9 +436,9 @@ func TestNewHTTPClientTelemetryDisabler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			disabler := &fakeTelemetryDisabler{}
+			telemetry := &fakeAPIRequestRecorder{}
 			client, err := NewHTTPClient(HTTPClientOptions{
-				TelemetryDisabler: disabler,
+				APIRequestTelemetry: telemetry,
 			})
 			require.NoError(t, err)
 
@@ -448,62 +449,39 @@ func TestNewHTTPClientTelemetryDisabler(t *testing.T) {
 			res, err := client.Do(req)
 			require.NoError(t, err)
 			assert.Equal(t, 204, res.StatusCode)
-			assert.Equal(t, tt.wantDisabled, disabler.disabled, "Disable() called")
+			assert.Equal(t, tt.wantDisabled, telemetry.disabled, "Disable() called")
 		})
 	}
 }
 
-func TestNewHTTPClientWithoutTelemetryDisabler(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer ts.Close()
-
-	client, err := NewHTTPClient(HTTPClientOptions{})
-	require.NoError(t, err)
-
-	req, err := http.NewRequest("GET", ts.URL, nil)
-	require.NoError(t, err)
-	req.Host = "ghes.example.com"
-
-	res, err := client.Do(req)
-	require.NoError(t, err)
-	assert.Equal(t, 204, res.StatusCode)
-}
-
 func TestNewHTTPClientRecordsRequestIDs(t *testing.T) {
 	recorder := &fakeAPIRequestRecorder{}
-	responses := []*http.Response{
-		{
-			StatusCode: http.StatusFound,
-			Header: http.Header{
-				"Location":            []string{"https://api.github.com/final"},
-				"X-Github-Request-Id": []string{"REQUEST-1"},
-			},
-			Body: io.NopCloser(strings.NewReader("")),
-		},
-		{
-			StatusCode: http.StatusNoContent,
-			Header: http.Header{
-				"X-Github-Request-Id": []string{"REQUEST-2"},
-			},
-			Body: io.NopCloser(strings.NewReader("")),
-		},
-	}
-	transport := &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
-		res := responses[0]
-		responses = responses[1:]
-		res.Request = req
-		return res, nil
-	}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			w.Header().Set("X-GitHub-Request-Id", "REQUEST-1")
+			http.Redirect(w, r, "/final", http.StatusFound)
+		case "/final":
+			w.Header().Set("X-GitHub-Request-Id", "REQUEST-2")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
 	client, err := NewHTTPClient(HTTPClientOptions{
-		APIRequestRecorder: recorder,
-		Transport:          transport,
+		APIRequestTelemetry: recorder,
 	})
 	require.NoError(t, err)
+	client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+		req.Host = "github.com"
+		return nil
+	}
 
-	req, err := http.NewRequest("GET", "https://api.github.com/start", nil)
+	req, err := http.NewRequest("GET", server.URL+"/start", nil)
 	require.NoError(t, err)
+	req.Host = "github.com"
 	res, err := client.Do(req)
 	require.NoError(t, err)
 	res.Body.Close()
@@ -517,21 +495,20 @@ func TestNewHTTPClientRecordsRequestIDs(t *testing.T) {
 
 func TestNewHTTPClientDoesNotRecordMissingRequestID(t *testing.T) {
 	recorder := &fakeAPIRequestRecorder{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-GitHub-Request-Id", "  ")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
 	client, err := NewHTTPClient(HTTPClientOptions{
-		APIRequestRecorder: recorder,
-		Transport: &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusNoContent,
-				Header:     http.Header{"X-Github-Request-Id": []string{"  "}},
-				Body:       io.NopCloser(strings.NewReader("")),
-				Request:    req,
-			}, nil
-		}},
+		APIRequestTelemetry: recorder,
 	})
 	require.NoError(t, err)
 
-	req, err := http.NewRequest("GET", "https://api.github.com/", nil)
+	req, err := http.NewRequest("GET", server.URL, nil)
 	require.NoError(t, err)
+	req.Host = "github.com"
 	res, err := client.Do(req)
 	require.NoError(t, err)
 	res.Body.Close()
@@ -540,28 +517,28 @@ func TestNewHTTPClientDoesNotRecordMissingRequestID(t *testing.T) {
 }
 
 func TestNewHTTPClientDoesNotReplayCachedRequestIDs(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
 	recorder := &fakeAPIRequestRecorder{}
 	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("X-GitHub-Request-Id", fmt.Sprintf("REQUEST-%d", requestCount))
+		fmt.Fprint(w, "{}")
+	}))
+	defer server.Close()
+
 	client, err := NewHTTPClient(HTTPClientOptions{
-		CacheDir:           t.TempDir(),
-		CacheTTL:           time.Hour,
-		EnableCache:        true,
-		APIRequestRecorder: recorder,
-		Transport: &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
-			requestCount++
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Header:     http.Header{"X-Github-Request-Id": []string{fmt.Sprintf("REQUEST-%d", requestCount)}},
-				Body:       io.NopCloser(strings.NewReader("{}")),
-				Request:    req,
-			}, nil
-		}},
+		CacheTTL:            time.Hour,
+		EnableCache:         true,
+		APIRequestTelemetry: recorder,
 	})
 	require.NoError(t, err)
 
 	for range 2 {
-		req, err := http.NewRequest("GET", "https://api.github.com/repos/cli/cli", nil)
+		req, err := http.NewRequest("GET", server.URL+"/repos/cli/cli", nil)
 		require.NoError(t, err)
+		req.Host = "github.com"
 		res, err := client.Do(req)
 		require.NoError(t, err)
 		_, err = io.ReadAll(res.Body)
@@ -578,22 +555,20 @@ func TestNewHTTPClientDropsTelemetryForEnterpriseRequests(t *testing.T) {
 	recorder := telemetry.NewService(func(p telemetry.SendTelemetryPayload) {
 		payload = p
 	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-GitHub-Request-Id", "ENTERPRISE-REQUEST")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
 	client, err := NewHTTPClient(HTTPClientOptions{
-		APIRequestRecorder: recorder,
-		TelemetryDisabler:  recorder,
-		Transport: &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusNoContent,
-				Header:     http.Header{"X-Github-Request-Id": []string{"ENTERPRISE-REQUEST"}},
-				Body:       io.NopCloser(strings.NewReader("")),
-				Request:    req,
-			}, nil
-		}},
+		APIRequestTelemetry: recorder,
 	})
 	require.NoError(t, err)
 
-	req, err := http.NewRequest("GET", "https://ghes.example.com/api/v3/user", nil)
+	req, err := http.NewRequest("GET", server.URL+"/api/v3/user", nil)
 	require.NoError(t, err)
+	req.Host = "ghes.example.com"
 	res, err := client.Do(req)
 	require.NoError(t, err)
 	res.Body.Close()
@@ -649,14 +624,6 @@ func TestNewExternalHTTPClient(t *testing.T) {
 			assert.Empty(t, gotReq.Header.Values("time-zone"))
 		})
 	}
-}
-
-type fakeTelemetryDisabler struct {
-	disabled bool
-}
-
-func (f *fakeTelemetryDisabler) Disable() {
-	f.disabled = true
 }
 
 type fakeAPIRequestRecorder struct {

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -12,8 +12,10 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -468,6 +470,134 @@ func TestNewHTTPClientWithoutTelemetryDisabler(t *testing.T) {
 	assert.Equal(t, 204, res.StatusCode)
 }
 
+func TestNewHTTPClientRecordsRequestIDs(t *testing.T) {
+	recorder := &fakeRequestIDRecorder{}
+	responses := []*http.Response{
+		{
+			StatusCode: http.StatusFound,
+			Header: http.Header{
+				"Location":            []string{"https://api.github.com/final"},
+				"X-Github-Request-Id": []string{"REQUEST-1"},
+			},
+			Body: io.NopCloser(strings.NewReader("")),
+		},
+		{
+			StatusCode: http.StatusNoContent,
+			Header: http.Header{
+				"X-Github-Request-Id": []string{"REQUEST-2"},
+			},
+			Body: io.NopCloser(strings.NewReader("")),
+		},
+	}
+	transport := &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+		res := responses[0]
+		responses = responses[1:]
+		res.Request = req
+		return res, nil
+	}}
+	client, err := NewHTTPClient(HTTPClientOptions{
+		RequestIDRecorder: recorder,
+		Transport:         transport,
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("GET", "https://api.github.com/start", nil)
+	require.NoError(t, err)
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	res.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, res.StatusCode)
+	assert.Equal(t, []string{"REQUEST-1", "REQUEST-2"}, recorder.requestIDs)
+}
+
+func TestNewHTTPClientDoesNotRecordMissingRequestID(t *testing.T) {
+	recorder := &fakeRequestIDRecorder{}
+	client, err := NewHTTPClient(HTTPClientOptions{
+		RequestIDRecorder: recorder,
+		Transport: &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Header:     http.Header{"X-Github-Request-Id": []string{"  "}},
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}, nil
+		}},
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("GET", "https://api.github.com/", nil)
+	require.NoError(t, err)
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	res.Body.Close()
+
+	assert.Empty(t, recorder.requestIDs)
+}
+
+func TestNewHTTPClientDoesNotReplayCachedRequestIDs(t *testing.T) {
+	recorder := &fakeRequestIDRecorder{}
+	requestCount := 0
+	client, err := NewHTTPClient(HTTPClientOptions{
+		CacheDir:          t.TempDir(),
+		CacheTTL:          time.Hour,
+		EnableCache:       true,
+		RequestIDRecorder: recorder,
+		Transport: &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			requestCount++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"X-Github-Request-Id": []string{fmt.Sprintf("REQUEST-%d", requestCount)}},
+				Body:       io.NopCloser(strings.NewReader("{}")),
+				Request:    req,
+			}, nil
+		}},
+	})
+	require.NoError(t, err)
+
+	for range 2 {
+		req, err := http.NewRequest("GET", "https://api.github.com/repos/cli/cli", nil)
+		require.NoError(t, err)
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		_, err = io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+	}
+
+	assert.Equal(t, 1, requestCount)
+	assert.Equal(t, []string{"REQUEST-1"}, recorder.requestIDs)
+}
+
+func TestNewHTTPClientDropsTelemetryForEnterpriseRequests(t *testing.T) {
+	var payload telemetry.SendTelemetryPayload
+	recorder := telemetry.NewService(func(p telemetry.SendTelemetryPayload) {
+		payload = p
+	})
+	client, err := NewHTTPClient(HTTPClientOptions{
+		RequestIDRecorder: recorder,
+		TelemetryDisabler: recorder,
+		Transport: &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Header:     http.Header{"X-Github-Request-Id": []string{"ENTERPRISE-REQUEST"}},
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}, nil
+		}},
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("GET", "https://ghes.example.com/api/v3/user", nil)
+	require.NoError(t, err)
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	res.Body.Close()
+	recorder.Flush()
+
+	assert.Empty(t, payload.Events)
+}
+
 func TestNewExternalHTTPClient(t *testing.T) {
 	tests := []struct {
 		name string
@@ -522,6 +652,22 @@ type fakeTelemetryDisabler struct {
 }
 
 func (f *fakeTelemetryDisabler) Disable() {
+	f.disabled = true
+}
+
+type fakeRequestIDRecorder struct {
+	requestIDs []string
+	disabled   bool
+}
+
+func (f *fakeRequestIDRecorder) RecordRequestID(requestID string) {
+	requestID = strings.TrimSpace(requestID)
+	if requestID != "" {
+		f.requestIDs = append(f.requestIDs, requestID)
+	}
+}
+
+func (f *fakeRequestIDRecorder) Disable() {
 	f.disabled = true
 }
 

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
@@ -471,7 +472,7 @@ func TestNewHTTPClientWithoutTelemetryDisabler(t *testing.T) {
 }
 
 func TestNewHTTPClientRecordsRequestIDs(t *testing.T) {
-	recorder := &fakeRequestIDRecorder{}
+	recorder := &fakeAPIRequestRecorder{}
 	responses := []*http.Response{
 		{
 			StatusCode: http.StatusFound,
@@ -496,8 +497,8 @@ func TestNewHTTPClientRecordsRequestIDs(t *testing.T) {
 		return res, nil
 	}}
 	client, err := NewHTTPClient(HTTPClientOptions{
-		RequestIDRecorder: recorder,
-		Transport:         transport,
+		APIRequestRecorder: recorder,
+		Transport:          transport,
 	})
 	require.NoError(t, err)
 
@@ -508,13 +509,16 @@ func TestNewHTTPClientRecordsRequestIDs(t *testing.T) {
 	res.Body.Close()
 
 	assert.Equal(t, http.StatusNoContent, res.StatusCode)
-	assert.Equal(t, []string{"REQUEST-1", "REQUEST-2"}, recorder.requestIDs)
+	assert.Equal(t, []ghtelemetry.APIRequest{
+		{RequestID: "REQUEST-1"},
+		{RequestID: "REQUEST-2"},
+	}, recorder.requests)
 }
 
 func TestNewHTTPClientDoesNotRecordMissingRequestID(t *testing.T) {
-	recorder := &fakeRequestIDRecorder{}
+	recorder := &fakeAPIRequestRecorder{}
 	client, err := NewHTTPClient(HTTPClientOptions{
-		RequestIDRecorder: recorder,
+		APIRequestRecorder: recorder,
 		Transport: &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusNoContent,
@@ -532,17 +536,17 @@ func TestNewHTTPClientDoesNotRecordMissingRequestID(t *testing.T) {
 	require.NoError(t, err)
 	res.Body.Close()
 
-	assert.Empty(t, recorder.requestIDs)
+	assert.Empty(t, recorder.requests)
 }
 
 func TestNewHTTPClientDoesNotReplayCachedRequestIDs(t *testing.T) {
-	recorder := &fakeRequestIDRecorder{}
+	recorder := &fakeAPIRequestRecorder{}
 	requestCount := 0
 	client, err := NewHTTPClient(HTTPClientOptions{
-		CacheDir:          t.TempDir(),
-		CacheTTL:          time.Hour,
-		EnableCache:       true,
-		RequestIDRecorder: recorder,
+		CacheDir:           t.TempDir(),
+		CacheTTL:           time.Hour,
+		EnableCache:        true,
+		APIRequestRecorder: recorder,
 		Transport: &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
 			requestCount++
 			return &http.Response{
@@ -566,7 +570,7 @@ func TestNewHTTPClientDoesNotReplayCachedRequestIDs(t *testing.T) {
 	}
 
 	assert.Equal(t, 1, requestCount)
-	assert.Equal(t, []string{"REQUEST-1"}, recorder.requestIDs)
+	assert.Equal(t, []ghtelemetry.APIRequest{{RequestID: "REQUEST-1"}}, recorder.requests)
 }
 
 func TestNewHTTPClientDropsTelemetryForEnterpriseRequests(t *testing.T) {
@@ -575,8 +579,8 @@ func TestNewHTTPClientDropsTelemetryForEnterpriseRequests(t *testing.T) {
 		payload = p
 	})
 	client, err := NewHTTPClient(HTTPClientOptions{
-		RequestIDRecorder: recorder,
-		TelemetryDisabler: recorder,
+		APIRequestRecorder: recorder,
+		TelemetryDisabler:  recorder,
 		Transport: &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusNoContent,
@@ -655,19 +659,16 @@ func (f *fakeTelemetryDisabler) Disable() {
 	f.disabled = true
 }
 
-type fakeRequestIDRecorder struct {
-	requestIDs []string
-	disabled   bool
+type fakeAPIRequestRecorder struct {
+	requests []ghtelemetry.APIRequest
+	disabled bool
 }
 
-func (f *fakeRequestIDRecorder) RecordRequestID(requestID string) {
-	requestID = strings.TrimSpace(requestID)
-	if requestID != "" {
-		f.requestIDs = append(f.requestIDs, requestID)
-	}
+func (f *fakeAPIRequestRecorder) RecordAPIRequest(request ghtelemetry.APIRequest) {
+	f.requests = append(f.requests, request)
 }
 
-func (f *fakeRequestIDRecorder) Disable() {
+func (f *fakeAPIRequestRecorder) Disable() {
 	f.disabled = true
 }
 

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
@@ -356,9 +357,10 @@ func TestRequestHeadersAgainstRealTransport(t *testing.T) {
 
 	ios, _, _, _ := iostreams.Test()
 	httpClient, err := NewHTTPClient(HTTPClientOptions{
-		AppVersion: "v1.2.3",
-		Config:     tinyConfig{serverHostname(t, ts.URL) + ":oauth_token": "MYTOKEN"},
-		Log:        ios.ErrOut,
+		AppVersion:          "v1.2.3",
+		Config:              tinyConfig{serverHostname(t, ts.URL) + ":oauth_token": "MYTOKEN"},
+		Log:                 ios.ErrOut,
+		APIRequestTelemetry: &telemetry.NoOpService{},
 	})
 	require.NoError(t, err)
 	client := NewClientFromHTTP(httpClient)

--- a/internal/gh/ghtelemetry/telemetry.go
+++ b/internal/gh/ghtelemetry/telemetry.go
@@ -29,6 +29,13 @@ type APIRequestRecorder interface {
 	RecordAPIRequest(request APIRequest)
 }
 
+// APIRequestTelemetry records GitHub API requests and disables telemetry when
+// requests cross a host boundary where telemetry is not allowed.
+type APIRequestTelemetry interface {
+	APIRequestRecorder
+	Disabler
+}
+
 type CommandRecorder interface {
 	EventRecorder
 	SetSampleRate(rate int)
@@ -36,7 +43,7 @@ type CommandRecorder interface {
 
 type Service interface {
 	CommandRecorder
-	APIRequestRecorder
+	APIRequestTelemetry
 	Flush()
 }
 

--- a/internal/gh/ghtelemetry/telemetry.go
+++ b/internal/gh/ghtelemetry/telemetry.go
@@ -19,6 +19,11 @@ type EventRecorder interface {
 	Disabler
 }
 
+// RequestIDRecorder records GitHub server request IDs for invocation correlation.
+type RequestIDRecorder interface {
+	RecordRequestID(requestID string)
+}
+
 type CommandRecorder interface {
 	EventRecorder
 	SetSampleRate(rate int)
@@ -26,6 +31,7 @@ type CommandRecorder interface {
 
 type Service interface {
 	CommandRecorder
+	RequestIDRecorder
 	Flush()
 }
 

--- a/internal/gh/ghtelemetry/telemetry.go
+++ b/internal/gh/ghtelemetry/telemetry.go
@@ -19,9 +19,14 @@ type EventRecorder interface {
 	Disabler
 }
 
-// RequestIDRecorder records GitHub server request IDs for invocation correlation.
-type RequestIDRecorder interface {
-	RecordRequestID(requestID string)
+// APIRequest contains telemetry-safe metadata about a GitHub API request.
+type APIRequest struct {
+	RequestID string
+}
+
+// APIRequestRecorder records GitHub API requests for invocation correlation.
+type APIRequestRecorder interface {
+	RecordAPIRequest(request APIRequest)
 }
 
 type CommandRecorder interface {
@@ -31,7 +36,7 @@ type CommandRecorder interface {
 
 type Service interface {
 	CommandRecorder
-	RequestIDRecorder
+	APIRequestRecorder
 	Flush()
 }
 

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -335,6 +335,8 @@ func checkForUpdate(ctx context.Context, f *cmdutil.Factory, currentVersion stri
 	if err != nil {
 		return nil, err
 	}
+	// Update checks use the invocation's GitHub client, so their server request IDs
+	// are intentionally correlated with the invocation that triggered the check.
 	stateFilePath := filepath.Join(config.StateDir(), "state.yml")
 	return update.CheckForUpdate(ctx, httpClient, stateFilePath, updaterEnabled, currentVersion)
 }

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -335,8 +335,6 @@ func checkForUpdate(ctx context.Context, f *cmdutil.Factory, currentVersion stri
 	if err != nil {
 		return nil, err
 	}
-	// Update checks use the invocation's GitHub client, so their server request IDs
-	// are intentionally correlated with the invocation that triggered the check.
 	stateFilePath := filepath.Join(config.StateDir(), "state.yml")
 	return update.CheckForUpdate(ctx, httpClient, stateFilePath, updaterEnabled, currentVersion)
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -28,6 +28,10 @@ import (
 
 const deviceIDFileName = "device-id"
 
+// Request events repeat common dimensions in the wire payload. Keep the cap
+// conservative so they cannot crowd command telemetry out of the 16 KB payload.
+const maxRequestIDEvents = 10
+
 // stateDirFunc returns the state directory path. Can be replaced in tests.
 var stateDirFunc = config.StateDir
 
@@ -262,7 +266,8 @@ type service struct {
 
 	events []recordedEvent
 
-	disabled bool
+	requestIDCount int
+	disabled       bool
 }
 
 func (s *service) Disable() {
@@ -277,6 +282,35 @@ func (s *service) Record(event ghtelemetry.Event) {
 	defer s.mu.Unlock()
 
 	s.events = append(s.events, recordedEvent{event: event, recordedAt: time.Now()})
+}
+
+func (s *service) RecordRequestID(requestID string) {
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.disabled {
+		return
+	}
+
+	s.requestIDCount++
+	if s.requestIDCount > maxRequestIDEvents {
+		return
+	}
+
+	s.events = append(s.events, recordedEvent{
+		event: ghtelemetry.Event{
+			Type: "api_request",
+			Dimensions: ghtelemetry.Dimensions{
+				"request_id": requestID,
+			},
+		},
+		recordedAt: time.Now(),
+	})
 }
 
 func (s *service) SetSampleRate(rate int) {
@@ -308,6 +342,19 @@ func (s *service) Flush() {
 	events := s.events
 	if s.disabled {
 		events = nil
+	}
+
+	if len(events) > 0 && s.requestIDCount > maxRequestIDEvents {
+		events = append(events, recordedEvent{
+			event: ghtelemetry.Event{
+				Type: "api_request_summary",
+				Measures: ghtelemetry.Measures{
+					"request_count":          int64(s.requestIDCount),
+					"recorded_request_count": maxRequestIDEvents,
+				},
+			},
+			recordedAt: time.Now(),
+		})
 	}
 
 	payload := SendTelemetryPayload{
@@ -417,6 +464,8 @@ func SpawnSendTelemetry(executable string, payload SendTelemetryPayload) {
 type NoOpService struct{}
 
 func (s *NoOpService) Record(event ghtelemetry.Event) {}
+
+func (s *NoOpService) RecordRequestID(requestID string) {}
 
 func (s *NoOpService) Disable() {}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -28,9 +28,9 @@ import (
 
 const deviceIDFileName = "device-id"
 
-// Request events repeat common dimensions in the wire payload. Keep the cap
-// conservative so they cannot crowd command telemetry out of the 16 KB payload.
-const maxRequestIDEvents = 10
+// Leave room in the 16 KB payload for common dimensions, command telemetry,
+// and other invocation events.
+const maxRequestIDsEncodedSize = 8 * 1024
 
 // stateDirFunc returns the state directory path. Can be replaced in tests.
 var stateDirFunc = config.StateDir
@@ -266,8 +266,10 @@ type service struct {
 
 	events []recordedEvent
 
-	requestIDCount int
-	disabled       bool
+	requestIDs            []string
+	requestIDsEncodedSize int
+	apiRequestCount       int
+	disabled              bool
 }
 
 func (s *service) Disable() {
@@ -284,8 +286,8 @@ func (s *service) Record(event ghtelemetry.Event) {
 	s.events = append(s.events, recordedEvent{event: event, recordedAt: time.Now()})
 }
 
-func (s *service) RecordRequestID(requestID string) {
-	requestID = strings.TrimSpace(requestID)
+func (s *service) RecordAPIRequest(request ghtelemetry.APIRequest) {
+	requestID := strings.TrimSpace(request.RequestID)
 	if requestID == "" {
 		return
 	}
@@ -297,20 +299,22 @@ func (s *service) RecordRequestID(requestID string) {
 		return
 	}
 
-	s.requestIDCount++
-	if s.requestIDCount > maxRequestIDEvents {
+	s.apiRequestCount++
+
+	encodedRequestID, err := json.Marshal(requestID)
+	if err != nil {
+		return
+	}
+	size := len(encodedRequestID) - 2
+	if len(s.requestIDs) > 0 {
+		size++
+	}
+	if s.requestIDsEncodedSize+size > maxRequestIDsEncodedSize {
 		return
 	}
 
-	s.events = append(s.events, recordedEvent{
-		event: ghtelemetry.Event{
-			Type: "api_request",
-			Dimensions: ghtelemetry.Dimensions{
-				"request_id": requestID,
-			},
-		},
-		recordedAt: time.Now(),
-	})
+	s.requestIDs = append(s.requestIDs, requestID)
+	s.requestIDsEncodedSize += size
 }
 
 func (s *service) SetSampleRate(rate int) {
@@ -344,13 +348,16 @@ func (s *service) Flush() {
 		events = nil
 	}
 
-	if len(events) > 0 && s.requestIDCount > maxRequestIDEvents {
+	if len(s.requestIDs) > 0 && !s.disabled {
 		events = append(events, recordedEvent{
 			event: ghtelemetry.Event{
-				Type: "api_request_summary",
+				Type: "api_requests",
+				Dimensions: ghtelemetry.Dimensions{
+					"request_ids": strings.Join(s.requestIDs, ","),
+				},
 				Measures: ghtelemetry.Measures{
-					"request_count":          int64(s.requestIDCount),
-					"recorded_request_count": maxRequestIDEvents,
+					"request_count":          int64(s.apiRequestCount),
+					"recorded_request_count": int64(len(s.requestIDs)),
 				},
 			},
 			recordedAt: time.Now(),
@@ -465,7 +472,7 @@ type NoOpService struct{}
 
 func (s *NoOpService) Record(event ghtelemetry.Event) {}
 
-func (s *NoOpService) RecordRequestID(requestID string) {}
+func (s *NoOpService) RecordAPIRequest(request ghtelemetry.APIRequest) {}
 
 func (s *NoOpService) Disable() {}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -356,8 +356,8 @@ func (s *service) Flush() {
 					"request_ids": strings.Join(s.requestIDs, ","),
 				},
 				Measures: ghtelemetry.Measures{
-					"request_count":          int64(s.apiRequestCount),
-					"recorded_request_count": int64(len(s.requestIDs)),
+					"observed_request_count":   int64(s.apiRequestCount),
+					"omitted_request_id_count": int64(s.apiRequestCount - len(s.requestIDs)),
 				},
 			},
 			recordedAt: time.Now(),

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -2,7 +2,9 @@ package telemetry
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
@@ -613,6 +615,75 @@ func TestServiceSampling(t *testing.T) {
 	})
 }
 
+func TestServiceRecordRequestID(t *testing.T) {
+	t.Cleanup(stubDeviceID("test-device"))
+
+	var captured SendTelemetryPayload
+	svc := newService(func(p SendTelemetryPayload) { captured = p }, nil)
+	svc.RecordRequestID(" REQUEST-1 ")
+	svc.RecordRequestID("")
+	svc.Record(ghtelemetry.Event{
+		Type:       "command_invocation",
+		Dimensions: ghtelemetry.Dimensions{"command": "gh pr list"},
+	})
+	svc.Flush()
+
+	require.Len(t, captured.Events, 2)
+	requestEvent := captured.Events[0]
+	commandEvent := captured.Events[1]
+	assert.Equal(t, "api_request", requestEvent.Type)
+	assert.Equal(t, "REQUEST-1", requestEvent.Dimensions["request_id"])
+	assert.NotEmpty(t, requestEvent.Dimensions["invocation_id"])
+	assert.Equal(t, "command_invocation", commandEvent.Type)
+	assert.Equal(t, requestEvent.Dimensions["invocation_id"], commandEvent.Dimensions["invocation_id"])
+	assert.NotContains(t, commandEvent.Dimensions, "request_id")
+}
+
+func TestServiceBoundsRequestIDEvents(t *testing.T) {
+	t.Cleanup(stubDeviceID("test-device"))
+
+	var captured SendTelemetryPayload
+	svc := newService(func(p SendTelemetryPayload) { captured = p }, ghtelemetry.Dimensions{
+		"version":             "2.99.0",
+		"is_tty":              "true",
+		"agent":               "copilot_cli",
+		"ci":                  "false",
+		"github_actions":      "false",
+		"accessible_colors":   "false",
+		"accessible_prompter": "false",
+		"color_labels":        "false",
+		"spinner_disabled":    "false",
+		"sample_rate":         "1",
+	})
+	for i := 0; i < maxRequestIDEvents+5; i++ {
+		svc.RecordRequestID(fmt.Sprintf("REQUEST-%d", i))
+	}
+	svc.Record(ghtelemetry.Event{Type: "command_invocation"})
+	svc.Flush()
+
+	require.Len(t, captured.Events, maxRequestIDEvents+2)
+	assert.Equal(t, "command_invocation", captured.Events[maxRequestIDEvents].Type)
+	summary := captured.Events[maxRequestIDEvents+1]
+	assert.Equal(t, "api_request_summary", summary.Type)
+	assert.Equal(t, int64(maxRequestIDEvents+5), summary.Measures["request_count"])
+	assert.Equal(t, int64(maxRequestIDEvents), summary.Measures["recorded_request_count"])
+
+	payloadBytes, err := json.Marshal(captured)
+	require.NoError(t, err)
+	assert.Less(t, len(payloadBytes), maxPayloadSize)
+}
+
+func TestServiceDoesNotRecordRequestIDAfterDisable(t *testing.T) {
+	t.Cleanup(stubDeviceID("test-device"))
+
+	svc := newService(func(SendTelemetryPayload) {}, nil)
+	svc.Disable()
+	svc.RecordRequestID("REQUEST-1")
+
+	assert.Empty(t, svc.events)
+	assert.Zero(t, svc.requestIDCount)
+}
+
 func TestWithAdditionalCommonDimensions(t *testing.T) {
 	t.Cleanup(stubDeviceID("test-device"))
 
@@ -700,6 +771,7 @@ func TestNoOpService(t *testing.T) {
 	svc := &NoOpService{}
 	// All methods should be safe to call without panicking
 	svc.Record(ghtelemetry.Event{Type: "test"})
+	svc.RecordRequestID("REQUEST-1")
 	svc.Disable()
 	svc.SetSampleRate(50)
 	svc.Flush()

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -615,13 +615,13 @@ func TestServiceSampling(t *testing.T) {
 	})
 }
 
-func TestServiceRecordRequestID(t *testing.T) {
+func TestServiceRecordAPIRequest(t *testing.T) {
 	t.Cleanup(stubDeviceID("test-device"))
 
 	var captured SendTelemetryPayload
 	svc := newService(func(p SendTelemetryPayload) { captured = p }, nil)
-	svc.RecordRequestID(" REQUEST-1 ")
-	svc.RecordRequestID("")
+	svc.RecordAPIRequest(ghtelemetry.APIRequest{RequestID: " REQUEST-1 "})
+	svc.RecordAPIRequest(ghtelemetry.APIRequest{})
 	svc.Record(ghtelemetry.Event{
 		Type:       "command_invocation",
 		Dimensions: ghtelemetry.Dimensions{"command": "gh pr list"},
@@ -629,17 +629,19 @@ func TestServiceRecordRequestID(t *testing.T) {
 	svc.Flush()
 
 	require.Len(t, captured.Events, 2)
-	requestEvent := captured.Events[0]
-	commandEvent := captured.Events[1]
-	assert.Equal(t, "api_request", requestEvent.Type)
-	assert.Equal(t, "REQUEST-1", requestEvent.Dimensions["request_id"])
+	commandEvent := captured.Events[0]
+	requestEvent := captured.Events[1]
+	assert.Equal(t, "api_requests", requestEvent.Type)
+	assert.Equal(t, "REQUEST-1", requestEvent.Dimensions["request_ids"])
+	assert.Equal(t, int64(1), requestEvent.Measures["request_count"])
+	assert.Equal(t, int64(1), requestEvent.Measures["recorded_request_count"])
 	assert.NotEmpty(t, requestEvent.Dimensions["invocation_id"])
 	assert.Equal(t, "command_invocation", commandEvent.Type)
 	assert.Equal(t, requestEvent.Dimensions["invocation_id"], commandEvent.Dimensions["invocation_id"])
-	assert.NotContains(t, commandEvent.Dimensions, "request_id")
+	assert.NotContains(t, commandEvent.Dimensions, "request_ids")
 }
 
-func TestServiceBoundsRequestIDEvents(t *testing.T) {
+func TestServiceBoundsAPIRequests(t *testing.T) {
 	t.Cleanup(stubDeviceID("test-device"))
 
 	var captured SendTelemetryPayload
@@ -655,33 +657,38 @@ func TestServiceBoundsRequestIDEvents(t *testing.T) {
 		"spinner_disabled":    "false",
 		"sample_rate":         "1",
 	})
-	for i := 0; i < maxRequestIDEvents+5; i++ {
-		svc.RecordRequestID(fmt.Sprintf("REQUEST-%d", i))
+	const requestCount = 300
+	for i := 0; i < requestCount; i++ {
+		svc.RecordAPIRequest(ghtelemetry.APIRequest{
+			RequestID: fmt.Sprintf("REQUEST-%04d:%s", i, strings.Repeat("A", 24)),
+		})
 	}
 	svc.Record(ghtelemetry.Event{Type: "command_invocation"})
 	svc.Flush()
 
-	require.Len(t, captured.Events, maxRequestIDEvents+2)
-	assert.Equal(t, "command_invocation", captured.Events[maxRequestIDEvents].Type)
-	summary := captured.Events[maxRequestIDEvents+1]
-	assert.Equal(t, "api_request_summary", summary.Type)
-	assert.Equal(t, int64(maxRequestIDEvents+5), summary.Measures["request_count"])
-	assert.Equal(t, int64(maxRequestIDEvents), summary.Measures["recorded_request_count"])
+	require.Len(t, captured.Events, 2)
+	assert.Equal(t, "command_invocation", captured.Events[0].Type)
+	requests := captured.Events[1]
+	assert.Equal(t, "api_requests", requests.Type)
+	assert.Equal(t, int64(requestCount), requests.Measures["request_count"])
+	assert.Less(t, requests.Measures["recorded_request_count"], int64(requestCount))
+	assert.LessOrEqual(t, len(requests.Dimensions["request_ids"]), maxRequestIDsEncodedSize)
 
 	payloadBytes, err := json.Marshal(captured)
 	require.NoError(t, err)
 	assert.Less(t, len(payloadBytes), maxPayloadSize)
 }
 
-func TestServiceDoesNotRecordRequestIDAfterDisable(t *testing.T) {
+func TestServiceDoesNotRecordAPIRequestAfterDisable(t *testing.T) {
 	t.Cleanup(stubDeviceID("test-device"))
 
 	svc := newService(func(SendTelemetryPayload) {}, nil)
 	svc.Disable()
-	svc.RecordRequestID("REQUEST-1")
+	svc.RecordAPIRequest(ghtelemetry.APIRequest{RequestID: "REQUEST-1"})
 
 	assert.Empty(t, svc.events)
-	assert.Zero(t, svc.requestIDCount)
+	assert.Zero(t, svc.apiRequestCount)
+	assert.Empty(t, svc.requestIDs)
 }
 
 func TestWithAdditionalCommonDimensions(t *testing.T) {
@@ -771,7 +778,7 @@ func TestNoOpService(t *testing.T) {
 	svc := &NoOpService{}
 	// All methods should be safe to call without panicking
 	svc.Record(ghtelemetry.Event{Type: "test"})
-	svc.RecordRequestID("REQUEST-1")
+	svc.RecordAPIRequest(ghtelemetry.APIRequest{RequestID: "REQUEST-1"})
 	svc.Disable()
 	svc.SetSampleRate(50)
 	svc.Flush()

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -633,8 +633,8 @@ func TestServiceRecordAPIRequest(t *testing.T) {
 	requestEvent := captured.Events[1]
 	assert.Equal(t, "api_requests", requestEvent.Type)
 	assert.Equal(t, "REQUEST-1", requestEvent.Dimensions["request_ids"])
-	assert.Equal(t, int64(1), requestEvent.Measures["request_count"])
-	assert.Equal(t, int64(1), requestEvent.Measures["recorded_request_count"])
+	assert.Equal(t, int64(1), requestEvent.Measures["observed_request_count"])
+	assert.Zero(t, requestEvent.Measures["omitted_request_id_count"])
 	assert.NotEmpty(t, requestEvent.Dimensions["invocation_id"])
 	assert.Equal(t, "command_invocation", commandEvent.Type)
 	assert.Equal(t, requestEvent.Dimensions["invocation_id"], commandEvent.Dimensions["invocation_id"])
@@ -670,8 +670,8 @@ func TestServiceBoundsAPIRequests(t *testing.T) {
 	assert.Equal(t, "command_invocation", captured.Events[0].Type)
 	requests := captured.Events[1]
 	assert.Equal(t, "api_requests", requests.Type)
-	assert.Equal(t, int64(requestCount), requests.Measures["request_count"])
-	assert.Less(t, requests.Measures["recorded_request_count"], int64(requestCount))
+	assert.Equal(t, int64(requestCount), requests.Measures["observed_request_count"])
+	assert.Positive(t, requests.Measures["omitted_request_id_count"])
 	assert.LessOrEqual(t, len(requests.Dimensions["request_ids"]), maxRequestIDsEncodedSize)
 
 	payloadBytes, err := json.Marshal(captured)

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/factory"
@@ -34,13 +35,14 @@ const (
 )
 
 type ApiOptions struct {
-	AppVersion    string
-	InvokingAgent string
-	BaseRepo      func() (ghrepo.Interface, error)
-	Branch        func() (string, error)
-	Config        func() (gh.Config, error)
-	HttpClient    func() (*http.Client, error)
-	IO            *iostreams.IOStreams
+	AppVersion        string
+	InvokingAgent     string
+	BaseRepo          func() (ghrepo.Interface, error)
+	Branch            func() (string, error)
+	Config            func() (gh.Config, error)
+	HttpClient        func() (*http.Client, error)
+	IO                *iostreams.IOStreams
+	RequestIDRecorder ghtelemetry.RequestIDRecorder
 
 	Hostname            string
 	RequestMethod       string
@@ -65,12 +67,13 @@ type ApiOptions struct {
 
 func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command {
 	opts := ApiOptions{
-		AppVersion:    f.AppVersion,
-		InvokingAgent: f.InvokingAgent,
-		BaseRepo:      f.BaseRepo,
-		Branch:        f.Branch,
-		Config:        f.Config,
-		IO:            f.IOStreams,
+		AppVersion:        f.AppVersion,
+		InvokingAgent:     f.InvokingAgent,
+		BaseRepo:          f.BaseRepo,
+		Branch:            f.Branch,
+		Config:            f.Config,
+		IO:                f.IOStreams,
+		RequestIDRecorder: f.RequestIDRecorder,
 	}
 
 	cmd := &cobra.Command{
@@ -395,14 +398,15 @@ func apiRun(opts *ApiOptions) error {
 				log = opts.IO.Out
 			}
 			opts := api.HTTPClientOptions{
-				AppVersion:     opts.AppVersion,
-				InvokingAgent:  opts.InvokingAgent,
-				CacheTTL:       opts.CacheTTL,
-				Config:         cfg.Authentication(),
-				EnableCache:    opts.CacheTTL > 0,
-				Log:            log,
-				LogColorize:    opts.IO.ColorEnabled(),
-				LogVerboseHTTP: opts.Verbose,
+				AppVersion:        opts.AppVersion,
+				InvokingAgent:     opts.InvokingAgent,
+				CacheTTL:          opts.CacheTTL,
+				Config:            cfg.Authentication(),
+				EnableCache:       opts.CacheTTL > 0,
+				Log:               log,
+				LogColorize:       opts.IO.ColorEnabled(),
+				LogVerboseHTTP:    opts.Verbose,
+				RequestIDRecorder: opts.RequestIDRecorder,
 			}
 			return api.NewHTTPClient(opts)
 		}

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -35,15 +35,14 @@ const (
 )
 
 type ApiOptions struct {
-	AppVersion         string
-	InvokingAgent      string
-	BaseRepo           func() (ghrepo.Interface, error)
-	Branch             func() (string, error)
-	Config             func() (gh.Config, error)
-	HttpClient         func(api.HTTPClientOptions) (*http.Client, error)
-	IO                 *iostreams.IOStreams
-	APIRequestRecorder ghtelemetry.APIRequestRecorder
-	TelemetryDisabler  ghtelemetry.Disabler
+	AppVersion          string
+	InvokingAgent       string
+	BaseRepo            func() (ghrepo.Interface, error)
+	Branch              func() (string, error)
+	Config              func() (gh.Config, error)
+	HttpClient          func(api.HTTPClientOptions) (*http.Client, error)
+	IO                  *iostreams.IOStreams
+	APIRequestTelemetry ghtelemetry.APIRequestTelemetry
 
 	Hostname            string
 	RequestMethod       string
@@ -68,15 +67,14 @@ type ApiOptions struct {
 
 func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command {
 	opts := ApiOptions{
-		AppVersion:         f.AppVersion,
-		InvokingAgent:      f.InvokingAgent,
-		BaseRepo:           f.BaseRepo,
-		Branch:             f.Branch,
-		Config:             f.Config,
-		HttpClient:         api.NewHTTPClient,
-		IO:                 f.IOStreams,
-		APIRequestRecorder: f.APIRequestRecorder,
-		TelemetryDisabler:  f.TelemetryDisabler,
+		AppVersion:          f.AppVersion,
+		InvokingAgent:       f.InvokingAgent,
+		BaseRepo:            f.BaseRepo,
+		Branch:              f.Branch,
+		Config:              f.Config,
+		HttpClient:          api.NewHTTPClient,
+		IO:                  f.IOStreams,
+		APIRequestTelemetry: f.APIRequestTelemetry,
 	}
 
 	cmd := &cobra.Command{
@@ -399,16 +397,15 @@ func apiRun(opts *ApiOptions) error {
 		log = opts.IO.Out
 	}
 	httpClient, err := opts.HttpClient(api.HTTPClientOptions{
-		AppVersion:         opts.AppVersion,
-		InvokingAgent:      opts.InvokingAgent,
-		CacheTTL:           opts.CacheTTL,
-		Config:             cfg.Authentication(),
-		EnableCache:        opts.CacheTTL > 0,
-		Log:                log,
-		LogColorize:        opts.IO.ColorEnabled(),
-		LogVerboseHTTP:     opts.Verbose,
-		APIRequestRecorder: opts.APIRequestRecorder,
-		TelemetryDisabler:  opts.TelemetryDisabler,
+		AppVersion:          opts.AppVersion,
+		InvokingAgent:       opts.InvokingAgent,
+		CacheTTL:            opts.CacheTTL,
+		Config:              cfg.Authentication(),
+		EnableCache:         opts.CacheTTL > 0,
+		Log:                 log,
+		LogColorize:         opts.IO.ColorEnabled(),
+		LogVerboseHTTP:      opts.Verbose,
+		APIRequestTelemetry: opts.APIRequestTelemetry,
 	})
 	if err != nil {
 		return err

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -40,9 +40,10 @@ type ApiOptions struct {
 	BaseRepo           func() (ghrepo.Interface, error)
 	Branch             func() (string, error)
 	Config             func() (gh.Config, error)
-	HttpClient         func() (*http.Client, error)
+	HttpClient         func(api.HTTPClientOptions) (*http.Client, error)
 	IO                 *iostreams.IOStreams
 	APIRequestRecorder ghtelemetry.APIRequestRecorder
+	TelemetryDisabler  ghtelemetry.Disabler
 
 	Hostname            string
 	RequestMethod       string
@@ -72,8 +73,10 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 		BaseRepo:           f.BaseRepo,
 		Branch:             f.Branch,
 		Config:             f.Config,
+		HttpClient:         api.NewHTTPClient,
 		IO:                 f.IOStreams,
 		APIRequestRecorder: f.APIRequestRecorder,
+		TelemetryDisabler:  f.TelemetryDisabler,
 	}
 
 	cmd := &cobra.Command{
@@ -391,27 +394,22 @@ func apiRun(opts *ApiOptions) error {
 		return err
 	}
 
-	if opts.HttpClient == nil {
-		opts.HttpClient = func() (*http.Client, error) {
-			log := opts.IO.ErrOut
-			if opts.Verbose {
-				log = opts.IO.Out
-			}
-			opts := api.HTTPClientOptions{
-				AppVersion:         opts.AppVersion,
-				InvokingAgent:      opts.InvokingAgent,
-				CacheTTL:           opts.CacheTTL,
-				Config:             cfg.Authentication(),
-				EnableCache:        opts.CacheTTL > 0,
-				Log:                log,
-				LogColorize:        opts.IO.ColorEnabled(),
-				LogVerboseHTTP:     opts.Verbose,
-				APIRequestRecorder: opts.APIRequestRecorder,
-			}
-			return api.NewHTTPClient(opts)
-		}
+	log := opts.IO.ErrOut
+	if opts.Verbose {
+		log = opts.IO.Out
 	}
-	httpClient, err := opts.HttpClient()
+	httpClient, err := opts.HttpClient(api.HTTPClientOptions{
+		AppVersion:         opts.AppVersion,
+		InvokingAgent:      opts.InvokingAgent,
+		CacheTTL:           opts.CacheTTL,
+		Config:             cfg.Authentication(),
+		EnableCache:        opts.CacheTTL > 0,
+		Log:                log,
+		LogColorize:        opts.IO.ColorEnabled(),
+		LogVerboseHTTP:     opts.Verbose,
+		APIRequestRecorder: opts.APIRequestRecorder,
+		TelemetryDisabler:  opts.TelemetryDisabler,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -35,14 +35,14 @@ const (
 )
 
 type ApiOptions struct {
-	AppVersion        string
-	InvokingAgent     string
-	BaseRepo          func() (ghrepo.Interface, error)
-	Branch            func() (string, error)
-	Config            func() (gh.Config, error)
-	HttpClient        func() (*http.Client, error)
-	IO                *iostreams.IOStreams
-	RequestIDRecorder ghtelemetry.RequestIDRecorder
+	AppVersion         string
+	InvokingAgent      string
+	BaseRepo           func() (ghrepo.Interface, error)
+	Branch             func() (string, error)
+	Config             func() (gh.Config, error)
+	HttpClient         func() (*http.Client, error)
+	IO                 *iostreams.IOStreams
+	APIRequestRecorder ghtelemetry.APIRequestRecorder
 
 	Hostname            string
 	RequestMethod       string
@@ -67,13 +67,13 @@ type ApiOptions struct {
 
 func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command {
 	opts := ApiOptions{
-		AppVersion:        f.AppVersion,
-		InvokingAgent:     f.InvokingAgent,
-		BaseRepo:          f.BaseRepo,
-		Branch:            f.Branch,
-		Config:            f.Config,
-		IO:                f.IOStreams,
-		RequestIDRecorder: f.RequestIDRecorder,
+		AppVersion:         f.AppVersion,
+		InvokingAgent:      f.InvokingAgent,
+		BaseRepo:           f.BaseRepo,
+		Branch:             f.Branch,
+		Config:             f.Config,
+		IO:                 f.IOStreams,
+		APIRequestRecorder: f.APIRequestRecorder,
 	}
 
 	cmd := &cobra.Command{
@@ -398,15 +398,15 @@ func apiRun(opts *ApiOptions) error {
 				log = opts.IO.Out
 			}
 			opts := api.HTTPClientOptions{
-				AppVersion:        opts.AppVersion,
-				InvokingAgent:     opts.InvokingAgent,
-				CacheTTL:          opts.CacheTTL,
-				Config:            cfg.Authentication(),
-				EnableCache:       opts.CacheTTL > 0,
-				Log:               log,
-				LogColorize:       opts.IO.ColorEnabled(),
-				LogVerboseHTTP:    opts.Verbose,
-				RequestIDRecorder: opts.RequestIDRecorder,
+				AppVersion:         opts.AppVersion,
+				InvokingAgent:      opts.InvokingAgent,
+				CacheTTL:           opts.CacheTTL,
+				Config:             cfg.Authentication(),
+				EnableCache:        opts.CacheTTL > 0,
+				Log:                log,
+				LogColorize:        opts.IO.ColorEnabled(),
+				LogVerboseHTTP:     opts.Verbose,
+				APIRequestRecorder: opts.APIRequestRecorder,
 			}
 			return api.NewHTTPClient(opts)
 		}

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cli/cli/v2/internal/gh"
 	ghmock "github.com/cli/cli/v2/internal/gh/mock"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/go-gh/v2/pkg/template"
@@ -420,6 +421,22 @@ func Test_NewCmdApi_WindowsAbsPath(t *testing.T) {
 	cmd.SetArgs([]string{`C:\users\repos`})
 	_, err := cmd.ExecuteC()
 	assert.EqualError(t, err, `invalid API endpoint: "C:\users\repos". Your shell might be rewriting URL paths as filesystem paths. To avoid this, omit the leading slash from the endpoint argument`)
+}
+
+func TestNewCmdApiUsesFactoryRequestIDRecorder(t *testing.T) {
+	recorder := &telemetry.NoOpService{}
+	f := &cmdutil.Factory{
+		RequestIDRecorder: recorder,
+	}
+
+	cmd := NewCmdApi(f, func(opts *ApiOptions) error {
+		assert.Same(t, recorder, opts.RequestIDRecorder)
+		return nil
+	})
+	cmd.SetArgs([]string{"user"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
 }
 
 func Test_apiRun(t *testing.T) {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -427,13 +427,11 @@ func Test_NewCmdApi_WindowsAbsPath(t *testing.T) {
 func TestNewCmdApiUsesFactoryTelemetryRecorder(t *testing.T) {
 	recorder := &telemetry.NoOpService{}
 	f := &cmdutil.Factory{
-		APIRequestRecorder: recorder,
-		TelemetryDisabler:  recorder,
+		APIRequestTelemetry: recorder,
 	}
 
 	cmd := NewCmdApi(f, func(opts *ApiOptions) error {
-		assert.Same(t, recorder, opts.APIRequestRecorder)
-		assert.Same(t, recorder, opts.TelemetryDisabler)
+		assert.Same(t, recorder, opts.APIRequestTelemetry)
 		return nil
 	})
 	cmd.SetArgs([]string{"user"})
@@ -455,12 +453,11 @@ func TestAPIRunDisablesTelemetryForEnterpriseRequest(t *testing.T) {
 	})
 	ios, _, _, _ := iostreams.Test()
 	opts := ApiOptions{
-		Config:             func() (gh.Config, error) { return config.NewMockConfig(), nil },
-		HttpClient:         rootapi.NewHTTPClient,
-		IO:                 ios,
-		RequestPath:        server.URL,
-		APIRequestRecorder: recorder,
-		TelemetryDisabler:  recorder,
+		Config:              func() (gh.Config, error) { return config.NewMockConfig(), nil },
+		HttpClient:          rootapi.NewHTTPClient,
+		IO:                  ios,
+		RequestPath:         server.URL,
+		APIRequestTelemetry: recorder,
 	}
 
 	err := apiRun(&opts)
@@ -1482,8 +1479,9 @@ func Test_apiRun_cache(t *testing.T) {
 
 	ios, _, stdout, stderr := iostreams.Test()
 	options := ApiOptions{
-		IO:         ios,
-		HttpClient: rootapi.NewHTTPClient,
+		IO:                  ios,
+		HttpClient:          rootapi.NewHTTPClient,
+		APIRequestTelemetry: &telemetry.NoOpService{},
 		Config: func() (gh.Config, error) {
 			return &ghmock.ConfigMock{
 				AuthenticationFunc: func() gh.AuthConfig {
@@ -1527,10 +1525,11 @@ func Test_apiRun_invokingAgent(t *testing.T) {
 
 	ios, _, _, _ := iostreams.Test()
 	options := ApiOptions{
-		IO:            ios,
-		AppVersion:    "1.2.3",
-		InvokingAgent: "copilot-cli",
-		HttpClient:    rootapi.NewHTTPClient,
+		IO:                  ios,
+		AppVersion:          "1.2.3",
+		InvokingAgent:       "copilot-cli",
+		HttpClient:          rootapi.NewHTTPClient,
+		APIRequestTelemetry: &telemetry.NoOpService{},
 		Config: func() (gh.Config, error) {
 			return &ghmock.ConfigMock{
 				AuthenticationFunc: func() gh.AuthConfig {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -423,14 +423,14 @@ func Test_NewCmdApi_WindowsAbsPath(t *testing.T) {
 	assert.EqualError(t, err, `invalid API endpoint: "C:\users\repos". Your shell might be rewriting URL paths as filesystem paths. To avoid this, omit the leading slash from the endpoint argument`)
 }
 
-func TestNewCmdApiUsesFactoryRequestIDRecorder(t *testing.T) {
+func TestNewCmdApiUsesFactoryAPIRequestRecorder(t *testing.T) {
 	recorder := &telemetry.NoOpService{}
 	f := &cmdutil.Factory{
-		RequestIDRecorder: recorder,
+		APIRequestRecorder: recorder,
 	}
 
 	cmd := NewCmdApi(f, func(opts *ApiOptions) error {
-		assert.Same(t, recorder, opts.RequestIDRecorder)
+		assert.Same(t, recorder, opts.APIRequestRecorder)
 		return nil
 	})
 	cmd.SetArgs([]string{"user"})

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	rootapi "github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
@@ -423,20 +424,50 @@ func Test_NewCmdApi_WindowsAbsPath(t *testing.T) {
 	assert.EqualError(t, err, `invalid API endpoint: "C:\users\repos". Your shell might be rewriting URL paths as filesystem paths. To avoid this, omit the leading slash from the endpoint argument`)
 }
 
-func TestNewCmdApiUsesFactoryAPIRequestRecorder(t *testing.T) {
+func TestNewCmdApiUsesFactoryTelemetryRecorder(t *testing.T) {
 	recorder := &telemetry.NoOpService{}
 	f := &cmdutil.Factory{
 		APIRequestRecorder: recorder,
+		TelemetryDisabler:  recorder,
 	}
 
 	cmd := NewCmdApi(f, func(opts *ApiOptions) error {
 		assert.Same(t, recorder, opts.APIRequestRecorder)
+		assert.Same(t, recorder, opts.TelemetryDisabler)
 		return nil
 	})
 	cmd.SetArgs([]string{"user"})
 
 	_, err := cmd.ExecuteC()
 	require.NoError(t, err)
+}
+
+func TestAPIRunDisablesTelemetryForEnterpriseRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-GitHub-Request-Id", "ENTERPRISE-REQUEST")
+		fmt.Fprint(w, "{}")
+	}))
+	defer server.Close()
+
+	var payload telemetry.SendTelemetryPayload
+	recorder := telemetry.NewService(func(p telemetry.SendTelemetryPayload) {
+		payload = p
+	})
+	ios, _, _, _ := iostreams.Test()
+	opts := ApiOptions{
+		Config:             func() (gh.Config, error) { return config.NewMockConfig(), nil },
+		HttpClient:         rootapi.NewHTTPClient,
+		IO:                 ios,
+		RequestPath:        server.URL,
+		APIRequestRecorder: recorder,
+		TelemetryDisabler:  recorder,
+	}
+
+	err := apiRun(&opts)
+	require.NoError(t, err)
+	recorder.Flush()
+
+	assert.Empty(t, payload.Events)
 }
 
 func Test_apiRun(t *testing.T) {
@@ -758,7 +789,7 @@ func Test_apiRun(t *testing.T) {
 
 			tt.options.IO = ios
 			tt.options.Config = func() (gh.Config, error) { return config.NewMockConfig(), nil }
-			tt.options.HttpClient = func() (*http.Client, error) {
+			tt.options.HttpClient = func(rootapi.HTTPClientOptions) (*http.Client, error) {
 				var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 					resp := tt.httpResponse
 					resp.Request = req
@@ -827,7 +858,7 @@ func Test_apiRun_paginationREST(t *testing.T) {
 
 	options := ApiOptions{
 		IO: ios,
-		HttpClient: func() (*http.Client, error) {
+		HttpClient: func(rootapi.HTTPClientOptions) (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				resp := responses[requestCount]
 				resp.Request = req
@@ -899,7 +930,7 @@ func Test_apiRun_arrayPaginationREST(t *testing.T) {
 
 	options := ApiOptions{
 		IO: ios,
-		HttpClient: func() (*http.Client, error) {
+		HttpClient: func(rootapi.HTTPClientOptions) (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				resp := responses[requestCount]
 				resp.Request = req
@@ -971,7 +1002,7 @@ func Test_apiRun_arrayPaginationREST_with_headers(t *testing.T) {
 
 	options := ApiOptions{
 		IO: ios,
-		HttpClient: func() (*http.Client, error) {
+		HttpClient: func(rootapi.HTTPClientOptions) (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				resp := responses[requestCount]
 				resp.Request = req
@@ -1040,7 +1071,7 @@ func Test_apiRun_paginationGraphQL(t *testing.T) {
 
 	options := ApiOptions{
 		IO: ios,
-		HttpClient: func() (*http.Client, error) {
+		HttpClient: func(rootapi.HTTPClientOptions) (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				resp := responses[requestCount]
 				resp.Request = req
@@ -1139,7 +1170,7 @@ func Test_apiRun_paginationGraphQL_slurp(t *testing.T) {
 
 	options := ApiOptions{
 		IO: ios,
-		HttpClient: func() (*http.Client, error) {
+		HttpClient: func(rootapi.HTTPClientOptions) (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				resp := responses[requestCount]
 				resp.Request = req
@@ -1251,7 +1282,7 @@ func Test_apiRun_paginated_template(t *testing.T) {
 
 	options := ApiOptions{
 		IO: ios,
-		HttpClient: func() (*http.Client, error) {
+		HttpClient: func(rootapi.HTTPClientOptions) (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				resp := responses[requestCount]
 				resp.Request = req
@@ -1310,7 +1341,7 @@ func Test_apiRun_DELETE(t *testing.T) {
 		Config: func() (gh.Config, error) {
 			return config.NewMockConfig(), nil
 		},
-		HttpClient: func() (*http.Client, error) {
+		HttpClient: func(rootapi.HTTPClientOptions) (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				gotRequest = req
 				return &http.Response{StatusCode: 204, Request: req}, nil
@@ -1339,7 +1370,7 @@ func Test_apiRun_HEAD(t *testing.T) {
 		Config: func() (gh.Config, error) {
 			return config.NewMockConfig(), nil
 		},
-		HttpClient: func() (*http.Client, error) {
+		HttpClient: func(rootapi.HTTPClientOptions) (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 422,
@@ -1410,7 +1441,7 @@ func Test_apiRun_inputFile(t *testing.T) {
 				RawFields:        []string{"a=b", "c=d"},
 
 				IO: ios,
-				HttpClient: func() (*http.Client, error) {
+				HttpClient: func(rootapi.HTTPClientOptions) (*http.Client, error) {
 					var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 						var err error
 						if bodyBytes, err = io.ReadAll(req.Body); err != nil {
@@ -1451,7 +1482,8 @@ func Test_apiRun_cache(t *testing.T) {
 
 	ios, _, stdout, stderr := iostreams.Test()
 	options := ApiOptions{
-		IO: ios,
+		IO:         ios,
+		HttpClient: rootapi.NewHTTPClient,
 		Config: func() (gh.Config, error) {
 			return &ghmock.ConfigMock{
 				AuthenticationFunc: func() gh.AuthConfig {
@@ -1498,6 +1530,7 @@ func Test_apiRun_invokingAgent(t *testing.T) {
 		IO:            ios,
 		AppVersion:    "1.2.3",
 		InvokingAgent: "copilot-cli",
+		HttpClient:    rootapi.NewHTTPClient,
 		Config: func() (gh.Config, error) {
 			return &ghmock.ConfigMock{
 				AuthenticationFunc: func() gh.AuthConfig {
@@ -1906,7 +1939,7 @@ func Test_apiRun_acceptHeader(t *testing.T) {
 			}
 
 			var gotReq *http.Request
-			tt.options.HttpClient = func() (*http.Client, error) {
+			tt.options.HttpClient = func(rootapi.HTTPClientOptions) (*http.Client, error) {
 				var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 					gotReq = req
 					resp := &http.Response{

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -23,12 +23,7 @@ import (
 var ssoHeader string
 var ssoURLRE = regexp.MustCompile(`\burl=([^;]+)`)
 
-type telemetryRecorder interface {
-	ghtelemetry.APIRequestRecorder
-	ghtelemetry.Disabler
-}
-
-func New(appVersion string, invokingAgent string, cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams, executablePath string, telemetryRecorder telemetryRecorder) *cmdutil.Factory {
+func New(appVersion string, invokingAgent string, cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams, executablePath string, apiRequestTelemetry ghtelemetry.APIRequestTelemetry) *cmdutil.Factory {
 	f := &cmdutil.Factory{
 		AppVersion:     appVersion,
 		InvokingAgent:  invokingAgent,
@@ -37,10 +32,9 @@ func New(appVersion string, invokingAgent string, cfgFunc func() (gh.Config, err
 	}
 
 	f.IOStreams = ios
-	f.APIRequestRecorder = telemetryRecorder
-	f.TelemetryDisabler = telemetryRecorder
-	f.HttpClient = HttpClientFunc(cfgFunc, ios, appVersion, invokingAgent, telemetryRecorder)
-	f.PlainHttpClient = plainHttpClientFunc(ios, appVersion, invokingAgent, telemetryRecorder)
+	f.APIRequestTelemetry = apiRequestTelemetry
+	f.HttpClient = HttpClientFunc(cfgFunc, ios, appVersion, invokingAgent, apiRequestTelemetry)
+	f.PlainHttpClient = plainHttpClientFunc(ios, appVersion, invokingAgent, apiRequestTelemetry)
 	f.ExternalHttpClient = externalHttpClientFunc(ios, appVersion)
 	f.GitClient = newGitClient(f) // Depends on IOStreams, and Executable
 	f.Remotes = remotesFunc(f)    // Depends on Config, and GitClient
@@ -192,20 +186,19 @@ func remotesFunc(f *cmdutil.Factory) func() (ghContext.Remotes, error) {
 	return rr.Resolver()
 }
 
-func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams, appVersion string, invokingAgent string, telemetryRecorder telemetryRecorder) func() (*http.Client, error) {
+func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams, appVersion string, invokingAgent string, apiRequestTelemetry ghtelemetry.APIRequestTelemetry) func() (*http.Client, error) {
 	return func() (*http.Client, error) {
 		cfg, err := cfgFunc()
 		if err != nil {
 			return nil, err
 		}
 		opts := api.HTTPClientOptions{
-			Config:             cfg.Authentication(),
-			Log:                ios.ErrOut,
-			LogColorize:        ios.ColorEnabled(),
-			AppVersion:         appVersion,
-			InvokingAgent:      invokingAgent,
-			APIRequestRecorder: telemetryRecorder,
-			TelemetryDisabler:  telemetryRecorder,
+			Config:              cfg.Authentication(),
+			Log:                 ios.ErrOut,
+			LogColorize:         ios.ColorEnabled(),
+			AppVersion:          appVersion,
+			InvokingAgent:       invokingAgent,
+			APIRequestTelemetry: apiRequestTelemetry,
 		}
 		client, err := api.NewHTTPClient(opts)
 		if err != nil {
@@ -216,7 +209,7 @@ func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams,
 	}
 }
 
-func plainHttpClientFunc(ios *iostreams.IOStreams, appVersion string, invokingAgent string, telemetryRecorder telemetryRecorder) func() (*http.Client, error) {
+func plainHttpClientFunc(ios *iostreams.IOStreams, appVersion string, invokingAgent string, apiRequestTelemetry ghtelemetry.APIRequestTelemetry) func() (*http.Client, error) {
 	return func() (*http.Client, error) {
 		opts := api.HTTPClientOptions{
 			Log:           ios.ErrOut,
@@ -224,9 +217,8 @@ func plainHttpClientFunc(ios *iostreams.IOStreams, appVersion string, invokingAg
 			AppVersion:    appVersion,
 			InvokingAgent: invokingAgent,
 			// This is required to prevent automatic setting of auth and other headers.
-			SkipDefaultHeaders: true,
-			APIRequestRecorder: telemetryRecorder,
-			TelemetryDisabler:  telemetryRecorder,
+			SkipDefaultHeaders:  true,
+			APIRequestTelemetry: apiRequestTelemetry,
 		}
 		client, err := api.NewHTTPClient(opts)
 		if err != nil {

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -38,6 +38,7 @@ func New(appVersion string, invokingAgent string, cfgFunc func() (gh.Config, err
 
 	f.IOStreams = ios
 	f.APIRequestRecorder = telemetryRecorder
+	f.TelemetryDisabler = telemetryRecorder
 	f.HttpClient = HttpClientFunc(cfgFunc, ios, appVersion, invokingAgent, telemetryRecorder)
 	f.PlainHttpClient = plainHttpClientFunc(ios, appVersion, invokingAgent, telemetryRecorder)
 	f.ExternalHttpClient = externalHttpClientFunc(ios, appVersion)

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -23,7 +23,12 @@ import (
 var ssoHeader string
 var ssoURLRE = regexp.MustCompile(`\burl=([^;]+)`)
 
-func New(appVersion string, invokingAgent string, cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams, executablePath string, telemetryDisabler ghtelemetry.Disabler) *cmdutil.Factory {
+type telemetryRecorder interface {
+	ghtelemetry.RequestIDRecorder
+	ghtelemetry.Disabler
+}
+
+func New(appVersion string, invokingAgent string, cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams, executablePath string, telemetryRecorder telemetryRecorder) *cmdutil.Factory {
 	f := &cmdutil.Factory{
 		AppVersion:     appVersion,
 		InvokingAgent:  invokingAgent,
@@ -32,8 +37,9 @@ func New(appVersion string, invokingAgent string, cfgFunc func() (gh.Config, err
 	}
 
 	f.IOStreams = ios
-	f.HttpClient = HttpClientFunc(cfgFunc, ios, appVersion, invokingAgent, telemetryDisabler)
-	f.PlainHttpClient = plainHttpClientFunc(ios, appVersion, invokingAgent, telemetryDisabler)
+	f.RequestIDRecorder = telemetryRecorder
+	f.HttpClient = HttpClientFunc(cfgFunc, ios, appVersion, invokingAgent, telemetryRecorder)
+	f.PlainHttpClient = plainHttpClientFunc(ios, appVersion, invokingAgent, telemetryRecorder)
 	f.ExternalHttpClient = externalHttpClientFunc(ios, appVersion)
 	f.GitClient = newGitClient(f) // Depends on IOStreams, and Executable
 	f.Remotes = remotesFunc(f)    // Depends on Config, and GitClient
@@ -185,7 +191,7 @@ func remotesFunc(f *cmdutil.Factory) func() (ghContext.Remotes, error) {
 	return rr.Resolver()
 }
 
-func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams, appVersion string, invokingAgent string, telemetryDisabler ghtelemetry.Disabler) func() (*http.Client, error) {
+func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams, appVersion string, invokingAgent string, telemetryRecorder telemetryRecorder) func() (*http.Client, error) {
 	return func() (*http.Client, error) {
 		cfg, err := cfgFunc()
 		if err != nil {
@@ -197,7 +203,8 @@ func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams,
 			LogColorize:       ios.ColorEnabled(),
 			AppVersion:        appVersion,
 			InvokingAgent:     invokingAgent,
-			TelemetryDisabler: telemetryDisabler,
+			RequestIDRecorder: telemetryRecorder,
+			TelemetryDisabler: telemetryRecorder,
 		}
 		client, err := api.NewHTTPClient(opts)
 		if err != nil {
@@ -208,7 +215,7 @@ func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams,
 	}
 }
 
-func plainHttpClientFunc(ios *iostreams.IOStreams, appVersion string, invokingAgent string, telemetryDisabler ghtelemetry.Disabler) func() (*http.Client, error) {
+func plainHttpClientFunc(ios *iostreams.IOStreams, appVersion string, invokingAgent string, telemetryRecorder telemetryRecorder) func() (*http.Client, error) {
 	return func() (*http.Client, error) {
 		opts := api.HTTPClientOptions{
 			Log:           ios.ErrOut,
@@ -217,7 +224,8 @@ func plainHttpClientFunc(ios *iostreams.IOStreams, appVersion string, invokingAg
 			InvokingAgent: invokingAgent,
 			// This is required to prevent automatic setting of auth and other headers.
 			SkipDefaultHeaders: true,
-			TelemetryDisabler:  telemetryDisabler,
+			RequestIDRecorder:  telemetryRecorder,
+			TelemetryDisabler:  telemetryRecorder,
 		}
 		client, err := api.NewHTTPClient(opts)
 		if err != nil {

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -24,7 +24,7 @@ var ssoHeader string
 var ssoURLRE = regexp.MustCompile(`\burl=([^;]+)`)
 
 type telemetryRecorder interface {
-	ghtelemetry.RequestIDRecorder
+	ghtelemetry.APIRequestRecorder
 	ghtelemetry.Disabler
 }
 
@@ -37,7 +37,7 @@ func New(appVersion string, invokingAgent string, cfgFunc func() (gh.Config, err
 	}
 
 	f.IOStreams = ios
-	f.RequestIDRecorder = telemetryRecorder
+	f.APIRequestRecorder = telemetryRecorder
 	f.HttpClient = HttpClientFunc(cfgFunc, ios, appVersion, invokingAgent, telemetryRecorder)
 	f.PlainHttpClient = plainHttpClientFunc(ios, appVersion, invokingAgent, telemetryRecorder)
 	f.ExternalHttpClient = externalHttpClientFunc(ios, appVersion)
@@ -198,13 +198,13 @@ func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams,
 			return nil, err
 		}
 		opts := api.HTTPClientOptions{
-			Config:            cfg.Authentication(),
-			Log:               ios.ErrOut,
-			LogColorize:       ios.ColorEnabled(),
-			AppVersion:        appVersion,
-			InvokingAgent:     invokingAgent,
-			RequestIDRecorder: telemetryRecorder,
-			TelemetryDisabler: telemetryRecorder,
+			Config:             cfg.Authentication(),
+			Log:                ios.ErrOut,
+			LogColorize:        ios.ColorEnabled(),
+			AppVersion:         appVersion,
+			InvokingAgent:      invokingAgent,
+			APIRequestRecorder: telemetryRecorder,
+			TelemetryDisabler:  telemetryRecorder,
 		}
 		client, err := api.NewHTTPClient(opts)
 		if err != nil {
@@ -224,7 +224,7 @@ func plainHttpClientFunc(ios *iostreams.IOStreams, appVersion string, invokingAg
 			InvokingAgent: invokingAgent,
 			// This is required to prevent automatic setting of auth and other headers.
 			SkipDefaultHeaders: true,
-			RequestIDRecorder:  telemetryRecorder,
+			APIRequestRecorder: telemetryRecorder,
 			TelemetryDisabler:  telemetryRecorder,
 		}
 		client, err := api.NewHTTPClient(opts)

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/extensions"
@@ -18,11 +19,12 @@ type Factory struct {
 	ExecutablePath string
 	InvokingAgent  string
 
-	Browser          browser.Browser
-	ExtensionManager extensions.ExtensionManager
-	GitClient        *git.Client
-	IOStreams        *iostreams.IOStreams
-	Prompter         prompter.Prompter
+	Browser           browser.Browser
+	ExtensionManager  extensions.ExtensionManager
+	GitClient         *git.Client
+	IOStreams         *iostreams.IOStreams
+	Prompter          prompter.Prompter
+	RequestIDRecorder ghtelemetry.RequestIDRecorder
 
 	BaseRepo func() (ghrepo.Interface, error)
 	Branch   func() (string, error)

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -19,12 +19,12 @@ type Factory struct {
 	ExecutablePath string
 	InvokingAgent  string
 
-	Browser           browser.Browser
-	ExtensionManager  extensions.ExtensionManager
-	GitClient         *git.Client
-	IOStreams         *iostreams.IOStreams
-	Prompter          prompter.Prompter
-	RequestIDRecorder ghtelemetry.RequestIDRecorder
+	Browser            browser.Browser
+	ExtensionManager   extensions.ExtensionManager
+	GitClient          *git.Client
+	IOStreams          *iostreams.IOStreams
+	Prompter           prompter.Prompter
+	APIRequestRecorder ghtelemetry.APIRequestRecorder
 
 	BaseRepo func() (ghrepo.Interface, error)
 	Branch   func() (string, error)

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -19,13 +19,12 @@ type Factory struct {
 	ExecutablePath string
 	InvokingAgent  string
 
-	Browser            browser.Browser
-	ExtensionManager   extensions.ExtensionManager
-	GitClient          *git.Client
-	IOStreams          *iostreams.IOStreams
-	Prompter           prompter.Prompter
-	APIRequestRecorder ghtelemetry.APIRequestRecorder
-	TelemetryDisabler  ghtelemetry.Disabler
+	Browser             browser.Browser
+	ExtensionManager    extensions.ExtensionManager
+	GitClient           *git.Client
+	IOStreams           *iostreams.IOStreams
+	Prompter            prompter.Prompter
+	APIRequestTelemetry ghtelemetry.APIRequestTelemetry
 
 	BaseRepo func() (ghrepo.Interface, error)
 	Branch   func() (string, error)

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -25,6 +25,7 @@ type Factory struct {
 	IOStreams          *iostreams.IOStreams
 	Prompter           prompter.Prompter
 	APIRequestRecorder ghtelemetry.APIRequestRecorder
+	TelemetryDisabler  ghtelemetry.Disabler
 
 	BaseRepo func() (ghrepo.Interface, error)
 	Branch   func() (string, error)


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

GitHub CLI command telemetry cannot currently be correlated with GitHub server-side request telemetry.

This adds one `api_requests` event per invocation containing the request IDs from real GitHub HTTP responses in a comma-delimited `request_ids` dimension. The telemetry service's common `invocation_id` dimension links it to the separate `command_invocation` event without repeating request data there.

Capture happens below go-gh's cache at the HTTP transport seam, so cache hits do not replay stale IDs and redirects or retries capture each actual response. External HTTP clients remain excluded, and existing invocation sampling and enterprise telemetry disablement apply unchanged.

The encoded request-ID list is limited to 8 KB, leaving room within the 16 KB telemetry payload for common dimensions, command telemetry, and other invocation events. `observed_request_count` reports responses carrying request IDs, while `omitted_request_id_count` reports IDs omitted because they exceeded the event budget.

### How did you test this change?

I built commit `d12ce03a1` (`gh version 2.99.0-59-gd12ce03a1`, SHA-256 `60562296f799eeb8810fba9c1abcf75bd7f45524375241a58084c10a042b41cd`) and ran it against an isolated local TLS proxy serving deterministic synthetic GitHub responses. Each GIF uses a separate temporary home, config, state, and cache against the local synthetic service. The service cannot forward traffic, avoids exposing a real account or request ID, and makes pagination and caching deterministic; it does not prove behavior against GitHub's production service.

**Multiple responses from one paginated invocation:**

![A paginated gh api invocation emitting one api_requests event with two request IDs, observed_request_count 2, and omitted_request_id_count 0](https://github.com/user-attachments/assets/697f3b4c-04d6-4e4c-946d-54663365e73c)

**A network response is recorded, then a cache hit does not replay its request ID:**

![Two cached gh api invocations where the network response emits request ID telemetry and the cache hit emits only command telemetry](https://github.com/user-attachments/assets/d87254dd-e69b-4132-bb86-f4e34c608213)

**Enterprise telemetry remains disabled:**

![A gh api invocation against a synthetic enterprise host reporting that there is no telemetry payload](https://github.com/user-attachments/assets/54177fab-d116-4c70-b778-2fc41a9bfe70)

### Key points

Request IDs preserve response order and duplicates. CAFE's schema currently constrains to string only dimensions, so no array allowed. We also don't want to emit one event per request because it may quickly blow the 16KB budget we have. Big picture I think we might want to revisit how we do telemetry in some way to support increasing the sample rate.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [x] Nobody has explicitly committed to replying.