### PR TITLE
prompter: answer survey terminal-size probe on unresponsive PTYs

### DIFF
--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -2,6 +2,7 @@ package prompter
 
 import (
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -71,13 +72,61 @@ func New(editorCmd string, io *iostreams.IOStreams) Prompter {
 		}
 	}
 
+	probe := newSurveyProbeIO(asFile(io.In), asFile(io.Out))
 	return &surveyPrompter{
-		prompter:  ghPrompter.New(io.In, io.Out, io.ErrOut),
-		stdin:     io.In,
+		prompter:  ghPrompter.New(wrapFileReader(io.In, probe), wrapFileWriter(io.Out, probe), io.ErrOut),
 		stdout:    io.Out,
 		stderr:    io.ErrOut,
 		editorCmd: editorCmd,
 	}
+}
+
+// asFile narrows an arbitrary stream to *os.File, tolerating nil and
+// non-file implementations (tests).
+func asFile(f any) *os.File {
+	if f == nil {
+		return nil
+	}
+	if file, ok := f.(*os.File); ok {
+		return file
+	}
+	return nil
+}
+
+// wrapFileReader keeps the original FileReader for ghPrompter bookkeeping
+// (Fd is required) while making its Read surface the probe-bounded view. If
+// either stream is not a real file, the wrapper degrades to a no-op and the
+// original stream is passed through untouched.
+type probeFileReader struct {
+	inner ghPrompter.FileReader
+	read  func([]byte) (int, error)
+}
+
+func (r *probeFileReader) Read(p []byte) (int, error) { return r.read(p) }
+func (r *probeFileReader) Fd() uintptr                { return r.inner.Fd() }
+
+func wrapFileReader(in ghPrompter.FileReader, probe *surveyProbeIO) ghPrompter.FileReader {
+	if probe == nil || probe.In() == nil {
+		return in
+	}
+	bounded := probe.In()
+	return &probeFileReader{inner: in, read: bounded.Read}
+}
+
+type probeFileWriter struct {
+	inner ghPrompter.FileWriter
+	write func([]byte) (int, error)
+}
+
+func (w *probeFileWriter) Write(p []byte) (int, error) { return w.write(p) }
+func (w *probeFileWriter) Fd() uintptr                 { return w.inner.Fd() }
+
+func wrapFileWriter(out ghPrompter.FileWriter, probe *surveyProbeIO) ghPrompter.FileWriter {
+	if probe == nil || probe.Out() == nil {
+		return out
+	}
+	watched := probe.Out()
+	return &probeFileWriter{inner: out, write: watched.Write}
 }
 
 type accessiblePrompter struct {

--- a/internal/prompter/survey_probe_reader.go
+++ b/internal/prompter/survey_probe_reader.go
@@ -1,0 +1,269 @@
+//go:build !windows
+// +build !windows
+
+package prompter
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// This file works around cli/cli#14323: the survey-based prompts (used through
+// go-gh's prompter) determine the terminal size by writing a cursor-position
+// request (ESC[6n, a Device Status Report) to stdout and then blocking on
+// stdin until the terminal answers ESC[<row>;<col>R. A terminal emulator
+// answers instantly, but a bare PTY without one behind it — CI wrappers,
+// automation harnesses, pty-based RPC supervisors — never does, so the prompt
+// hangs forever.
+//
+// surveyProbeIO sits between go-gh and survey (the same seam as
+// survey_escape_reader.go). Its output side watches for DSR requests and
+// records that an answer is due; its input side waits for stdin bytes with a
+// bounded poll, and if the deadline expires without a plausible answer, it
+// injects a synthetic ESC[<row>;<col>R so the probe completes and the prompt
+// proceeds.
+
+const surveyProbeTimeoutDefault = 500 * time.Millisecond
+
+var dsrRequest = []byte("\x1b[6n")
+
+// surveyProbeTimeout is how long the terminal has to answer the DSR request.
+// Real terminals answer in microseconds, and the go-expect virtual terminals
+// used in the prompter test suite answer synchronously; even a slow remote
+// link has orders of magnitude of headroom. GH_CURSOR_QUERY_TIMEOUT_MS
+// overrides it (in milliseconds) for tests.
+func surveyProbeTimeout() time.Duration {
+	if v := os.Getenv("GH_CURSOR_QUERY_TIMEOUT_MS"); v != "" {
+		if ms, err := strconv.ParseInt(v, 10, 64); err == nil && ms > 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return surveyProbeTimeoutDefault
+}
+
+// probeState tracks cursor-position requests and whether they have been
+// answered by the terminal.
+type probeState struct {
+	mu  sync.Mutex
+	out *os.File
+	// unanswered counts DSR requests written to the terminal that have not
+	// seen any plausible reply yet.
+	unanswered int
+	// deadline is when the oldest unanswered request expires.
+	deadline time.Time
+	// hostile records that the terminal already missed a deadline once; on
+	// such a stream later probes are answered synthetically without waiting
+	// again, so multi-probe prompts do not pay the timeout twice.
+	hostile bool
+}
+
+func (s *probeState) requestStarted(now time.Time, timeout time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unanswered++
+	if s.hostile || s.deadline.IsZero() {
+		s.deadline = now
+		if s.hostile {
+			// Answer immediately; the terminal has already shown it will
+			// not.
+			s.deadline = now.Add(-time.Millisecond)
+		} else {
+			s.deadline = now.Add(timeout)
+		}
+	}
+}
+
+var dsrReplyPattern = regexp.MustCompile(`\x1b\[\d+;\d+R`)
+
+// sawInput records that arbitrary bytes arrived. Only bytes that look like a
+// cursor-position report clear the pending probe; user keystrokes typed
+// while the request is in flight are passed through to survey's probe loop
+// but do not cancel it.
+func (s *probeState) sawInput(b []byte) {
+	if len(b) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if dsrReplyPattern.Match(b) {
+		s.unanswered = 0
+		s.deadline = time.Time{}
+	}
+}
+
+// replyToInject returns a synthetic cursor report if every outstanding
+// request's deadline has expired, and marks the stream hostile so subsequent
+// probes are answered instantly.
+func (s *probeState) replyToInject() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.unanswered == 0 || s.deadline.IsZero() || time.Now().Before(s.deadline) {
+		return ""
+	}
+	s.hostile = true
+	w, h := s.fallbackSize()
+	return "\x1b[" + strconv.Itoa(h) + ";" + strconv.Itoa(w) + "R"
+}
+
+// surveyProbeIO wraps the streams handed to the survey prompter.
+type surveyProbeIO struct {
+	in    *os.File
+	out   *os.File
+	state *probeState
+}
+
+func newSurveyProbeIO(in, out *os.File) *surveyProbeIO {
+	state := &probeState{out: out}
+	return &surveyProbeIO{
+		in:    in,
+		out:   out,
+		state: state,
+	}
+}
+
+// In returns the bounded reader to hand to survey as Stdio.In.
+func (p *surveyProbeIO) In() io.Reader {
+	if p.in == nil {
+		return nil
+	}
+	return &surveyProbeReader{probe: p}
+}
+
+// Out returns the watching writer to hand to survey as Stdio.Out.
+func (p *surveyProbeIO) Out() io.Writer {
+	if p.out == nil {
+		return nil
+	}
+	return &surveyProbeWriter{probe: p}
+}
+
+// surveyProbeWriter watches survey's output for DSR requests. It never
+// modifies what is written.
+type surveyProbeWriter struct {
+	probe *surveyProbeIO
+}
+
+// Fd satisfies ghPrompter.FileWriter (survey's renderer needs the real
+// descriptor for terminal ioctls).
+func (w *surveyProbeWriter) Fd() uintptr { return w.probe.out.Fd() }
+
+func (w *surveyProbeWriter) Write(p []byte) (int, error) {
+	if bytes.Contains(p, dsrRequest) {
+		w.probe.state.requestStarted(time.Now(), surveyProbeTimeout())
+	}
+	return w.probe.out.Write(p)
+}
+
+// surveyProbeReader serves stdin reads, injecting a synthetic cursor report
+// when the terminal fails to answer a probe in time.
+type surveyProbeReader struct {
+	probe    *surveyProbeIO
+	injected []byte
+}
+
+// waitReadable polls the terminal fd, returning true when data is available
+// before the deadline.
+func (r *surveyProbeReader) waitReadable(remaining time.Duration) bool {
+	fds := []unix.PollFd{{Fd: int32(r.probe.in.Fd()), Events: unix.POLLIN}}
+	ms := int(remaining / time.Millisecond)
+	if ms < 1 {
+		ms = 1
+	}
+	n, err := unix.Poll(fds, ms)
+	return err == nil && n > 0
+}
+
+func (r *surveyProbeReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if n := copy(p, r.injected); n > 0 {
+		r.injected = r.injected[n:]
+		return n, nil
+	}
+
+	// Without an outstanding probe, read the way survey always has.
+	if !r.probe.state.awaitingReply() {
+		return r.probe.in.Read(p)
+	}
+
+	remaining := r.probe.state.remaining()
+	if remaining > 0 && r.waitReadable(remaining) {
+		n, err := r.probe.in.Read(p)
+		r.probe.state.sawInput(p[:n])
+		return n, err
+	}
+
+	// Deadline expired without any input: answer the probe synthetically.
+	reply := r.probe.state.replyToInject()
+	if reply == "" {
+		// Should not happen when awaitingReply() was true; last-resort
+		// re-check under the state lock to avoid a blocking read here.
+		if r.probe.state.awaitingReply() {
+			// Force-expire and inject.
+			r.probe.state.forceExpire()
+			reply = r.probe.state.replyToInject()
+		}
+		if reply == "" {
+			return r.probe.in.Read(p)
+		}
+	}
+	r.injected = append(r.injected, reply...)
+	n := copy(p, reply)
+	r.injected = r.injected[n:]
+	return n, nil
+}
+
+func (s *probeState) awaitingReply() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.unanswered > 0
+}
+
+func (s *probeState) forceExpire() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.unanswered > 0 {
+		s.deadline = time.Now().Add(-time.Millisecond)
+	}
+}
+
+func (s *probeState) remaining() time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.deadline.IsZero() {
+		return 0
+	}
+	return time.Until(s.deadline)
+}
+
+// fallbackSize computes the terminal size used when the DSR probe fails:
+// TIOCGWINSZ first (a bare pty still reports the harness's winsize), then
+func (s *probeState) fallbackSize() (int, int) {
+	if s.out != nil {
+		if ws, err := unix.IoctlGetWinsize(int(s.out.Fd()), unix.TIOCGWINSZ); err == nil && ws != nil {
+			if ws.Col > 0 && ws.Row > 0 {
+				return int(ws.Col), int(ws.Row)
+			}
+		}
+	}
+	w, h := 80, 24
+	if v := os.Getenv("COLUMNS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			w = n
+		}
+	}
+	if v := os.Getenv("LINES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			h = n
+		}
+	}
+	return w, h
+}

--- a/internal/prompter/survey_probe_reader_posix_test.go
+++ b/internal/prompter/survey_probe_reader_posix_test.go
@@ -1,0 +1,118 @@
+//go:build !windows
+// +build !windows
+
+package prompter
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"golang.org/x/sys/unix"
+)
+
+func TestSurveyProbeInjectsOnDumbPty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("needs a pty")
+	}
+	m, s, err := pty.Open()
+	if err != nil {
+		t.Skipf("no pty: %v", err)
+	}
+	defer m.Close()
+	defer s.Close()
+
+	p := newSurveyProbeIO(s, s)
+
+	// Simulate survey writing the probe through the watched writer.
+	out := p.Out()
+	if _, err := out.Write([]byte("\x1b[999;999f")); err != nil {
+		t.Fatalf("write move: %v", err)
+	}
+	if _, err := out.Write(dsrRequest); err != nil {
+		t.Fatalf("write dsr: %v", err)
+	}
+
+	// Now read like survey's Location does; expect a synthetic report.
+	buf := make([]byte, 64)
+	in := p.In()
+	start := time.Now()
+	n, err := in.Read(buf)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	line := buf[:n]
+	t.Logf("elapsed=%v reply=%q", elapsed, line)
+	if !bytes.Contains(line, []byte("R")) {
+		t.Fatalf("no synthetic cursor report injected: %q", line)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("probe fallback took too long: %v", elapsed)
+	}
+}
+
+func TestSurveyProbePassthroughRealAnswer(t *testing.T) {
+	m, s, err := pty.Open()
+	if err != nil {
+		t.Skipf("no pty: %v", err)
+	}
+	defer m.Close()
+	defer s.Close()
+
+	p := newSurveyProbeIO(s, s)
+	// Put the pty in raw mode like survey's SetTermMode does mid-prompt; in
+	// canonical mode a partial line (no newline, like a DSR answer) is not
+	// readable at all, which is not the environment we are modelling.
+	raw, err := unix.IoctlGetTermios(int(s.Fd()), unix.TCGETS)
+	if err != nil {
+		t.Skipf("termios: %v", err)
+	}
+	raw.Lflag &^= unix.ICANON | unix.ECHO
+	raw.Cc[unix.VMIN] = 1
+	raw.Cc[unix.VTIME] = 0
+	if err := unix.IoctlSetTermios(int(s.Fd()), unix.TCSETS, raw); err != nil {
+		t.Skipf("termios set: %v", err)
+	}
+	// Start a goroutine that supplies a REAL cursor answer after 50 ms.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		if _, err := m.Write([]byte("\x1b[24;80R")); err != nil {
+			t.Logf("master write: %v", err)
+		}
+	}()
+	// Arm a probe, then supply a REAL answer; it must be passed through and
+	// clear the pending state.
+	if _, err := p.Out().Write(dsrRequest); err != nil {
+		t.Fatalf("write dsr: %v", err)
+	}
+	buf := make([]byte, 64)
+	n, err := p.In().Read(buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Contains(buf[:n], []byte("\x1b[24;80R")) {
+		t.Fatalf("real answer not passed through: %q", buf[:n])
+	}
+	if p.state.hostile {
+		t.Fatalf("real answer should clear pending state without hostility")
+	}
+
+	// A second probe with no real answer should inject (not hang) and mark
+	// the stream hostile so later probes do not wait again.
+	if _, err := p.Out().Write(dsrRequest); err != nil {
+		t.Fatalf("write dsr 2: %v", err)
+	}
+	start := time.Now()
+	n, err = p.In().Read(buf)
+	if err != nil {
+		t.Fatalf("read 2: %v", err)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("second probe waited too long: %v", time.Since(start))
+	}
+	if !bytes.Contains(buf[:n], []byte("R")) {
+		t.Fatalf("second probe got no synthetic reply: %q", buf[:n])
+	}
+}


### PR DESCRIPTION
### Description

Fixes #14323

The survey-based prompts (the default prompter) determine the terminal size by writing a cursor-position request (`ESC[6n`, a Device Status Report) to stdout and then blocking on stdin until the terminal answers `ESC[<row>;<col>R`. A terminal emulator answers instantly, but a bare PTY without one behind it — CI wrappers, automation harnesses, pty-based RPC supervisors — never does, so the prompt hangs forever. Reproduction and evidence are in #14323.

The probing code lives in AlecAivazis/survey, which is archived, so the fix cannot land upstream. Following the precedent of #13366 (a stdin normalizer layered at the same seam), this PR wraps the streams handed to the survey prompter instead of forking the dependency:

- **Writer side** watches for `ESC[6n` and arms a 500 ms deadline (`GH_CURSOR_QUERY_TIMEOUT_MS` overrides it).
- **Reader side** waits for stdin with a bounded poll; if the deadline expires without a real cursor report, it injects a synthetic `ESC[<row>;<col>R` so the probe completes.
- **Fallback size** comes from `TIOCGWINSZ` (a bare pty still reports the harness's winsize), then `LINES`/`COLUMNS`, then 80x24.
- **Bytes that are not cursor reports pass through untouched**, so keystrokes typed early and real terminal answers behave exactly as before. survey's `BufferedReader` serves its `Buffer` first, which preserves early input across the injection.
- **Windows is a no-op**: survey's Windows cursor code uses the Console API and never issues a DSR (build-tagged files only).

This follows the accepted direction discussed in the issue (the "shallow wrapper" option), consistent with how the team handled the survey escape-sequence problem (#13366), and it is trivially removable once the huh-based prompter fully replaces survey.

### How did you test this change?

I built the modified `gh` and drove the exact scenario from the issue through a pty pair with no terminal emulator behind it (`gh auth refresh -h github.com -s delete_repo`, with a non-`gh` git credential helper configured so the confirm prompt runs):

- Without the fix, the process renders the confirm prompt, emits the size probe (`ESC 7 ESC[999;999f ESC[6n`), and hangs forever; the `y` I write to the pty is never consumed. This matches the issue's strace evidence.
- With the fix, the probe is answered synthetically (~500 ms), the confirm prompt accepts my `y`, renders `Yes`, and the flow continues into the device-code output — no hang.
- With a real terminal emulator answering the DSR (I reply with a real cursor report from the pty master and set a real winsize), behavior is unchanged: no synthetic reply is injected, the real winsize is used, and the flow completes.

I added `internal/prompter/survey_probe_reader_posix_test.go` with two tests driving a real pty from `github.com/creack/pty` (already a test dependency): one asserting the synthetic answer is injected on a silent pty, and one asserting a real terminal answer passes through verbatim and prevents injection. `go test ./internal/prompter/ -run 'TestSurveyPrompter|TestSurveyProbe|TestAccessiblePrompter|TestPrompter'` and `go test ./pkg/cmd/auth/... ./pkg/iostreams/` pass. The `TestHuhPrompter*` suite (unrelated to this change — huh never issues DSR probes) was already flaky/hanging on my machine before the change and was left out of the verification run.
