### PR TITLE
docs: announce Linux PGP key rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GitHub CLI
 
+> [!IMPORTANT]
+> GitHub CLI's PGP signing key rotation for Linux package repositories is effective September 5, 2026; users experiencing package installation or update problems can find solutions in the [public announcement](https://github.com/cli/cli/issues/13118).
+
 `gh` is GitHub on the command line. It brings pull requests, issues, and other GitHub concepts to the terminal next to where you are already working with `git` and your code.
 
 ![screenshot of gh pr status](https://user-images.githubusercontent.com/98482/84171218-327e7a80-aa40-11ea-8cd1-5177fc2d0e72.png)


### PR DESCRIPTION
Related to #13118

### Description

The PGP signing key for GitHub CLI Linux package repositories changes on September 5, 2026. This adds a prominent README alert that directs affected users to the public announcement for installation and update solutions.

### How did you test this change?

I inspected the README Markdown and confirmed the important alert appears directly below the title as a single sentence with a working link to the public announcement.

### Key points

The wording remains accurate before and after the effective date.

### Notes for reviewers

Start with the new alert at the top of `README.md`; #13118 contains the full announcement and remediation guidance.

### Authorship and follow-up

Who wrote this:

* [ ] A human wrote it.
* [x] An agent wrote it under close human direction.
* [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

* [x] @babakks will read and reply directly. Name the account.
* [ ] An agent will draft replies and @babakks will read them before they are posted.
* [ ] Nobody has explicitly committed to replying.