### PR TITLE
Remove obsolete Git test seams

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -57,8 +57,7 @@ type Client struct {
 	Stdin   io.Reader
 	Stdout  io.Writer
 
-	commandContext commandCtx
-	mu             sync.Mutex
+	mu sync.Mutex
 }
 
 func (c *Client) Copy() *Client {
@@ -69,18 +68,12 @@ func (c *Client) Copy() *Client {
 		Stderr:  c.Stderr,
 		Stdin:   c.Stdin,
 		Stdout:  c.Stdout,
-
-		commandContext: c.commandContext,
 	}
 }
 
 func (c *Client) Command(ctx context.Context, args ...string) (*Command, error) {
 	if c.RepoDir != "" {
 		args = append([]string{"-C", c.RepoDir}, args...)
-	}
-	commandContext := exec.CommandContext
-	if c.commandContext != nil {
-		commandContext = c.commandContext
 	}
 	var err error
 	c.mu.Lock()
@@ -91,7 +84,7 @@ func (c *Client) Command(ctx context.Context, args ...string) (*Command, error) 
 	if err != nil {
 		return nil, err
 	}
-	cmd := commandContext(ctx, c.GitPath, args...)
+	cmd := exec.CommandContext(ctx, c.GitPath, args...)
 	cmd.Stderr = c.Stderr
 	cmd.Stdin = c.Stdin
 	cmd.Stdout = c.Stdout
@@ -643,6 +636,10 @@ func (c *Client) PushRevision(ctx context.Context, branch string) (RemoteTrackin
 		return RemoteTrackingRef{}, err
 	}
 
+	return parsePushRevision(revParseOut)
+}
+
+func parsePushRevision(revParseOut []byte) (RemoteTrackingRef, error) {
 	ref, err := ParseRemoteTrackingRef(firstLine(revParseOut))
 	if err != nil {
 		return RemoteTrackingRef{}, fmt.Errorf("could not parse push revision: %v", err)

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -3,8 +3,6 @@ package git
 import (
 	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -244,19 +242,17 @@ func TestClientSetRemoteResolutionAddsResolution(t *testing.T) {
 }
 
 func TestClientSetRemoteResolutionPropagatesGitError(t *testing.T) {
-	// Given Git will fail while setting a remote resolution
-	_, cmdCtx := createCommandContext(t, 2, "", "git error message")
-	client := Client{
-		GitPath:        "path/to/git",
-		commandContext: cmdCtx,
-	}
+	// Given a client whose repository directory does not exist
+	client := Client{RepoDir: filepath.Join(t.TempDir(), "missing")}
 
 	// When a remote resolution is set
 	err := client.SetRemoteResolution(t.Context(), "origin", "base")
 
 	// Then the Git error is returned
 	require.Error(t, err)
-	assert.EqualError(t, err, "failed to run git: git error message")
+	var gitErr *GitError
+	require.ErrorAs(t, err, &gitErr)
+	assert.NotZero(t, gitErr.ExitCode)
 }
 
 func TestClientCurrentBranchReturnsCurrentBranch(t *testing.T) {
@@ -332,19 +328,17 @@ func TestClientConfigReportsUnknownKey(t *testing.T) {
 }
 
 func TestClientConfigPropagatesGitError(t *testing.T) {
-	// Given Git will fail with an unexpected exit status
-	_, cmdCtx := createCommandContext(t, 2, "", "git error message")
-	client := Client{
-		GitPath:        "path/to/git",
-		commandContext: cmdCtx,
-	}
+	// Given a client whose repository directory does not exist
+	client := Client{RepoDir: filepath.Join(t.TempDir(), "missing")}
 
 	// When configuration is read
 	value, err := client.Config(t.Context(), "credential.helper")
 
 	// Then the Git error is returned unchanged
 	require.Error(t, err)
-	assert.EqualError(t, err, "failed to run git: git error message")
+	var gitErr *GitError
+	require.ErrorAs(t, err, &gitErr)
+	assert.NotZero(t, gitErr.ExitCode)
 	assert.Empty(t, value)
 }
 
@@ -795,15 +789,12 @@ func TestClientPushRevisionReportsUnresolvedBranch(t *testing.T) {
 	assert.Empty(t, trackingRef)
 }
 
-func TestClientPushRevisionReportsMalformedSymbolicRef(t *testing.T) {
+func TestParsePushRevisionReportsMalformedSymbolicRef(t *testing.T) {
 	// Given Git returns a symbolic push ref outside refs/remotes
-	cmdCtx := createMockedCommandContext(t, mockedCommands{
-		`path/to/git rev-parse --symbolic-full-name trunk@{push}`: {Stdout: "not/a/valid/remote/ref"},
-	})
-	client := Client{GitPath: "path/to/git", commandContext: cmdCtx}
+	output := []byte("not/a/valid/remote/ref")
 
 	// When the push revision is parsed
-	trackingRef, err := client.PushRevision(t.Context(), "trunk")
+	trackingRef, err := parsePushRevision(output)
 
 	// Then the malformed ref is reported with context
 	require.EqualError(t, err, "could not parse push revision: remote tracking branch must have format refs/remotes/<remote>/<branch> but was: not/a/valid/remote/ref")
@@ -1123,19 +1114,17 @@ func TestClientUnsetRemoteResolutionRemovesResolution(t *testing.T) {
 }
 
 func TestClientUnsetRemoteResolutionPropagatesGitError(t *testing.T) {
-	// Given Git will fail while unsetting a remote resolution
-	_, cmdCtx := createCommandContext(t, 2, "", "git error message")
-	client := Client{
-		GitPath:        "path/to/git",
-		commandContext: cmdCtx,
-	}
+	// Given a client whose repository directory does not exist
+	client := Client{RepoDir: filepath.Join(t.TempDir(), "missing")}
 
 	// When a remote resolution is unset
 	err := client.UnsetRemoteResolution(t.Context(), "origin")
 
 	// Then the Git error is returned
 	require.Error(t, err)
-	assert.EqualError(t, err, "failed to run git: git error message")
+	var gitErr *GitError
+	require.ErrorAs(t, err, &gitErr)
+	assert.NotZero(t, gitErr.ExitCode)
 }
 
 func TestClientSetRemoteBranchesLimitsTrackedBranches(t *testing.T) {
@@ -1201,18 +1190,15 @@ func TestClientFetchReportsMissingRef(t *testing.T) {
 
 func TestClientFetchUsesAuthenticatedCommand(t *testing.T) {
 	// Given a client that records the Git command
-	cmd, cmdCtx := createCommandContext(t, 0, "", "")
-	client := Client{
-		GitPath:        "path/to/git",
-		commandContext: cmdCtx,
-	}
+	var gotArgs []string
+	client := Client{GitPath: "path/to/git"}
 
 	// When a remote branch is fetched
-	err := client.Fetch(t.Context(), "origin", "trunk")
+	err := client.Fetch(t.Context(), "origin", "trunk", recordCommandArgs(t, &gotArgs))
 
 	// Then Git clears existing helpers and scopes gh credentials to all hosts
 	require.NoError(t, err)
-	assert.Equal(t, []string{"path/to/git", "-c", "credential.helper=", "-c", `credential.helper=!"gh" auth git-credential`, "fetch", "origin", "trunk"}, cmd.Args[3:])
+	assert.Equal(t, []string{"path/to/git", "-c", "credential.helper=", "-c", `credential.helper=!"gh" auth git-credential`, "fetch", "origin", "trunk"}, gotArgs)
 }
 
 func TestClientPullFastForwardsCurrentBranch(t *testing.T) {
@@ -1268,18 +1254,15 @@ func TestClientPullRejectsNonFastForwardUpdate(t *testing.T) {
 
 func TestClientPullUsesAuthenticatedFastForwardOnlyCommand(t *testing.T) {
 	// Given a client that records the Git command
-	cmd, cmdCtx := createCommandContext(t, 0, "", "")
-	client := Client{
-		GitPath:        "path/to/git",
-		commandContext: cmdCtx,
-	}
+	var gotArgs []string
+	client := Client{GitPath: "path/to/git"}
 
 	// When a remote branch is pulled
-	err := client.Pull(t.Context(), "origin", "trunk")
+	err := client.Pull(t.Context(), "origin", "trunk", recordCommandArgs(t, &gotArgs))
 
 	// Then Git clears existing helpers, scopes gh credentials, and requires a fast-forward
 	require.NoError(t, err)
-	assert.Equal(t, []string{"path/to/git", "-c", "credential.helper=", "-c", `credential.helper=!"gh" auth git-credential`, "pull", "--ff-only", "origin", "trunk"}, cmd.Args[3:])
+	assert.Equal(t, []string{"path/to/git", "-c", "credential.helper=", "-c", `credential.helper=!"gh" auth git-credential`, "pull", "--ff-only", "origin", "trunk"}, gotArgs)
 }
 
 func TestClientPushCreatesRemoteBranchAndUpstream(t *testing.T) {
@@ -1315,18 +1298,15 @@ func TestClientPushReportsMissingRemote(t *testing.T) {
 
 func TestClientPushUsesAuthenticatedUpstreamCommand(t *testing.T) {
 	// Given a client that records the Git command
-	cmd, cmdCtx := createCommandContext(t, 0, "", "")
-	client := Client{
-		GitPath:        "path/to/git",
-		commandContext: cmdCtx,
-	}
+	var gotArgs []string
+	client := Client{GitPath: "path/to/git"}
 
 	// When a branch is pushed
-	err := client.Push(t.Context(), "origin", "trunk")
+	err := client.Push(t.Context(), "origin", "trunk", recordCommandArgs(t, &gotArgs))
 
 	// Then Git clears existing helpers, scopes gh credentials, and sets the upstream
 	require.NoError(t, err)
-	assert.Equal(t, []string{"path/to/git", "-c", "credential.helper=", "-c", `credential.helper=!"gh" auth git-credential`, "push", "--set-upstream", "origin", "trunk"}, cmd.Args[3:])
+	assert.Equal(t, []string{"path/to/git", "-c", "credential.helper=", "-c", `credential.helper=!"gh" auth git-credential`, "push", "--set-upstream", "origin", "trunk"}, gotArgs)
 }
 
 func TestClientCloneCreatesWorkingRepositoryInModifiedRepoDir(t *testing.T) {
@@ -1410,18 +1390,15 @@ func TestClientCloneReportsMissingRepository(t *testing.T) {
 
 func TestClientCloneUsesHostScopedAuthenticatedCommand(t *testing.T) {
 	// Given a client that records the Git command
-	cmd, cmdCtx := createCommandContext(t, 0, "", "")
-	client := Client{
-		GitPath:        "path/to/git",
-		commandContext: cmdCtx,
-	}
+	var gotArgs []string
+	client := Client{GitPath: "path/to/git"}
 
 	// When an HTTPS repository is cloned
-	_, err := client.Clone(t.Context(), "https://github.com/cli/cli", nil)
+	_, err := client.Clone(t.Context(), "https://github.com/cli/cli", nil, recordCommandArgs(t, &gotArgs))
 
 	// Then Git clears existing helpers and scopes gh credentials to the repository host
 	require.NoError(t, err)
-	assert.Equal(t, []string{"path/to/git", "-c", "credential.https://github.com.helper=", "-c", `credential.https://github.com.helper=!"gh" auth git-credential`, "clone", "https://github.com/cli/cli"}, cmd.Args[3:])
+	assert.Equal(t, []string{"path/to/git", "-c", "credential.https://github.com.helper=", "-c", `credential.https://github.com.helper=!"gh" auth git-credential`, "clone", "https://github.com/cli/cli"}, gotArgs)
 }
 
 func TestParseCloneArgs(t *testing.T) {
@@ -1589,81 +1566,21 @@ func runGitAt(t *testing.T, dir string, args ...string) string {
 	return strings.TrimSpace(string(output))
 }
 
-type args string
-
-type commandResult struct {
-	ExitStatus int    `json:"exitStatus"`
-	Stdout     string `json:"out"`
-	Stderr     string `json:"err"`
-}
-
-type mockedCommands map[args]commandResult
-
-// TestCommandMocking is an invoked test helper that emulates expected behavior for predefined shell commands, erroring when unexpected conditions are encountered.
-func TestCommandMocking(t *testing.T) {
-	if os.Getenv("GH_WANT_HELPER_PROCESS_RICH") != "1" {
+func TestGitCommandHelperProcess(t *testing.T) {
+	if len(os.Args) != 7 || os.Args[3] != "git-command-helper" {
 		return
 	}
 
-	jsonVar, ok := os.LookupEnv("GH_HELPER_PROCESS_RICH_COMMANDS")
-	if !ok {
-		fmt.Fprint(os.Stderr, "missing GH_HELPER_PROCESS_RICH_COMMANDS")
-		// Exit 1 is used for empty key values in the git config. This is non-breaking in those use cases,
-		// so this is returning a non-zero exit code to avoid suppressing this error for those use cases.
-		os.Exit(16)
+	exitStatus, err := strconv.Atoi(os.Args[4])
+	if err != nil {
+		fmt.Fprint(os.Stderr, "invalid helper process exit status")
+		os.Exit(1)
 	}
-
-	var commands mockedCommands
-	if err := json.Unmarshal([]byte(jsonVar), &commands); err != nil {
-		fmt.Fprint(os.Stderr, "failed to unmarshal GH_HELPER_PROCESS_RICH_COMMANDS")
-		// Exit 1 is used for empty key values in the git config. This is non-breaking in those use cases,
-		// so this is returning a non-zero exit code to avoid suppressing this error for those use cases.
-		os.Exit(16)
+	fmt.Fprint(os.Stdout, os.Args[5])
+	if exitStatus != 0 {
+		fmt.Fprint(os.Stderr, os.Args[6])
 	}
-
-	// The discarded args are those for the go test binary itself, e.g. `-test.run=TestHelperProcessRich`
-	realArgs := os.Args[3:]
-
-	commandResult, ok := commands[args(strings.Join(realArgs, " "))]
-	if !ok {
-		fmt.Fprintf(os.Stderr, "unexpected command: %s\n", strings.Join(realArgs, " "))
-		// Exit 1 is used for empty key values in the git config. This is non-breaking in those use cases,
-		// so this is returning a non-zero exit code to avoid suppressing this error for those use cases.
-		os.Exit(16)
-	}
-
-	if commandResult.Stdout != "" {
-		fmt.Fprint(os.Stdout, commandResult.Stdout)
-	}
-
-	if commandResult.Stderr != "" {
-		fmt.Fprint(os.Stderr, commandResult.Stderr)
-	}
-
-	os.Exit(commandResult.ExitStatus)
-}
-
-func TestHelperProcess(t *testing.T) {
-	if os.Getenv("GH_WANT_HELPER_PROCESS") != "1" {
-		return
-	}
-	if err := func(args []string) error {
-		fmt.Fprint(os.Stdout, os.Getenv("GH_HELPER_PROCESS_STDOUT"))
-		exitStatus := os.Getenv("GH_HELPER_PROCESS_EXIT_STATUS")
-		if exitStatus != "0" {
-			return errors.New("error")
-		}
-		return nil
-	}(os.Args[3:]); err != nil {
-		fmt.Fprint(os.Stderr, os.Getenv("GH_HELPER_PROCESS_STDERR"))
-		exitStatus := os.Getenv("GH_HELPER_PROCESS_EXIT_STATUS")
-		i, err := strconv.Atoi(exitStatus)
-		if err != nil {
-			os.Exit(1)
-		}
-		os.Exit(i)
-	}
-	os.Exit(0)
+	os.Exit(exitStatus)
 }
 
 func TestCredentialPatternFromGitURL(t *testing.T) {
@@ -1741,37 +1658,25 @@ func TestParsePushDefaultReportsUnknownValue(t *testing.T) {
 	assert.Empty(t, pushDefault)
 }
 
-func createCommandContext(t *testing.T, exitStatus int, stdout, stderr string) (*exec.Cmd, commandCtx) {
+func createCommand(t *testing.T, exitStatus int, stdout, stderr string) *exec.Cmd {
 	t.Helper()
-	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestHelperProcess", "--")
-	cmd.Env = append(os.Environ(),
-		"GH_WANT_HELPER_PROCESS=1",
-		fmt.Sprintf("GH_HELPER_PROCESS_STDOUT=%s", stdout),
-		fmt.Sprintf("GH_HELPER_PROCESS_STDERR=%s", stderr),
-		fmt.Sprintf("GH_HELPER_PROCESS_EXIT_STATUS=%v", exitStatus),
+	return exec.CommandContext(
+		context.Background(),
+		os.Args[0],
+		"-test.run=^TestGitCommandHelperProcess$",
+		"--",
+		"git-command-helper",
+		strconv.Itoa(exitStatus),
+		stdout,
+		stderr,
 	)
-	return cmd, func(ctx context.Context, exe string, args ...string) *exec.Cmd {
-		cmd.Args = append(cmd.Args, exe)
-		cmd.Args = append(cmd.Args, args...)
-		return cmd
-	}
 }
 
-func createMockedCommandContext(t *testing.T, commands mockedCommands) commandCtx {
-	marshaledCommands, err := json.Marshal(commands)
-	require.NoError(t, err)
-
-	// invokes helper within current test binary, emulating desired behavior
-	return func(ctx context.Context, exe string, args ...string) *exec.Cmd {
-		cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestCommandMocking", "--")
-		cmd.Env = append(os.Environ(),
-			"GH_WANT_HELPER_PROCESS_RICH=1",
-			fmt.Sprintf("GH_HELPER_PROCESS_RICH_COMMANDS=%s", string(marshaledCommands)),
-		)
-
-		cmd.Args = append(cmd.Args, exe)
-		cmd.Args = append(cmd.Args, args...)
-		return cmd
+func recordCommandArgs(t *testing.T, gotArgs *[]string) CommandModifier {
+	t.Helper()
+	return func(cmd *Command) {
+		*gotArgs = append([]string(nil), cmd.Args...)
+		cmd.Cmd = createCommand(t, 0, "", "")
 	}
 }
 
@@ -1803,19 +1708,16 @@ func TestClientRemoteURLReportsMissingRemote(t *testing.T) {
 }
 
 func TestClientRemoteURLSeparatesRemoteNameFromOptions(t *testing.T) {
-	// Given a remote name that resembles a Git option
-	cmd, cmdCtx := createCommandContext(t, 0, "https://example.com/repo.git\n", "")
-	client := Client{
-		GitPath:        "path/to/git",
-		commandContext: cmdCtx,
-	}
+	// Given a configured remote whose name resembles a Git option
+	repo := newTestRepo(t)
+	repo.run(t, "config", "remote.--upload-pack=malicious.url", "https://example.com/repo.git")
 
 	// When the remote URL is requested
-	_, err := client.RemoteURL(t.Context(), "--upload-pack=malicious")
+	remoteURL, err := repo.client.RemoteURL(t.Context(), "--upload-pack=malicious")
 
 	// Then an option separator protects the remote name
 	require.NoError(t, err)
-	assert.Equal(t, "path/to/git remote get-url -- --upload-pack=malicious", strings.Join(cmd.Args[3:], " "))
+	assert.Equal(t, "https://example.com/repo.git", remoteURL)
 }
 
 func TestClientRemoteURLReportsMissingGitExecutable(t *testing.T) {
@@ -1871,20 +1773,17 @@ func TestClientIsIgnoredReportsFatalGitError(t *testing.T) {
 }
 
 func TestClientIsIgnoredSeparatesPathFromOptions(t *testing.T) {
-	// Given a path that resembles a Git option
-	cmd, cmdCtx := createCommandContext(t, 0, "", "")
-	client := Client{
-		GitPath:        "path/to/git",
-		commandContext: cmdCtx,
-	}
+	// Given an ignored path that resembles a Git option
+	repo := newTestRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(repo.dir, ".gitignore"), []byte("--no-index\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(repo.dir, "--no-index"), nil, 0600))
 
 	// When the path is checked
-	ignored, err := client.IsIgnored(t.Context(), "--no-index")
+	ignored, err := repo.client.IsIgnored(t.Context(), "--no-index")
 
 	// Then an option separator protects the path
 	require.NoError(t, err)
-	assert.True(t, ignored, "the successful Git result should report the path as ignored")
-	assert.Equal(t, "path/to/git check-ignore -q -- --no-index", strings.Join(cmd.Args[3:], " "))
+	assert.True(t, ignored, "expected option-like path to match its ignore rule")
 }
 
 func TestClientIsIgnoredReportsMissingGitExecutable(t *testing.T) {

--- a/git/command.go
+++ b/git/command.go
@@ -2,15 +2,12 @@ package git
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"io"
 	"os/exec"
 
 	"github.com/cli/cli/v2/internal/run"
 )
-
-type commandCtx = func(ctx context.Context, name string, args ...string) *exec.Cmd
 
 type Command struct {
 	*exec.Cmd

--- a/git/command_test.go
+++ b/git/command_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestOutputReturnsCommandOutput(t *testing.T) {
 	// Given a command that writes to standard output
-	cmd, _ := createCommandContext(t, 0, "hello world", "")
+	cmd := createCommand(t, 0, "hello world", "")
 	command := Command{cmd}
 
 	// When its output is captured
@@ -23,7 +23,7 @@ func TestOutputReturnsCommandOutput(t *testing.T) {
 func TestOutputReturnsGitError(t *testing.T) {
 	// Given a command that fails with Git's not-a-repository diagnostic
 	stderr := "fatal: not a git repository (or any of the parent directories): .git"
-	cmd, _ := createCommandContext(t, 128, "", stderr)
+	cmd := createCommand(t, 128, "", stderr)
 	command := Command{cmd}
 
 	// When its output is captured


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

N/A. This is the final code layer above draft PR #14351.

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

Layers 1-4 moved Git client tests onto real local repositories and focused command assertions, but the package still carried two subprocess mock protocols and a private `Client.commandContext` production field used only by tests.

This removes that field and its `commandCtx` alias, deletes the rich JSON/environment command-mocking protocol, and replaces the remaining uses with observable real-Git state, the existing `CommandModifier` seam, or a narrow malformed-output parser. The one surviving subprocess helper now accepts explicit arguments instead of test-only environment variables.

### How did you test this change?

<!--
Report only actions you actually performed and results you actually observed, using factual
first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
hypothetical, inferred, or merely expected scenarios as testing.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

If you did not exercise the changed behavior, write `Not tested` and explain why.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
   Given I was in a repo with no open pull requests
   When I ran `gh pr list`
   Then I saw "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

Not tested manually because this is a behavior-preserving cleanup of internal test infrastructure with no user-visible command change.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- Removed `Client.commandContext`, `commandCtx`, `createCommandContext`, `createMockedCommandContext`, `TestHelperProcess`, `TestCommandMocking`, `commandResult`, `mockedCommands`, and all `GH_*HELPER_PROCESS*` variables from `git` tests. `createCommitsCommandContext` and `TestCommitsHelperProcess` already had zero remaining definitions or callers at the layer-5 baseline.
- Retained one focused `TestGitCommandHelperProcess` plus `createCommand` for `Command.Output` stdout/stderr/exit behavior and `recordCommandArgs` for operation-to-auth wiring. These remain necessary to protect exact credential-helper clearing/scoping, `pull --ff-only`, push `--set-upstream`, and clone host scoping without executing a fake Git path.
- Moved `RemoteURL` and `IsIgnored` option-separator checks to observable real-Git state. Moved malformed push-revision output to a narrow parser seam. Real missing repository directories now prove arbitrary Git error propagation.
- Preserved command modifiers, missing executable behavior, local-only Git transport coverage, literal Given/When/Then scenarios, and the layer-4 test shape.
- Baseline `git` package metrics were 9.058s normal, 19.174s race, and 86.1% coverage. Final uncontended metrics were 8.074s normal, 14.688s race, and 86.4% coverage.
- Net diff: 78 additions, 185 deletions, 107 fewer lines across 4 files.
- Deliberately deferred moving `git.IsolateConfig` out of `git/test.go`: no existing internal test-support package fits, and introducing one would only relocate the production `testing` dependency while touching three consumer packages and exporting a test-only internal API.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `Client.Command` in `git/client.go`, then review the authenticated operation tests and real-Git option-boundary scenarios in `git/client_test.go`. This PR targets `williammartin-improve-git-tests`, the branch for draft PR #14351. Stack metadata is intentionally unchanged.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.