### PR TITLE
Run acceptance tests in Actions with a GitHub App token

### DIFF
--- a/.github/skills/writing-acceptance-tests/SKILL.md
+++ b/.github/skills/writing-acceptance-tests/SKILL.md
@@ -9,7 +9,8 @@ Acceptance tests exercise `gh` against live GitHub resources. Minimize repositor
 creation and cloning without allowing concurrent scripts to interfere.
 
 Read `acceptance/README.md` and nearby scripts before editing. Test groups are
-discovered from `acceptance/testdata/<group>/`; do not register them manually.
+discovered from `acceptance/testdata/<group>/`; do not register them in the Go
+harness, workflow, or dispatch helper.
 
 ## Declare token capability
 

--- a/.github/skills/writing-acceptance-tests/SKILL.md
+++ b/.github/skills/writing-acceptance-tests/SKILL.md
@@ -8,9 +8,7 @@ description: Use when adding or changing GitHub CLI acceptance tests, txtar scri
 Acceptance tests exercise `gh` against live GitHub resources. Minimize repository
 creation and cloning without allowing concurrent scripts to interfere.
 
-Read `acceptance/README.md` and nearby scripts before editing. Test groups are
-discovered from `acceptance/testdata/<group>/`; do not register them in the Go
-harness, workflow, or dispatch helper.
+Read `acceptance/README.md` and nearby scripts before editing.
 
 ## Declare token capability
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,66 @@
+name: Acceptance Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch or commit to test
+        required: true
+        default: trunk
+        type: string
+      os:
+        description: Operating system to test
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+      command:
+        description: Command tests to run, or all
+        required: true
+        default: all
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  acceptance:
+    environment: gh-acceptance-testing
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(inputs.os == 'all' && '["ubuntu-latest","windows-latest","macos-latest"]' || format('["{0}"]', inputs.os)) }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out tested revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Generate acceptance test token
+        id: acceptance-token
+        # actions/create-github-app-token v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # zizmor: ignore[github-app] - The disposable test organization intentionally exercises all App permissions.
+        with:
+          client-id: ${{ secrets.GH_ACCEPTANCE_TESTING_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_ACCEPTANCE_TESTING_APP_PRIVATE_KEY }}
+          owner: gh-acceptance-testing # zizmor: ignore[github-app] - Tests create repositories dynamically, so the token needs installation-wide access.
+
+      - name: Run acceptance tests
+        env:
+          GH_ACCEPTANCE_HOST: github.com
+          GH_ACCEPTANCE_ORG: gh-acceptance-testing
+          GH_ACCEPTANCE_TOKEN: ${{ steps.acceptance-token.outputs.token }}
+          GH_ACCEPTANCE_GROUP: ${{ inputs.command }}
+        run: go test -tags=acceptance ./acceptance

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -22,10 +22,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: acceptance-tests
-  cancel-in-progress: false
-
 jobs:
   acceptance:
     environment: gh-acceptance-testing

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -3,11 +3,6 @@ name: Acceptance Tests
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: Branch or commit to test
-        required: true
-        default: trunk
-        type: string
       os:
         description: Operating system to test
         required: true
@@ -27,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: acceptance-tests
+  cancel-in-progress: false
+
 jobs:
   acceptance:
     environment: gh-acceptance-testing
@@ -40,7 +39,6 @@ jobs:
       - name: Check out tested revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Set up Go

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -26,11 +26,60 @@ It's recommended to create and use a Legacy PAT for this; Fine-Grained PATs do n
 
 The test harness infers whether a token authenticates a user from GitHub's documented token prefixes. OAuth (`gho_`), classic PAT (`ghp_`), fine-grained PAT (`github_pat_`), and GitHub App user (`ghu_`) tokens provide user capabilities. GitHub App installation (`ghs_`) tokens do not, so scripts marked `requires-user-capability: true` are omitted from unfiltered runs. Explicitly selecting an incompatible script with `GH_ACCEPTANCE_SCRIPT` fails with an error instead.
 
+Users with write access can manually run the acceptance test workflow for a specified branch or commit. A run can target Linux, Windows, macOS, or all three, and can run either the complete suite or the tests for one command. The tests use a GitHub App installed for all repositories in the `gh-acceptance-testing` organization. The workflow uses the `gh-acceptance-testing` environment, where the App credentials are stored as the `GH_ACCEPTANCE_TESTING_APP_CLIENT_ID` and `GH_ACCEPTANCE_TESTING_APP_PRIVATE_KEY` secrets. Tests that require user authentication, including account key management and forks owned by a personal account, are excluded from this workflow based on each script's `requires-user-capability` declaration.
+
 Managed fixture repositories reduce repository creation by sharing state where
-tests can safely coexist.
+tests can safely coexist. Avoid overlapping full-suite workflow runs because
+every job uses the same GitHub App installation rate-limit buckets.
+
+After the workflow exists on the default branch, use
+`script/run-acceptance [REF] [COMMAND] [OS]` to dispatch it for a branch or
+commit. The ref defaults to the current branch, while the command and operating
+system default to `all`. List the available command groups with:
+
+```sh
+script/run-acceptance groups
+```
 
 Acceptance test groups are discovered from the directories under `testdata`, so
-adding a group does not require updating the test harness.
+adding a group does not require updating the workflow or dispatch helper.
+
+#### How the Acceptance Test GitHub App Was Created
+
+The GitHub App is owned by `gh-acceptance-testing` and restricted to installation on that
+account. The organization is dedicated to acceptance testing, so the App was intentionally
+granted broad installation permissions to let the suite exercise repository and
+organization administration without repeatedly changing the App registration.
+
+1. In the `gh-acceptance-testing` organization settings, **Developer settings**,
+   **GitHub Apps**, then **New GitHub App** were selected. See
+   [Registering a GitHub App](https://docs.github.com/apps/creating-github-apps/registering-a-github-app/registering-a-github-app).
+2. The App was given a globally unique name and `https://github.com/cli/cli` as its
+   homepage. No callback or redirect URI was configured, **Expire user authorization
+   tokens**, **Request user authorization (OAuth) during installation**, and
+   **Enable Device Flow** were disabled. No post-installation **Setup URL** was
+   configured and **Redirect on update** was disabled. Webhooks were also disabled,
+   and **Only on this account** was selected under
+   **Where can this GitHub App be installed?**
+3. Every **Repository permission** and **Organization permission** was set to the highest
+   available access. **Account permissions** were not requested because an installation
+   token does not authenticate a user, and the harness skips tests that require user
+   capabilities.
+4. After the App was created, its **Client ID** was recorded and **Generate a private
+   key** was selected. The complete downloaded PEM file became the private-key secret;
+   GitHub stores only the public half of the generated key. See
+   [Managing private keys for GitHub Apps](https://docs.github.com/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps).
+5. From the App settings, **Install App** was selected, followed by
+   `gh-acceptance-testing` and **All repositories**. See
+   [Installing your own GitHub App](https://docs.github.com/apps/using-github-apps/installing-your-own-github-app).
+6. A `gh-acceptance-testing` environment was created in the `cli/cli` repository without
+   required reviewers. It contains these environment secrets:
+   - `GH_ACCEPTANCE_TESTING_APP_CLIENT_ID`: the App's Client ID.
+   - `GH_ACCEPTANCE_TESTING_APP_PRIVATE_KEY`: the complete contents of the downloaded PEM file.
+
+Each operating-system job mints its own installation token. The token is scoped to the
+`gh-acceptance-testing` installation, covers all repositories in that installation, and
+expires after one hour.
 
 ---
 

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -26,16 +26,17 @@ It's recommended to create and use a Legacy PAT for this; Fine-Grained PATs do n
 
 The test harness infers whether a token authenticates a user from GitHub's documented token prefixes. OAuth (`gho_`), classic PAT (`ghp_`), fine-grained PAT (`github_pat_`), and GitHub App user (`ghu_`) tokens provide user capabilities. GitHub App installation (`ghs_`) tokens do not, so scripts marked `requires-user-capability: true` are omitted from unfiltered runs. Explicitly selecting an incompatible script with `GH_ACCEPTANCE_SCRIPT` fails with an error instead.
 
-Users with write access can manually run the acceptance test workflow for a specified branch or commit. A run can target Linux, Windows, macOS, or all three, and can run either the complete suite or the tests for one command. The tests use a GitHub App installed for all repositories in the `gh-acceptance-testing` organization. The workflow uses the `gh-acceptance-testing` environment, where the App credentials are stored as the `GH_ACCEPTANCE_TESTING_APP_CLIENT_ID` and `GH_ACCEPTANCE_TESTING_APP_PRIVATE_KEY` secrets. Tests that require user authentication, including account key management and forks owned by a personal account, are excluded from this workflow based on each script's `requires-user-capability` declaration.
+Users with write access can manually run the acceptance test workflow from a specified branch or tag in `cli/cli`. A run can target Linux, Windows, macOS, or all three, and can run either the complete suite or the tests for one command. The tests use a GitHub App installed for all repositories in the `gh-acceptance-testing` organization. The workflow uses the `gh-acceptance-testing` environment, where the App credentials are stored as the `GH_ACCEPTANCE_TESTING_APP_CLIENT_ID` and `GH_ACCEPTANCE_TESTING_APP_PRIVATE_KEY` secrets. Tests that require user authentication, including account key management and forks owned by a personal account, are excluded from this workflow based on each script's `requires-user-capability` declaration.
 
 Managed fixture repositories reduce repository creation by sharing state where
-tests can safely coexist. Avoid overlapping full-suite workflow runs because
-every job uses the same GitHub App installation rate-limit buckets.
+tests can safely coexist. Workflow runs are serialized because every job uses
+the same GitHub App installation rate-limit buckets.
 
 After the workflow exists on the default branch, use
-`script/run-acceptance [REF] [COMMAND] [OS]` to dispatch it for a branch or
-commit. The ref defaults to the current branch, while the command and operating
-system default to `all`. List the available command groups with:
+`script/run-acceptance [REF] [COMMAND] [OS]` to dispatch the version of the
+workflow on a branch or tag in `cli/cli`. The ref defaults to the current branch,
+while the command and operating system default to `all`. List the available
+command groups with:
 
 ```sh
 script/run-acceptance groups
@@ -72,8 +73,9 @@ organization administration without repeatedly changing the App registration.
 5. From the App settings, **Install App** was selected, followed by
    `gh-acceptance-testing` and **All repositories**. See
    [Installing your own GitHub App](https://docs.github.com/apps/using-github-apps/installing-your-own-github-app).
-6. A `gh-acceptance-testing` environment was created in the `cli/cli` repository without
-   required reviewers. It contains these environment secrets:
+6. A `gh-acceptance-testing` environment was created in the `cli/cli` repository. Access
+   requires approval from `cli/code-reviewers`, with self-review and administrator bypass
+   disabled. It contains these environment secrets:
    - `GH_ACCEPTANCE_TESTING_APP_CLIENT_ID`: the App's Client ID.
    - `GH_ACCEPTANCE_TESTING_APP_PRIVATE_KEY`: the complete contents of the downloaded PEM file.
 

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -29,8 +29,9 @@ The test harness infers whether a token authenticates a user from GitHub's docum
 Users with write access can manually run the acceptance test workflow from a specified branch or tag in `cli/cli`. A run can target Linux, Windows, macOS, or all three, and can run either the complete suite or the tests for one command. The tests use a GitHub App installed for all repositories in the `gh-acceptance-testing` organization. The workflow uses the `gh-acceptance-testing` environment, where the App credentials are stored as the `GH_ACCEPTANCE_TESTING_APP_CLIENT_ID` and `GH_ACCEPTANCE_TESTING_APP_PRIVATE_KEY` secrets. Tests that require user authentication, including account key management and forks owned by a personal account, are excluded from this workflow based on each script's `requires-user-capability` declaration.
 
 Managed fixture repositories reduce repository creation by sharing state where
-tests can safely coexist. Workflow runs are serialized because every job uses
-the same GitHub App installation rate-limit buckets.
+tests can safely coexist. Every job uses the same GitHub App installation
+rate-limit buckets. The dispatch helper warns when another acceptance workflow
+is already in flight and asks interactive users to confirm another run.
 
 After the workflow exists on the default branch, use
 `script/run-acceptance [REF] [COMMAND] [OS]` to dispatch the version of the

--- a/script/run-acceptance
+++ b/script/run-acceptance
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly repository="cli/cli"
+readonly workflow="acceptance.yml"
+readonly workflow_ref="trunk"
+readonly operating_systems="all ubuntu-latest windows-latest macos-latest"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly repo_root
+readonly testdata_dir="$repo_root/acceptance/testdata"
+
+usage() {
+  cat <<EOF
+Usage: script/run-acceptance [REF] [COMMAND] [OS]
+
+Dispatch acceptance tests for a branch or commit. REF defaults to the current
+branch. COMMAND and OS default to "all".
+
+List available command groups:
+  script/run-acceptance groups
+EOF
+}
+
+contains() {
+  local expected="$1"
+  shift
+
+  local candidate
+  for candidate in "$@"; do
+    if [[ "$candidate" == "$expected" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+test_groups() {
+  echo "all"
+
+  local directory
+  for directory in "$testdata_dir"/*; do
+    if [[ -d "$directory" ]]; then
+      basename "$directory"
+    fi
+  done
+}
+
+if [[ "${1:-}" == "groups" ]]; then
+  test_groups
+  exit
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit
+fi
+
+ref="${1:-}"
+command="${2:-all}"
+operating_system="${3:-all}"
+
+command_values=()
+while IFS= read -r group; do
+  command_values+=("$group")
+done < <(test_groups)
+if ! contains "$command" "${command_values[@]}"; then
+  echo "invalid command: $command" >&2
+  exit 1
+fi
+
+read -r -a operating_system_values <<<"$operating_systems"
+if ! contains "$operating_system" "${operating_system_values[@]}"; then
+  echo "invalid operating system: $operating_system" >&2
+  exit 1
+fi
+
+if [[ -z "$ref" ]]; then
+  ref="$(git branch --show-current)"
+  if [[ -z "$ref" ]]; then
+    echo "ref is required when HEAD is detached" >&2
+    exit 1
+  fi
+fi
+
+gh workflow run "$workflow" \
+  --repo "$repository" \
+  --ref "$workflow_ref" \
+  --raw-field "ref=$ref" \
+  --raw-field "command=$command" \
+  --raw-field "os=$operating_system"
+
+printf 'Dispatched acceptance tests for %s\n' "$ref"

--- a/script/run-acceptance
+++ b/script/run-acceptance
@@ -4,7 +4,6 @@ set -euo pipefail
 
 readonly repository="cli/cli"
 readonly workflow="acceptance.yml"
-readonly workflow_ref="trunk"
 readonly operating_systems="all ubuntu-latest windows-latest macos-latest"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly repo_root
@@ -14,8 +13,8 @@ usage() {
   cat <<EOF
 Usage: script/run-acceptance [REF] [COMMAND] [OS]
 
-Dispatch acceptance tests for a branch or commit. REF defaults to the current
-branch. COMMAND and OS default to "all".
+Dispatch acceptance tests using the workflow from a branch or tag. REF defaults
+to the current branch. COMMAND and OS default to "all".
 
 List available command groups:
   script/run-acceptance groups
@@ -85,8 +84,7 @@ fi
 
 gh workflow run "$workflow" \
   --repo "$repository" \
-  --ref "$workflow_ref" \
-  --raw-field "ref=$ref" \
+  --ref "$ref" \
   --raw-field "command=$command" \
   --raw-field "os=$operating_system"
 

--- a/script/run-acceptance
+++ b/script/run-acceptance
@@ -59,15 +59,6 @@ ref="${1:-}"
 command="${2:-all}"
 operating_system="${3:-all}"
 
-command_values=()
-while IFS= read -r group; do
-  command_values+=("$group")
-done < <(test_groups)
-if ! contains "$command" "${command_values[@]}"; then
-  echo "invalid command: $command" >&2
-  exit 1
-fi
-
 read -r -a operating_system_values <<<"$operating_systems"
 if ! contains "$operating_system" "${operating_system_values[@]}"; then
   echo "invalid operating system: $operating_system" >&2
@@ -79,6 +70,25 @@ if [[ -z "$ref" ]]; then
   if [[ -z "$ref" ]]; then
     echo "ref is required when HEAD is detached" >&2
     exit 1
+  fi
+fi
+
+active_runs="$(gh run list \
+  --repo "$repository" \
+  --workflow "$workflow" \
+  --limit 100 \
+  --json databaseId,headBranch,status,url \
+  --jq '.[] | select(.status != "completed") | "\(.databaseId)\t\(.status)\t\(.headBranch)\t\(.url)"')"
+if [[ -n "$active_runs" ]]; then
+  echo "warning: acceptance test workflows are already in flight; another run might be rate limited" >&2
+  printf '%s\n' "$active_runs" >&2
+
+  if [[ -t 0 ]]; then
+    read -r -p "Dispatch another acceptance test run? [y/N] " response
+    case "$response" in
+      y | Y | yes | YES | Yes) ;;
+      *) exit 1 ;;
+    esac
   fi
 fi
 


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

The live acceptance suite is currently manual to assemble and depends on a maintainer supplying a user OAuth token. This adds a manually dispatched workflow that mints a GitHub App installation token for `gh-acceptance-testing` and runs either the complete suite or one selected command group on Linux, macOS, Windows, or all three. A small dispatch helper discovers command groups from the testdata directories and dispatches the workflow from the selected branch or tag in `cli/cli`, without requiring maintainers to expose a user token.

This is the top layer of a three-layer native PR stack. It depends on #14354, which depends on #14320. The lower layers retain responsibility for token-capability policy and fixture repository/clone reductions; this layer does not change fixture classification or capability policy. The outcome is that maintainers can run the installation-compatible suite across all supported runner platforms while user-capability tests are skipped by the middle layer.

### How did you test this change?

<!--
Report only actions you actually performed and results you actually observed, using factual
first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
hypothetical, inferred, or merely expected scenarios as testing.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

If you did not exercise the changed behavior, write `Not tested` and explain why.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
   Given I was in a repo with no open pull requests
   When I ran `gh pr list`
   Then I saw "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

I ran `script/run-acceptance groups` and saw the discovered testdata groups, exercised its help and invalid platform paths, and replaced `gh` with a recording test double to confirm a Windows PR-group dispatch selects the requested branch with `--ref` and sends the command and operating-system inputs to `acceptance.yml`. With a recorded in-progress run, I saw a warning before a non-interactive dispatch continued. In a pseudo-terminal, I answered `n` to the confirmation prompt and saw that no dispatch occurred. I did not dispatch the live workflow because it must first exist on the selected branch or tag.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

The workflow uses an installation-wide token because the suite dynamically creates repositories in the dedicated test organization. Each platform job mints its own one-hour token. The helper warns when another acceptance workflow is in flight and asks interactive users to confirm another dispatch because overlapping or closely spaced runs can exhaust the App installation's rate-limit buckets. Non-interactive callers receive the warning and continue.

The workflow is dispatched from the branch or tag being tested, so GitHub limits the selectable revision to refs in `cli/cli` rather than accepting an arbitrary checkout ref. Before App credentials become available, the `gh-acceptance-testing` environment requires approval from `cli/code-reviewers`; self-review and administrator bypass are disabled.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `.github/workflows/acceptance.yml`, then review `script/run-acceptance` and the incremental workflow guidance in `acceptance/README.md`.

- #14354 is the middle layer that identifies installation tokens and skips tests requiring a user principal.
- #14320 is the bottom layer that reduces repository creation and cloning through managed fixtures.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.