### PR TITLE
Record attachment operation counts in telemetry

### DIFF
--- a/internal/attachments/attach.go
+++ b/internal/attachments/attach.go
@@ -6,21 +6,28 @@ import (
 	"strings"
 )
 
+// UploadResult reports the successful upload and markdown operation counts.
+type UploadResult struct {
+	Uploaded          int
+	AppendOperations  int
+	ReplaceOperations int
+}
+
 // UploadAndAttach uploads assets in order and stops at the first failure. It
 // points existing references at the URLs of successful uploads and appends only
 // successful uploads the markdown did not reference. Assets after a failure
 // are not attempted.
 //
-// The returned count reports how many assets reached the server. A caller must
-// write the returned markdown when that count is above zero, even when the
-// returned error is non-nil. An upload cannot be undone and there is no endpoint
-// to delete one, so discarding that markdown would orphan the successful assets.
-// A count of zero means nothing was uploaded and nothing is lost by writing
-// nothing.
+// The result reports how many assets reached the server and how those successful
+// uploads changed the markdown. A caller must write the returned markdown when
+// Uploaded is above zero, even when the returned error is non-nil. An upload
+// cannot be undone and there is no endpoint to delete one, so discarding that
+// markdown would orphan the successful assets. An Uploaded count of zero means
+// nothing was uploaded and nothing is lost by writing nothing.
 //
 // The markdown is returned unchanged when it could not be rewritten, so a
 // caller that assigns the result in place never destroys what it was given.
-func (u *Uploader) UploadAndAttach(ctx context.Context, md string, assets []UserAsset) (string, int, error) {
+func (u *Uploader) UploadAndAttach(ctx context.Context, md string, assets []UserAsset) (string, UploadResult, error) {
 	args := make([]attachmentArg, len(assets))
 	for i, a := range assets {
 		f := a.getAsset()
@@ -29,11 +36,11 @@ func (u *Uploader) UploadAndAttach(ctx context.Context, md string, assets []User
 
 	attachableMD, err := newAttachableMarkdown(md, args)
 	if err != nil {
-		return md, 0, err
+		return md, UploadResult{}, err
 	}
 
 	var failures []error
-	uploaded := 0
+	result := UploadResult{}
 	for i, a := range assets {
 		assetURL, err := u.upload(ctx, a)
 		if err != nil {
@@ -42,16 +49,18 @@ func (u *Uploader) UploadAndAttach(ctx context.Context, md string, assets []User
 			break
 		}
 		args[i].URL = assetURL
-		uploaded++
+		result.Uploaded++
 	}
 
 	attachedMD, err := attachAssetsToMarkdown(attachableMD)
 	if err != nil {
 		failures = append(failures, err)
-		return md, uploaded, errors.Join(failures...)
+		return md, result, errors.Join(failures...)
 	}
 
-	return appendUnreferenced(attachedMD, assets), uploaded, errors.Join(failures...)
+	result.AppendOperations = len(attachedMD.ToAppend)
+	result.ReplaceOperations = attachedMD.ReplaceOperations
+	return appendUnreferenced(attachedMD, assets), result, errors.Join(failures...)
 }
 
 // appendUnreferenced adds a paragraph for every attachment the author never

--- a/internal/attachments/attach_test.go
+++ b/internal/attachments/attach_test.go
@@ -41,14 +41,15 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		files    []string
-		args     []string
-		body     string
-		uploads  []upload
-		wantBody string
-		// What a caller keys on to decide whether a body is worth writing.
+		name         string
+		files        []string
+		args         []string
+		body         string
+		uploads      []upload
+		wantBody     string
 		wantUploaded int
+		wantAppend   int
+		wantReplace  int
 		wantErr      string
 	}{
 		{
@@ -59,6 +60,7 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 			uploads:      []upload{{201, `{"url":"https://github.com/user-attachments/assets/1"}`}},
 			wantBody:     "See below\n\n![login](https://github.com/user-attachments/assets/1)",
 			wantUploaded: 1,
+			wantAppend:   1,
 		},
 		{
 			name:    "appends a video as a paragraph of its own",
@@ -70,6 +72,7 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 			// paragraph, so it must not land on the end of the line above.
 			wantBody:     "Watch this:\n\nhttps://github.com/user-attachments/assets/2",
 			wantUploaded: 1,
+			wantAppend:   1,
 		},
 		{
 			name:         "appends to an empty body without leading blank lines",
@@ -79,6 +82,7 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 			uploads:      []upload{{201, `{"url":"https://github.com/user-attachments/assets/1"}`}},
 			wantBody:     "![login](https://github.com/user-attachments/assets/1)",
 			wantUploaded: 1,
+			wantAppend:   1,
 		},
 		{
 			name:         "does not stack blank lines on a body that ends with them",
@@ -88,6 +92,7 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 			uploads:      []upload{{201, `{"url":"https://github.com/user-attachments/assets/1"}`}},
 			wantBody:     "See below\n\n![login](https://github.com/user-attachments/assets/1)",
 			wantUploaded: 1,
+			wantAppend:   1,
 		},
 		{
 			name:    "appends several assets in the order they were written",
@@ -100,6 +105,7 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 				"![After the fix](https://example.com/2)\n\n" +
 				"https://example.com/3",
 			wantUploaded: 3,
+			wantAppend:   3,
 		},
 		{
 			name:         "rewrites a reference in place instead of appending it",
@@ -109,6 +115,7 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 			uploads:      []upload{{201, `{"url":"https://example.com/1"}`}},
 			wantBody:     "The error:\n\n![the login screen](https://example.com/1)\n\nThat is all.",
 			wantUploaded: 1,
+			wantReplace:  1,
 		},
 		{
 			name:         "rewrites what the body references and appends what it does not",
@@ -118,6 +125,8 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 			uploads:      []upload{{201, `{"url":"https://example.com/1"}`}, {201, `{"url":"https://example.com/2"}`}},
 			wantBody:     "![the login screen](https://example.com/1)\n\n![after](https://example.com/2)",
 			wantUploaded: 2,
+			wantAppend:   1,
+			wantReplace:  1,
 		},
 		{
 			// Three files and two replies: c is never attempted, which the
@@ -129,6 +138,7 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 			uploads:      []upload{{201, `{"url":"https://example.com/1"}`}, {404, `{"message":"Not Found"}`}},
 			wantBody:     "Three files\n\n![a](https://example.com/1)",
 			wantUploaded: 1,
+			wantAppend:   1,
 			wantErr:      "could not upload ./b.png: attaching files requires write access to the repository",
 		},
 		{
@@ -170,6 +180,7 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 			uploads:      []upload{{201, `{"url":"https://example.com/1"}`}},
 			wantBody:     "[clip][c]\n\n[c]: https://example.com/1",
 			wantUploaded: 1,
+			wantReplace:  1,
 		},
 		{
 			// The only place a UserAsset becomes an attachmentArg, so the only row
@@ -183,6 +194,7 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 			uploads:      []upload{{201, `{"url":"https://example.com/1"}`}},
 			wantBody:     "The crash [repro.mp4](https://example.com/1) reproduces every time.",
 			wantUploaded: 1,
+			wantReplace:  1,
 		},
 	}
 
@@ -202,7 +214,7 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 				)
 			}
 
-			body, uploaded, err := testUploader(reg).UploadAndAttach(context.Background(), tt.body, assets)
+			body, result, err := testUploader(reg).UploadAndAttach(context.Background(), tt.body, assets)
 
 			if tt.wantErr == "" {
 				require.NoError(t, err)
@@ -210,7 +222,10 @@ func TestUploaderUploadAndAttach(t *testing.T) {
 				require.EqualError(t, err, tt.wantErr)
 			}
 			assert.Equal(t, tt.wantBody, body)
-			assert.Equal(t, tt.wantUploaded, uploaded)
+			assert.Equal(t, tt.wantUploaded, result.Uploaded)
+			assert.Equal(t, tt.wantAppend, result.AppendOperations)
+			assert.Equal(t, tt.wantReplace, result.ReplaceOperations)
+			assert.Equal(t, result.Uploaded, result.AppendOperations+result.ReplaceOperations)
 
 			// The bytes go up in the order they were attached, so a failure
 			// stops the ones after it rather than reordering them.
@@ -239,11 +254,11 @@ func TestUploaderUploadAndAttachUploadsOnceForRepeatedReferences(t *testing.T) {
 		httpmock.StatusStringResponse(201, `{"url":"https://example.com/1"}`),
 	)
 
-	body, uploaded, err := testUploader(reg).UploadAndAttach(context.Background(),
+	body, result, err := testUploader(reg).UploadAndAttach(context.Background(),
 		"![one](./shot.png)\n\ntext\n\n![two](./shot.png)", assets)
 
 	require.NoError(t, err)
-	assert.Equal(t, 1, uploaded)
+	assert.Equal(t, UploadResult{Uploaded: 1, ReplaceOperations: 1}, result)
 	assert.Equal(t, "![one](https://example.com/1)\n\ntext\n\n![two](https://example.com/1)", body)
 	assert.Len(t, reg.Requests, 1)
 }
@@ -252,10 +267,10 @@ func TestUploaderUploadAndAttachNoAssets(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 
-	body, uploaded, err := testUploader(reg).UploadAndAttach(context.Background(), "unchanged\n", nil)
+	body, result, err := testUploader(reg).UploadAndAttach(context.Background(), "unchanged\n", nil)
 
 	require.NoError(t, err)
-	assert.Zero(t, uploaded)
+	assert.Equal(t, UploadResult{}, result)
 	assert.Equal(t, "unchanged\n", body)
 	assert.Empty(t, reg.Requests)
 }
@@ -299,12 +314,12 @@ func TestUploaderUploadAndAttachDoesNotLeakTheAssetURLIntoAnError(t *testing.T) 
 		httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
 	)
 
-	body, uploaded, err := testUploader(reg).UploadAndAttach(context.Background(), "", assets)
+	body, result, err := testUploader(reg).UploadAndAttach(context.Background(), "", assets)
 
 	require.Error(t, err)
 	// One asset is up and cannot be deleted, so the caller must write this
 	// body even though the call failed.
-	assert.Equal(t, 1, uploaded)
+	assert.Equal(t, UploadResult{Uploaded: 1, AppendOperations: 1}, result)
 	assert.NotContains(t, err.Error(), "secret-asset")
 	assert.Contains(t, body, "secret-asset")
 }
@@ -324,9 +339,9 @@ func TestUploaderUploadAndAttachAbsolutePathReference(t *testing.T) {
 		httpmock.StatusStringResponse(201, `{"url":"https://example.com/1"}`),
 	)
 
-	body, uploaded, err := testUploader(reg).UploadAndAttach(context.Background(), "![shot](./shot.png)", assets)
+	body, result, err := testUploader(reg).UploadAndAttach(context.Background(), "![shot](./shot.png)", assets)
 
 	require.NoError(t, err)
-	assert.Equal(t, 1, uploaded)
+	assert.Equal(t, UploadResult{Uploaded: 1, ReplaceOperations: 1}, result)
 	assert.Equal(t, "![shot](https://example.com/1)", body)
 }

--- a/internal/attachments/doc.go
+++ b/internal/attachments/doc.go
@@ -25,16 +25,17 @@
 //
 //	// Every reasonable cancellation possible belongs here.
 //
-//	md, uploaded, err := uploader.UploadAndAttach(ctx, md, attachmentArgs)
-//	if uploaded == 0 {
+//	md, result, err := uploader.UploadAndAttach(ctx, md, attachmentArgs)
+//	if result.Uploaded == 0 {
 //		return err
 //	}
 //
 //	// Write md to target, then report err alongside whatever the write
 //	// returned.
 //
-// UploadAndAttach reports how many assets were successfully uploaded. The
-// caller must write the markdown when that count is above zero, including after
-// a partial failure, because what did upload must be referenced by something.
-// At zero nothing is stranded and nothing is written.
+// UploadAndAttach reports how many assets were successfully uploaded and how
+// they changed the markdown. The caller must write the markdown when Uploaded
+// is above zero, including after a partial failure, because what did upload must
+// be referenced by something. At zero nothing is stranded and nothing is
+// written.
 package attachments

--- a/internal/attachments/flags.go
+++ b/internal/attachments/flags.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -38,24 +37,6 @@ func AddFlag(cmd *cobra.Command) *Flag {
 // Changed reports whether the attachment flag was passed.
 func (f *Flag) Changed() bool {
 	return f.flag.Changed
-}
-
-// RecordTelemetry records how many attachment flags were provided.
-func (f *Flag) RecordTelemetry(command string, recorder ghtelemetry.CommandRecorder) {
-	if recorder == nil || !f.Changed() {
-		return
-	}
-
-	recorder.SetSampleRate(ghtelemetry.SAMPLE_ALL)
-	recorder.Record(ghtelemetry.Event{
-		Type: "attachment_invocation",
-		Dimensions: ghtelemetry.Dimensions{
-			"command": command,
-		},
-		Measures: ghtelemetry.Measures{
-			"attach_count": int64(len(f.values)),
-		},
-	})
 }
 
 // UserAssets validates the files named by the attachment flag, keeping them in

--- a/internal/attachments/flags_test.go
+++ b/internal/attachments/flags_test.go
@@ -1,6 +1,7 @@
 package attachments
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -90,12 +91,14 @@ func TestAddFlag(t *testing.T) {
 	}
 }
 
-func TestFlagRecordTelemetry(t *testing.T) {
+func TestInvocationTelemetry(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantEvent bool
-		wantCount int64
+		name              string
+		input             string
+		wantEvent         bool
+		wantCount         int64
+		operations        *UploadResult
+		wantValidationErr string
 	}{
 		{
 			name:  "flag not passed",
@@ -113,14 +116,50 @@ func TestFlagRecordTelemetry(t *testing.T) {
 			wantEvent: true,
 			wantCount: 3,
 		},
+		{
+			name:      "successful markdown operations",
+			input:     "--attach ./first.png --attach ./second.png",
+			wantEvent: true,
+			wantCount: 2,
+			operations: &UploadResult{
+				Uploaded:          2,
+				AppendOperations:  1,
+				ReplaceOperations: 1,
+			},
+		},
+		{
+			name:       "upload flow with no completed operations",
+			input:      "--attach ./first.png",
+			wantEvent:  true,
+			wantCount:  1,
+			operations: &UploadResult{},
+		},
+		{
+			name:              "over attachment limit",
+			input:             strings.Repeat("--attach ./missing.png ", maxAttachments+1),
+			wantEvent:         true,
+			wantCount:         maxAttachments + 1,
+			wantValidationErr: "`--attach` accepts at most 50 values per command",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, attachFlag := attachCmd(t, tt.input)
 			recorder := &telemetry.CommandRecorderSpy{}
+			invocationTelemetry := NewInvocationTelemetry(attachFlag, recorder)
 
-			attachFlag.RecordTelemetry("gh issue comment", recorder)
+			invocationTelemetry.start("gh issue comment")
+			assert.Empty(t, recorder.Events)
+			if tt.operations != nil {
+				invocationTelemetry.RecordOperations(*tt.operations)
+			}
+			if tt.wantValidationErr != "" {
+				_, err := attachFlag.UserAssets()
+				require.EqualError(t, err, tt.wantValidationErr)
+			}
+			recorder.Flush()
+			recorder.Flush()
 
 			if !tt.wantEvent {
 				assert.Empty(t, recorder.Events)
@@ -129,17 +168,63 @@ func TestFlagRecordTelemetry(t *testing.T) {
 			}
 
 			require.Equal(t, ghtelemetry.SAMPLE_ALL, recorder.LastSampleRate)
-			require.Equal(t, []ghtelemetry.Event{{
+			wantEvents := []ghtelemetry.Event{{
 				Type: "attachment_invocation",
 				Dimensions: ghtelemetry.Dimensions{
 					"command": "gh issue comment",
 				},
 				Measures: ghtelemetry.Measures{
-					"attach_count": tt.wantCount,
+					"attach_count":      tt.wantCount,
+					"append_ops_count":  0,
+					"replace_ops_count": 0,
 				},
-			}}, recorder.Events)
+			}}
+			if tt.operations != nil {
+				wantEvents[0].Measures["append_ops_count"] = int64(tt.operations.AppendOperations)
+				wantEvents[0].Measures["replace_ops_count"] = int64(tt.operations.ReplaceOperations)
+			}
+			require.Equal(t, wantEvents, recorder.Events)
 		})
 	}
+}
+
+func TestInvocationTelemetryWrapArgsRecordsBeforePersistentPreRunError(t *testing.T) {
+	recorder := &telemetry.CommandRecorderSpy{}
+	cmd := &cobra.Command{
+		Use:  "comment",
+		Args: cobra.ExactArgs(1),
+		RunE: func(*cobra.Command, []string) error {
+			return errors.New("run should not be called")
+		},
+	}
+	attachFlag := AddFlag(cmd)
+	invocationTelemetry := NewInvocationTelemetry(attachFlag, recorder)
+	cmd.Args = invocationTelemetry.WrapArgs(cmd.Args)
+
+	root := &cobra.Command{
+		Use:           "gh",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			return errors.New("authentication failed")
+		},
+	}
+	root.AddCommand(cmd)
+	root.SetArgs([]string{"comment", "1", "--attach", "./shot.png"})
+
+	_, err := root.ExecuteC()
+	require.EqualError(t, err, "authentication failed")
+	recorder.Flush()
+
+	require.Equal(t, []ghtelemetry.Event{{
+		Type:       "attachment_invocation",
+		Dimensions: ghtelemetry.Dimensions{"command": "gh comment"},
+		Measures: ghtelemetry.Measures{
+			"attach_count":      1,
+			"append_ops_count":  0,
+			"replace_ops_count": 0,
+		},
+	}}, recorder.Events)
 }
 
 func TestFlagUserAssets(t *testing.T) {

--- a/internal/attachments/references.go
+++ b/internal/attachments/references.go
@@ -14,9 +14,9 @@ import (
 )
 
 // This file finds the places a body already points at an attached file, and
-// repoints them. A file the author never mentioned is not its business: it is
-// reported in ToAppend and appended by attach.go, which knows that an image and
-// a video append different markdown.
+// repoints them. A file with no rewritten reference is reported in ToAppend and
+// appended by attach.go, which knows that an image and a video append different
+// markdown.
 //
 // The parts below run in that order: the two entry points, finding the
 // references, working out which attached file each one names, locating its
@@ -43,13 +43,15 @@ type attachmentArg struct {
 	RendersAsPlayer bool
 }
 
-// attachedMarkdown is the outcome of attaching, one field per flow. A file the
-// author already referenced is rewritten where they wrote it. A file they never
-// mentioned is left for the caller to append, because appending needs to know
-// how an image and a video each render and this file does not.
+// attachedMarkdown is the outcome of attaching, one field per flow. A file
+// rewritten where the author referenced it contributes one replacement,
+// regardless of how many references changed. A file that was not rewritten is
+// left for the caller to append, because appending needs to know how an image
+// and a video each render and this file does not.
 type attachedMarkdown struct {
-	Rewritten string
-	ToAppend  []attachmentArg
+	Rewritten         string
+	ToAppend          []attachmentArg
+	ReplaceOperations int
 }
 
 // attachableMarkdown is markdown scanned for the files it references, held
@@ -78,9 +80,10 @@ func newAttachableMarkdown(md string, attachmentArgs []attachmentArg) (attachabl
 	return attachableMarkdown{markdown: md, refs: refs, args: attachmentArgs}, nil
 }
 
-// attachAssetsToMarkdown points every markdown reference to an attached file
-// at that file's asset URL, and reports which arguments the markdown never
-// referenced.
+// attachAssetsToMarkdown points every rewritable markdown reference to an
+// attached file at that file's asset URL. It reports one replacement per
+// successfully rewritten attachment and which uploaded arguments remain to
+// append.
 //
 //	![alt](./file) alone in a paragraph   image: swap the path   video: the bare URL, which plays
 //	![alt](./file) anywhere else          image: swap the path   video: becomes [alt](URL)
@@ -173,12 +176,22 @@ func attachAssetsToMarkdown(v attachableMarkdown) (attachedMarkdown, error) {
 	out, written := applyEdits(md, edits)
 
 	var unreferenced []attachmentArg
+	replaced := 0
 	for i, a := range attachmentArgs {
-		if a.URL != "" && !written[i] {
+		if a.URL == "" {
+			continue
+		}
+		if written[i] {
+			replaced++
+		} else {
 			unreferenced = append(unreferenced, a)
 		}
 	}
-	return attachedMarkdown{Rewritten: out, ToAppend: unreferenced}, nil
+	return attachedMarkdown{
+		Rewritten:         out,
+		ToAppend:          unreferenced,
+		ReplaceOperations: replaced,
+	}, nil
 }
 
 // checkVideoReferenceImages returns an error naming every video the markdown

--- a/internal/attachments/telemetry.go
+++ b/internal/attachments/telemetry.go
@@ -1,0 +1,68 @@
+package attachments
+
+import (
+	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
+	"github.com/spf13/cobra"
+)
+
+// InvocationTelemetry records telemetry for one command invocation using
+// attachments.
+type InvocationTelemetry struct {
+	flag     *Flag
+	recorder ghtelemetry.CommandRecorder
+	event    *ghtelemetry.Event
+}
+
+// NewInvocationTelemetry creates attachment telemetry for flag.
+func NewInvocationTelemetry(flag *Flag, recorder ghtelemetry.CommandRecorder) *InvocationTelemetry {
+	return &InvocationTelemetry{
+		flag:     flag,
+		recorder: recorder,
+	}
+}
+
+// WrapArgs starts attachment telemetry before argument validation.
+func (t *InvocationTelemetry) WrapArgs(validate cobra.PositionalArgs) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		t.start(cmd.CommandPath())
+		return validate(cmd, args)
+	}
+}
+
+func (t *InvocationTelemetry) start(command string) {
+	if t == nil {
+		return
+	}
+
+	t.event = nil
+	if t.recorder == nil || t.flag == nil || !t.flag.Changed() {
+		return
+	}
+
+	event := &ghtelemetry.Event{
+		Type: "attachment_invocation",
+		Dimensions: ghtelemetry.Dimensions{
+			"command": command,
+		},
+		Measures: ghtelemetry.Measures{
+			"attach_count":      int64(len(t.flag.values)),
+			"append_ops_count":  0,
+			"replace_ops_count": 0,
+		},
+	}
+	t.event = event
+	t.recorder.SetSampleRate(ghtelemetry.SAMPLE_ALL)
+	t.recorder.RecordDeferred(func() ghtelemetry.Event {
+		return *event
+	})
+}
+
+// RecordOperations adds successful markdown operations to the invocation.
+func (t *InvocationTelemetry) RecordOperations(result UploadResult) {
+	if t == nil || t.event == nil {
+		return
+	}
+
+	t.event.Measures["append_ops_count"] = int64(result.AppendOperations)
+	t.event.Measures["replace_ops_count"] = int64(result.ReplaceOperations)
+}

--- a/internal/attachments/test.go
+++ b/internal/attachments/test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,38 @@ func NewTestAssets(t *testing.T, names ...string) []UserAsset {
 	assets, err := attachFlag.UserAssets()
 	require.NoError(t, err)
 	return assets
+}
+
+// NewTestInvocationTelemetry returns telemetry started with the given
+// attachment count.
+func NewTestInvocationTelemetry(t *testing.T, recorder ghtelemetry.CommandRecorder, attachCount int) *InvocationTelemetry {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "test"}
+	attachFlag := AddFlag(cmd)
+	for i := range attachCount {
+		require.NoError(t, cmd.Flags().Set(flagName, "attachment-"+strconv.Itoa(i)+".png"))
+	}
+	invocationTelemetry := NewInvocationTelemetry(attachFlag, recorder)
+	invocationTelemetry.start("gh test")
+	return invocationTelemetry
+}
+
+// AssertTestTelemetryEvents verifies the completed invocation event shape.
+func AssertTestTelemetryEvents(t *testing.T, events []ghtelemetry.Event, attachCount int, result UploadResult) {
+	t.Helper()
+
+	require.Equal(t, []ghtelemetry.Event{
+		{
+			Type:       "attachment_invocation",
+			Dimensions: ghtelemetry.Dimensions{"command": "gh test"},
+			Measures: ghtelemetry.Measures{
+				"attach_count":      int64(attachCount),
+				"append_ops_count":  int64(result.AppendOperations),
+				"replace_ops_count": int64(result.ReplaceOperations),
+			},
+		},
+	}, events)
 }
 
 // StubUpload registers one upload of name against repositoryID, answering with

--- a/internal/gh/ghtelemetry/telemetry.go
+++ b/internal/gh/ghtelemetry/telemetry.go
@@ -21,6 +21,8 @@ type EventRecorder interface {
 
 type CommandRecorder interface {
 	EventRecorder
+	// RecordDeferred schedules an event to be resolved when telemetry flushes.
+	RecordDeferred(func() Event)
 	SetSampleRate(rate int)
 }
 

--- a/internal/telemetry/fake.go
+++ b/internal/telemetry/fake.go
@@ -20,6 +20,7 @@ func (r *EventRecorderSpy) Flush() {}
 type CommandRecorderSpy struct {
 	Events         []ghtelemetry.Event
 	LastSampleRate int
+	deferredEvents []func() ghtelemetry.Event
 }
 
 func (r *CommandRecorderSpy) Record(event ghtelemetry.Event) {
@@ -28,8 +29,17 @@ func (r *CommandRecorderSpy) Record(event ghtelemetry.Event) {
 
 func (r *CommandRecorderSpy) Disable() {}
 
+func (r *CommandRecorderSpy) RecordDeferred(event func() ghtelemetry.Event) {
+	r.deferredEvents = append(r.deferredEvents, event)
+}
+
 func (r *CommandRecorderSpy) SetSampleRate(rate int) {
 	r.LastSampleRate = rate
 }
 
-func (r *CommandRecorderSpy) Flush() {}
+func (r *CommandRecorderSpy) Flush() {
+	for _, event := range r.deferredEvents {
+		r.Events = append(r.Events, event())
+	}
+	r.deferredEvents = nil
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -247,8 +247,9 @@ func NewService(flusher func(SendTelemetryPayload), opts ...telemetryServiceOpti
 }
 
 type recordedEvent struct {
-	event      ghtelemetry.Event
-	recordedAt time.Time
+	event         ghtelemetry.Event
+	deferredEvent func() ghtelemetry.Event
+	recordedAt    time.Time
 }
 
 type service struct {
@@ -277,6 +278,13 @@ func (s *service) Record(event ghtelemetry.Event) {
 	defer s.mu.Unlock()
 
 	s.events = append(s.events, recordedEvent{event: event, recordedAt: time.Now()})
+}
+
+func (s *service) RecordDeferred(event func() ghtelemetry.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.events = append(s.events, recordedEvent{deferredEvent: event, recordedAt: time.Now()})
 }
 
 func (s *service) SetSampleRate(rate int) {
@@ -315,16 +323,21 @@ func (s *service) Flush() {
 	}
 
 	for i, recorded := range events {
+		event := recorded.event
+		if recorded.deferredEvent != nil {
+			event = recorded.deferredEvent()
+		}
+
 		dimensions := map[string]string{
 			"timestamp": recorded.recordedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
 		}
 		maps.Copy(dimensions, s.commonDimensions)
-		maps.Copy(dimensions, recorded.event.Dimensions)
+		maps.Copy(dimensions, event.Dimensions)
 
 		payload.Events[i] = PayloadEvent{
-			Type:       recorded.event.Type,
+			Type:       event.Type,
 			Dimensions: dimensions,
-			Measures:   recorded.event.Measures,
+			Measures:   event.Measures,
 		}
 	}
 
@@ -417,6 +430,8 @@ func SpawnSendTelemetry(executable string, payload SendTelemetryPayload) {
 type NoOpService struct{}
 
 func (s *NoOpService) Record(event ghtelemetry.Event) {}
+
+func (s *NoOpService) RecordDeferred(event func() ghtelemetry.Event) {}
 
 func (s *NoOpService) Disable() {}
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -421,6 +421,27 @@ func TestServiceFlush(t *testing.T) {
 		assert.Equal(t, int64(150), event.Measures["duration_ms"])
 	})
 
+	t.Run("resolves deferred events when flushing", func(t *testing.T) {
+		t.Cleanup(stubDeviceID("test-device"))
+
+		var captured SendTelemetryPayload
+		svc := newService(func(p SendTelemetryPayload) { captured = p }, nil)
+		measure := int64(0)
+		svc.RecordDeferred(func() ghtelemetry.Event {
+			return ghtelemetry.Event{
+				Type:     "deferred",
+				Measures: ghtelemetry.Measures{"count": measure},
+			}
+		})
+		measure = 2
+
+		svc.Flush()
+
+		require.Len(t, captured.Events, 1)
+		assert.Equal(t, "deferred", captured.Events[0].Type)
+		assert.Equal(t, int64(2), captured.Events[0].Measures["count"])
+	})
+
 	t.Run("flushes multiple events", func(t *testing.T) {
 		t.Cleanup(stubDeviceID("test-device"))
 

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -59,8 +59,6 @@ func NewCmdComment(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, ru
 		`),
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			opts.AttachFlag.RecordTelemetry(cmd.CommandPath(), telemetry)
-
 			opts.RetrieveCommentable = func() (prShared.Commentable, ghrepo.Interface, error) {
 				// TODO wm: more testing
 				issueNumber, parsedBaseRepo, err := shared.ParseIssueFromArg(args[0])
@@ -136,6 +134,8 @@ func NewCmdComment(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, ru
 	cmd.Flags().BoolVar(&opts.DeleteLastConfirmed, "yes", false, "Skip the delete confirmation prompt when --delete-last is provided")
 	cmd.Flags().BoolVar(&opts.CreateIfNone, "create-if-none", false, "Create a new comment if no comments are found. Can be used only with --edit-last")
 	opts.AttachFlag = attachments.AddFlag(cmd)
+	opts.AttachTelemetry = attachments.NewInvocationTelemetry(opts.AttachFlag, telemetry)
+	cmd.Args = opts.AttachTelemetry.WrapArgs(cmd.Args)
 
 	return cmd
 }

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -276,6 +276,12 @@ func TestNewCmdComment(t *testing.T) {
 			wantsErr: false,
 		},
 		{
+			name:     "--attach telemetry survives argument validation",
+			input:    fmt.Sprintf("--attach '%s'", tmpImage),
+			isTTY:    false,
+			wantsErr: true,
+		},
+		{
 			name:  "--attach with --body keeps the body and records that one was given",
 			input: fmt.Sprintf("1 --body test --attach '%s'", tmpImage),
 			output: shared.CommentableOptions{
@@ -423,6 +429,7 @@ func TestNewCmdComment(t *testing.T) {
 			cmd.SetErr(&bytes.Buffer{})
 
 			_, err = cmd.ExecuteC()
+			recorder.Flush()
 			if cmd.Flags().Changed("attach") {
 				values, flagErr := cmd.Flags().GetStringArray("attach")
 				require.NoError(t, flagErr)
@@ -430,7 +437,11 @@ func TestNewCmdComment(t *testing.T) {
 				require.Len(t, recorder.Events, 1)
 				assert.Equal(t, "attachment_invocation", recorder.Events[0].Type)
 				assert.Equal(t, cmd.CommandPath(), recorder.Events[0].Dimensions["command"])
-				assert.Equal(t, int64(len(values)), recorder.Events[0].Measures["attach_count"])
+				assert.Equal(t, ghtelemetry.Measures{
+					"attach_count":      int64(len(values)),
+					"append_ops_count":  0,
+					"replace_ops_count": 0,
+				}, recorder.Events[0].Measures)
 			} else {
 				assert.Empty(t, recorder.Events)
 				assert.Zero(t, recorder.LastSampleRate)

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -58,8 +58,9 @@ type CreateOptions struct {
 	BlockedBy   []string
 	Blocking    []string
 
-	AttachFlag *attachments.Flag
-	Assets     []attachments.UserAsset
+	AttachFlag      *attachments.Flag
+	AttachTelemetry *attachments.InvocationTelemetry
+	Assets          []attachments.UserAsset
 }
 
 func NewCmdCreate(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, runF func(*CreateOptions) error) *cobra.Command {
@@ -121,8 +122,6 @@ func NewCmdCreate(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, run
 		Args:    cmdutil.NoArgsQuoteReminder,
 		Aliases: []string{"new"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.AttachFlag.RecordTelemetry(cmd.CommandPath(), telemetry)
-
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
 			opts.HasRepoOverride = cmd.Flags().Changed("repo")
@@ -194,6 +193,8 @@ func NewCmdCreate(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, run
 	cmd.Flags().StringSliceVar(&opts.BlockedBy, "blocked-by", nil, "Mark the new issue as blocked by these issue `numbers` or URLs")
 	cmd.Flags().StringSliceVar(&opts.Blocking, "blocking", nil, "Mark the new issue as blocking these issue `numbers` or URLs")
 	opts.AttachFlag = attachments.AddFlag(cmd)
+	opts.AttachTelemetry = attachments.NewInvocationTelemetry(opts.AttachFlag, telemetry)
+	cmd.Args = opts.AttachTelemetry.WrapArgs(cmd.Args)
 
 	return cmd
 }
@@ -466,8 +467,9 @@ func createRun(opts *CreateOptions) (err error) {
 		// not exist, so no issue is created. Once anything has uploaded the
 		// issue is created and the failures are reported.
 		if uploader != nil {
-			body, uploaded, uploadErr := uploader.UploadAndAttach(context.Background(), tb.Body, opts.Assets)
-			if uploadErr != nil && uploaded == 0 {
+			body, uploadResult, uploadErr := uploader.UploadAndAttach(context.Background(), tb.Body, opts.Assets)
+			opts.AttachTelemetry.RecordOperations(uploadResult)
+			if uploadErr != nil && uploadResult.Uploaded == 0 {
 				err = uploadErr
 				return
 			}

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -277,6 +277,12 @@ func TestNewCmdCreate(t *testing.T) {
 			wantAssetPaths: []string{tmpImage},
 		},
 		{
+			name:     "attach telemetry survives argument validation",
+			tty:      false,
+			cli:      fmt.Sprintf(`unexpected --attach '%s'`, tmpImage),
+			wantsErr: true,
+		},
+		{
 			name:        "attach conflict is reported before a missing file",
 			tty:         false,
 			cli:         `-t mytitle -b mybody --web --attach ./nope.png`,
@@ -325,6 +331,7 @@ func TestNewCmdCreate(t *testing.T) {
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			_, err = cmd.ExecuteC()
+			recorder.Flush()
 			if cmd.Flags().Changed("attach") {
 				values, flagErr := cmd.Flags().GetStringArray("attach")
 				require.NoError(t, flagErr)
@@ -332,7 +339,11 @@ func TestNewCmdCreate(t *testing.T) {
 				require.Len(t, recorder.Events, 1)
 				assert.Equal(t, "attachment_invocation", recorder.Events[0].Type)
 				assert.Equal(t, cmd.CommandPath(), recorder.Events[0].Dimensions["command"])
-				assert.Equal(t, int64(len(values)), recorder.Events[0].Measures["attach_count"])
+				assert.Equal(t, ghtelemetry.Measures{
+					"attach_count":      int64(len(values)),
+					"append_ops_count":  0,
+					"replace_ops_count": 0,
+				}, recorder.Events[0].Measures)
 			} else {
 				assert.Empty(t, recorder.Events)
 				assert.Zero(t, recorder.LastSampleRate)
@@ -376,17 +387,18 @@ func TestNewCmdCreate(t *testing.T) {
 
 func Test_createRun(t *testing.T) {
 	tests := []struct {
-		name        string
-		opts        CreateOptions
-		attach      []string
-		host        string
-		config      string
-		httpStubs   func(*testing.T, *httpmock.Registry)
-		promptStubs func(*testing.T, *prompter.PrompterMock)
-		wantsStdout string
-		wantsStderr string
-		wantsBrowse string
-		wantsErr    string
+		name           string
+		opts           CreateOptions
+		attach         []string
+		host           string
+		config         string
+		httpStubs      func(*testing.T, *httpmock.Registry)
+		promptStubs    func(*testing.T, *prompter.PrompterMock)
+		wantsStdout    string
+		wantsStderr    string
+		wantsBrowse    string
+		wantsErr       string
+		wantOperations *attachments.UploadResult
 	}{
 		{
 			name: "no args",
@@ -596,6 +608,10 @@ func Test_createRun(t *testing.T) {
 			attach:      []string{"shot.png"},
 			wantsStdout: "https://github.com/OWNER/REPO/issues/12\n",
 			wantsStderr: "\nCreating issue in OWNER/REPO\n\n",
+			wantOperations: &attachments.UploadResult{
+				Uploaded:          1,
+				ReplaceOperations: 1,
+			},
 		},
 		{
 			name: "editor and template",
@@ -1186,6 +1202,10 @@ func Test_createRun(t *testing.T) {
 						}))
 			},
 			wantsErr: "could not upload ./second.png: attaching files requires write access to the repository",
+			wantOperations: &attachments.UploadResult{
+				Uploaded:         1,
+				AppendOperations: 1,
+			},
 		},
 		{
 			name: "a create that fails after an upload failed reports both",
@@ -1415,6 +1435,10 @@ func Test_createRun(t *testing.T) {
 			if len(tt.attach) > 0 {
 				opts.Assets = attachments.NewTestAssets(t, tt.attach...)
 			}
+			attachmentRecorder := &telemetry.CommandRecorderSpy{}
+			if tt.wantOperations != nil {
+				opts.AttachTelemetry = attachments.NewTestInvocationTelemetry(t, attachmentRecorder, len(tt.attach))
+			}
 			opts.Config = func() (gh.Config, error) {
 				cfg := tt.config
 				if cfg == "" {
@@ -1424,6 +1448,10 @@ func Test_createRun(t *testing.T) {
 			}
 
 			err := createRun(opts)
+			if tt.wantOperations != nil {
+				attachmentRecorder.Flush()
+				attachments.AssertTestTelemetryEvents(t, attachmentRecorder.Events, len(tt.attach), *tt.wantOperations)
+			}
 			if tt.wantsErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -51,9 +51,10 @@ type EditOptions struct {
 	AddBlocking     []string
 	RemoveBlocking  []string
 
-	AttachFlag *attachments.Flag
-	Assets     []attachments.UserAsset
-	Config     func() (gh.Config, error)
+	AttachFlag      *attachments.Flag
+	AttachTelemetry *attachments.InvocationTelemetry
+	Assets          []attachments.UserAsset
+	Config          func() (gh.Config, error)
 
 	prShared.Editable
 }
@@ -123,8 +124,6 @@ func NewCmdEdit(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, runF 
 		`),
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.AttachFlag.RecordTelemetry(cmd.CommandPath(), telemetry)
-
 			issueNumbers, baseRepo, err := issueShared.ParseIssuesFromArgs(args)
 			if err != nil {
 				return err
@@ -274,6 +273,8 @@ func NewCmdEdit(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, runF 
 	cmd.Flags().StringSliceVar(&opts.AddBlocking, "add-blocking", nil, "Add 'blocking' relationships by issue `number` or URL")
 	cmd.Flags().StringSliceVar(&opts.RemoveBlocking, "remove-blocking", nil, "Remove 'blocking' relationships by issue `number` or URL")
 	opts.AttachFlag = attachments.AddFlag(cmd)
+	opts.AttachTelemetry = attachments.NewInvocationTelemetry(opts.AttachFlag, telemetry)
+	cmd.Args = opts.AttachTelemetry.WrapArgs(cmd.Args)
 
 	return cmd
 }
@@ -418,10 +419,11 @@ func editRun(opts *EditOptions) error {
 		// This sits outside the loop below so each file uploads once, and
 		// Clone carries the merged body into the issue. Nothing that can
 		// prompt or cancel may follow an upload.
-		var uploaded int
-		body, uploaded, uploadErr = uploader.UploadAndAttach(context.Background(), body, opts.Assets)
+		var uploadResult attachments.UploadResult
+		body, uploadResult, uploadErr = uploader.UploadAndAttach(context.Background(), body, opts.Assets)
+		opts.AttachTelemetry.RecordOperations(uploadResult)
 
-		if uploaded > 0 {
+		if uploadResult.Uploaded > 0 {
 			editable.Body.Value = body
 			editable.Body.Edited = true
 		} else {

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -410,6 +410,12 @@ func TestNewCmdEdit(t *testing.T) {
 			wantAssetPaths: []string{tmpImage},
 		},
 		{
+			name:        "attach telemetry survives argument validation",
+			input:       fmt.Sprintf("--attach '%s'", tmpImage),
+			wantsErr:    true,
+			wantsErrMsg: "requires at least 1 arg(s), only received 0",
+		},
+		{
 			name:  "attach flag beside another edit flag",
 			input: fmt.Sprintf("23 --add-label bug --attach '%s'", tmpImage),
 			output: EditOptions{
@@ -470,6 +476,7 @@ func TestNewCmdEdit(t *testing.T) {
 			cmd.SetErr(&bytes.Buffer{})
 
 			_, err = cmd.ExecuteC()
+			recorder.Flush()
 			if cmd.Flags().Changed("attach") {
 				values, flagErr := cmd.Flags().GetStringArray("attach")
 				require.NoError(t, flagErr)
@@ -477,7 +484,11 @@ func TestNewCmdEdit(t *testing.T) {
 				require.Len(t, recorder.Events, 1)
 				assert.Equal(t, "attachment_invocation", recorder.Events[0].Type)
 				assert.Equal(t, cmd.CommandPath(), recorder.Events[0].Dimensions["command"])
-				assert.Equal(t, int64(len(values)), recorder.Events[0].Measures["attach_count"])
+				assert.Equal(t, ghtelemetry.Measures{
+					"attach_count":      int64(len(values)),
+					"append_ops_count":  0,
+					"replace_ops_count": 0,
+				}, recorder.Events[0].Measures)
 			} else {
 				assert.Empty(t, recorder.Events)
 				assert.Zero(t, recorder.LastSampleRate)
@@ -547,6 +558,7 @@ func Test_editRun(t *testing.T) {
 		// Used instead of wantErrMsg when the subject is which errors survive,
 		// leaving their wording to the layer that formats them.
 		wantErrContains []string
+		wantOperations  *attachments.UploadResult
 	}{
 		{
 			name: "non-interactive",
@@ -1379,6 +1391,10 @@ func Test_editRun(t *testing.T) {
 				mockIssueUpdateWithBody(t, reg, "the original body\n\n![shot](https://example.com/1)")
 			},
 			stdout: "https://github.com/OWNER/REPO/issue/123\n",
+			wantOperations: &attachments.UploadResult{
+				Uploaded:         1,
+				AppendOperations: 1,
+			},
 		},
 		{
 			name: "a body flag replaces the body the attachment is then appended to",
@@ -1533,6 +1549,10 @@ func Test_editRun(t *testing.T) {
 			stdout:          "https://github.com/OWNER/REPO/issue/123\n",
 			wantErr:         true,
 			wantErrContains: []string{"./second.png"},
+			wantOperations: &attachments.UploadResult{
+				Uploaded:         1,
+				AppendOperations: 1,
+			},
 		},
 		{
 			name: "a sole failed upload does not write the body",
@@ -1746,6 +1766,10 @@ func Test_editRun(t *testing.T) {
 			if len(tt.attach) > 0 {
 				tt.input.Assets = attachments.NewTestAssets(t, tt.attach...)
 			}
+			attachmentRecorder := &telemetry.CommandRecorderSpy{}
+			if tt.wantOperations != nil {
+				tt.input.AttachTelemetry = attachments.NewTestInvocationTelemetry(t, attachmentRecorder, len(tt.attach))
+			}
 
 			hostTokens := tt.hostTokens
 			if hostTokens == nil {
@@ -1756,6 +1780,10 @@ func Test_editRun(t *testing.T) {
 			}
 
 			err := editRun(tt.input)
+			if tt.wantOperations != nil {
+				attachmentRecorder.Flush()
+				attachments.AssertTestTelemetryEvents(t, attachmentRecorder.Events, len(tt.attach), *tt.wantOperations)
+			}
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.wantErrMsg != "" {

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -57,8 +57,6 @@ func NewCmdComment(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, ru
 		`),
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			opts.AttachFlag.RecordTelemetry(cmd.CommandPath(), telemetry)
-
 			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && len(args) == 0 {
 				return cmdutil.FlagErrorf("argument required when using the --repo flag")
 			}
@@ -115,6 +113,8 @@ func NewCmdComment(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, ru
 	cmd.Flags().BoolVar(&opts.DeleteLastConfirmed, "yes", false, "Skip the delete confirmation prompt when --delete-last is provided")
 	cmd.Flags().BoolVar(&opts.CreateIfNone, "create-if-none", false, "Create a new comment if no comments are found. Can be used only with --edit-last")
 	opts.AttachFlag = attachments.AddFlag(cmd)
+	opts.AttachTelemetry = attachments.NewInvocationTelemetry(opts.AttachFlag, telemetry)
+	cmd.Args = opts.AttachTelemetry.WrapArgs(cmd.Args)
 
 	return cmd
 }

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -298,6 +298,12 @@ func TestNewCmdComment(t *testing.T) {
 			wantsErr: false,
 		},
 		{
+			name:     "--attach telemetry survives argument validation",
+			input:    fmt.Sprintf("1 2 --attach '%s'", tmpImage),
+			isTTY:    false,
+			wantsErr: true,
+		},
+		{
 			name:  "--attach with --body keeps the body and records that one was given",
 			input: fmt.Sprintf("1 --body test --attach '%s'", tmpImage),
 			output: shared.CommentableOptions{
@@ -445,6 +451,7 @@ func TestNewCmdComment(t *testing.T) {
 			cmd.SetErr(&bytes.Buffer{})
 
 			_, err = cmd.ExecuteC()
+			recorder.Flush()
 			if cmd.Flags().Changed("attach") {
 				values, flagErr := cmd.Flags().GetStringArray("attach")
 				require.NoError(t, flagErr)
@@ -452,7 +459,11 @@ func TestNewCmdComment(t *testing.T) {
 				require.Len(t, recorder.Events, 1)
 				assert.Equal(t, "attachment_invocation", recorder.Events[0].Type)
 				assert.Equal(t, cmd.CommandPath(), recorder.Events[0].Dimensions["command"])
-				assert.Equal(t, int64(len(values)), recorder.Events[0].Measures["attach_count"])
+				assert.Equal(t, ghtelemetry.Measures{
+					"attach_count":      int64(len(values)),
+					"append_ops_count":  0,
+					"replace_ops_count": 0,
+				}, recorder.Events[0].Measures)
 			} else {
 				assert.Empty(t, recorder.Events)
 				assert.Zero(t, recorder.LastSampleRate)

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -77,8 +77,9 @@ type CreateOptions struct {
 
 	DryRun bool
 
-	AttachFlag *attachments.Flag
-	Assets     []attachments.UserAsset
+	AttachFlag      *attachments.Flag
+	AttachTelemetry *attachments.InvocationTelemetry
+	Assets          []attachments.UserAsset
 }
 
 // creationRefs is an interface that provides the necessary information for creating a pull request in the API.
@@ -275,8 +276,6 @@ func NewCmdCreate(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, run
 		Args:    cmdutil.NoArgsQuoteReminder,
 		Aliases: []string{"new"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.AttachFlag.RecordTelemetry(cmd.CommandPath(), telemetry)
-
 			opts.Finder = shared.NewFinder(f)
 
 			opts.TitleProvided = cmd.Flags().Changed("title")
@@ -404,6 +403,8 @@ func NewCmdCreate(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, run
 	fl.StringVarP(&opts.Template, "template", "T", "", "Template `file` to use as starting body text")
 	fl.BoolVar(&opts.DryRun, "dry-run", false, "Print details instead of creating the PR. May still push git changes.")
 	opts.AttachFlag = attachments.AddFlag(cmd)
+	opts.AttachTelemetry = attachments.NewInvocationTelemetry(opts.AttachFlag, telemetry)
+	cmd.Args = opts.AttachTelemetry.WrapArgs(cmd.Args)
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "base", "head")
 
@@ -1127,12 +1128,13 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 
 	var uploadErr error
 	if uploader != nil {
-		body, uploaded, err := uploader.UploadAndAttach(context.Background(), state.Body, opts.Assets)
+		body, uploadResult, err := uploader.UploadAndAttach(context.Background(), state.Body, opts.Assets)
+		opts.AttachTelemetry.RecordOperations(uploadResult)
 		// With nothing uploaded, a body that lost the files it was written
 		// around is not what the caller asked to create. The branch is already
 		// pushed by now, so the message says what was not created rather than
 		// claiming the run had no effect.
-		if err != nil && uploaded == 0 {
+		if err != nil && uploadResult.Uploaded == 0 {
 			return fmt.Errorf("%w\nno pull request was created", err)
 		}
 		uploadErr = err

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -297,6 +297,11 @@ func TestNewCmdCreate(t *testing.T) {
 			wantAssetPaths: []string{tmpImage},
 		},
 		{
+			name:     "attach telemetry survives argument validation",
+			cli:      fmt.Sprintf("unexpected --attach '%s'", tmpImage),
+			wantsErr: true,
+		},
+		{
 			name:              "attach rejects a missing file",
 			cli:               "--title mytitle --body mybody --attach ./nope.png",
 			wantsErr:          true,
@@ -349,6 +354,7 @@ func TestNewCmdCreate(t *testing.T) {
 			cmd.SetOut(stderr)
 			cmd.SetErr(stderr)
 			_, err = cmd.ExecuteC()
+			recorder.Flush()
 			if cmd.Flags().Changed("attach") {
 				values, flagErr := cmd.Flags().GetStringArray("attach")
 				require.NoError(t, flagErr)
@@ -356,7 +362,11 @@ func TestNewCmdCreate(t *testing.T) {
 				require.Len(t, recorder.Events, 1)
 				assert.Equal(t, "attachment_invocation", recorder.Events[0].Type)
 				assert.Equal(t, cmd.CommandPath(), recorder.Events[0].Dimensions["command"])
-				assert.Equal(t, int64(len(values)), recorder.Events[0].Measures["attach_count"])
+				assert.Equal(t, ghtelemetry.Measures{
+					"attach_count":      int64(len(values)),
+					"append_ops_count":  0,
+					"replace_ops_count": 0,
+				}, recorder.Events[0].Measures)
 			} else {
 				assert.Empty(t, recorder.Events)
 				assert.Zero(t, recorder.LastSampleRate)
@@ -419,6 +429,7 @@ func Test_createRun(t *testing.T) {
 		customBranchConfig bool
 		// Defaults to WRITE, which can upload.
 		repoPermission string
+		wantOperations *attachments.UploadResult
 	}{
 		{
 			name: "nontty web",
@@ -1776,6 +1787,10 @@ func Test_createRun(t *testing.T) {
 						}))
 			},
 			expectedOut: "https://github.com/OWNER/REPO/pull/12\n",
+			wantOperations: &attachments.UploadResult{
+				Uploaded:          1,
+				ReplaceOperations: 1,
+			},
 		},
 		{
 
@@ -1871,6 +1886,10 @@ func Test_createRun(t *testing.T) {
 			},
 			expectedOut: "https://github.com/OWNER/REPO/pull/12\n",
 			wantErr:     "could not upload ./bad.png: attaching files requires write access to the repository",
+			wantOperations: &attachments.UploadResult{
+				Uploaded:         1,
+				AppendOperations: 1,
+			},
 		},
 		{
 			name: "the only upload failing creates no pull request",
@@ -2041,6 +2060,10 @@ func Test_createRun(t *testing.T) {
 				cleanSetup = tt.setup(&opts, t)
 			}
 			defer cleanSetup()
+			attachmentRecorder := &telemetry.CommandRecorderSpy{}
+			if tt.wantOperations != nil {
+				opts.AttachTelemetry = attachments.NewTestInvocationTelemetry(t, attachmentRecorder, len(opts.Assets))
+			}
 
 			// All tests in this function use github.com behavior
 			opts.Detector = &fd.EnabledDetectorMock{}
@@ -2050,6 +2073,10 @@ func Test_createRun(t *testing.T) {
 			}
 
 			err := createRun(&opts)
+			if tt.wantOperations != nil {
+				attachmentRecorder.Flush()
+				attachments.AssertTestTelemetryEvents(t, attachmentRecorder.Events, len(opts.Assets), *tt.wantOperations)
+			}
 			output := &test.CmdOut{
 				OutBuf:     stdout,
 				ErrBuf:     stderr,

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -40,9 +40,10 @@ type EditOptions struct {
 	SelectorArg string
 	Interactive bool
 
-	AttachFlag *attachments.Flag
-	Assets     []attachments.UserAsset
-	Config     func() (gh.Config, error)
+	AttachFlag      *attachments.Flag
+	AttachTelemetry *attachments.InvocationTelemetry
+	Assets          []attachments.UserAsset
+	Config          func() (gh.Config, error)
 
 	shared.Editable
 }
@@ -135,8 +136,6 @@ func NewCmdEdit(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, runF 
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.AttachFlag.RecordTelemetry(cmd.CommandPath(), telemetry)
-
 			opts.Finder = shared.NewFinder(f)
 
 			// support `-R, --repo` override
@@ -258,6 +257,8 @@ func NewCmdEdit(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, runF 
 	cmd.Flags().StringVarP(&opts.Editable.Milestone.Value, "milestone", "m", "", "Edit the milestone the pull request belongs to by `name`")
 	cmd.Flags().BoolVar(&removeMilestone, "remove-milestone", false, "Remove the milestone association from the pull request")
 	opts.AttachFlag = attachments.AddFlag(cmd)
+	opts.AttachTelemetry = attachments.NewInvocationTelemetry(opts.AttachFlag, telemetry)
+	cmd.Args = opts.AttachTelemetry.WrapArgs(cmd.Args)
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "base")
 
@@ -423,14 +424,15 @@ func editRun(opts *EditOptions) error {
 		}
 
 		// Nothing that can prompt or cancel may follow this.
-		var uploaded int
-		body, uploaded, uploadErr = uploader.UploadAndAttach(context.Background(), body, opts.Assets)
+		var uploadResult attachments.UploadResult
+		body, uploadResult, uploadErr = uploader.UploadAndAttach(context.Background(), body, opts.Assets)
+		opts.AttachTelemetry.RecordOperations(uploadResult)
 
 		// With nothing uploaded, even a body the caller typed goes unwritten:
 		// its references are still local paths, which render broken. The other
 		// fields are innocent of the upload, so they proceed either way.
-		editable.Body.Edited = uploaded > 0
-		if uploaded > 0 {
+		editable.Body.Edited = uploadResult.Uploaded > 0
+		if uploadResult.Uploaded > 0 {
 			editable.Body.Value = body
 		}
 

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -317,6 +317,11 @@ func TestNewCmdEdit(t *testing.T) {
 			wantAssetPaths: []string{tmpImage},
 		},
 		{
+			name:     "attach telemetry survives argument validation",
+			input:    fmt.Sprintf("23 24 --attach '%s'", tmpImage),
+			wantsErr: true,
+		},
+		{
 			name:  "attach with body records the body that replaces the old one",
 			input: fmt.Sprintf("23 --body 'a new body' --attach '%s'", tmpImage),
 			output: EditOptions{
@@ -369,6 +374,7 @@ func TestNewCmdEdit(t *testing.T) {
 			cmd.SetErr(&bytes.Buffer{})
 
 			_, err = cmd.ExecuteC()
+			recorder.Flush()
 			if cmd.Flags().Changed("attach") {
 				values, flagErr := cmd.Flags().GetStringArray("attach")
 				require.NoError(t, flagErr)
@@ -376,7 +382,11 @@ func TestNewCmdEdit(t *testing.T) {
 				require.Len(t, recorder.Events, 1)
 				assert.Equal(t, "attachment_invocation", recorder.Events[0].Type)
 				assert.Equal(t, cmd.CommandPath(), recorder.Events[0].Dimensions["command"])
-				assert.Equal(t, int64(len(values)), recorder.Events[0].Measures["attach_count"])
+				assert.Equal(t, ghtelemetry.Measures{
+					"attach_count":      int64(len(values)),
+					"append_ops_count":  0,
+					"replace_ops_count": 0,
+				}, recorder.Events[0].Measures)
 			} else {
 				assert.Empty(t, recorder.Events)
 				assert.Zero(t, recorder.LastSampleRate)
@@ -428,6 +438,7 @@ func Test_editRun(t *testing.T) {
 		stdout             string
 		stderr             string
 		wantErr            string
+		wantOperations     *attachments.UploadResult
 	}{
 		{
 			name: "non-interactive",
@@ -1290,6 +1301,10 @@ func Test_editRun(t *testing.T) {
 				mockPullRequestUpdateWithBody(t, reg, "the original body\n\n![shot](https://example.com/1)")
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+			wantOperations: &attachments.UploadResult{
+				Uploaded:         1,
+				AppendOperations: 1,
+			},
 		},
 		{
 			name: "an empty body flag clears the body and leaves the attachment",
@@ -1371,6 +1386,10 @@ func Test_editRun(t *testing.T) {
 			},
 			stdout:  "https://github.com/OWNER/REPO/pull/123\n",
 			wantErr: "could not upload ./b.png: attaching files requires write access to the repository",
+			wantOperations: &attachments.UploadResult{
+				Uploaded:         1,
+				AppendOperations: 1,
+			},
 		},
 		{
 			name: "a sole failed upload leaves the body alone and still edits the title",
@@ -1674,6 +1693,10 @@ func Test_editRun(t *testing.T) {
 			if len(tt.attach) > 0 {
 				tt.input.Assets = attachments.NewTestAssets(t, tt.attach...)
 			}
+			attachmentRecorder := &telemetry.CommandRecorderSpy{}
+			if tt.wantOperations != nil {
+				tt.input.AttachTelemetry = attachments.NewTestInvocationTelemetry(t, attachmentRecorder, len(tt.attach))
+			}
 
 			// The host comes from the pull request the row's finder returns, so
 			// a row can hold a token for a host the config's default is not.
@@ -1693,6 +1716,10 @@ func Test_editRun(t *testing.T) {
 			tt.input.Finder = fieldCapturingFinder{PRFinder: tt.input.Finder, fields: &lookupFields}
 
 			err := editRun(tt.input)
+			if tt.wantOperations != nil {
+				attachmentRecorder.Flush()
+				attachments.AssertTestTelemetryEvents(t, attachmentRecorder.Events, len(tt.attach), *tt.wantOperations)
+			}
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
 			} else {

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -61,6 +61,7 @@ type CommentableOptions struct {
 	BodyProvided     bool
 	KeepExistingBody bool
 	AttachFlag       *attachments.Flag
+	AttachTelemetry  *attachments.InvocationTelemetry
 	Assets           []attachments.UserAsset
 	Config           func() (gh.Config, error)
 }
@@ -353,8 +354,9 @@ func bodyForWrite(opts *CommentableOptions, uploader *attachments.Uploader) (bod
 	if uploader == nil {
 		return opts.Body, true, nil
 	}
-	body, uploaded, err := uploader.UploadAndAttach(context.Background(), opts.Body, opts.Assets)
-	if err != nil && uploaded == 0 {
+	body, uploadResult, err := uploader.UploadAndAttach(context.Background(), opts.Body, opts.Assets)
+	opts.AttachTelemetry.RecordOperations(uploadResult)
+	if err != nil && uploadResult.Uploaded == 0 {
 		return "", false, err
 	}
 	return body, true, err

--- a/pkg/cmd/pr/shared/commentable_test.go
+++ b/pkg/cmd/pr/shared/commentable_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
@@ -189,6 +190,7 @@ func TestCommentableRunUploadsAndWritesBodies(t *testing.T) {
 		wantStdout           string
 		wantErr              string
 		wantUploads          int
+		wantOperations       *attachments.UploadResult
 	}{
 		{
 			name:       "creating with no asset uploads nothing",
@@ -207,6 +209,10 @@ func TestCommentableRunUploadsAndWritesBodies(t *testing.T) {
 			wantBody:             "see below\n\n![shot](https://example.com/1)",
 			wantStdout:           "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
 			wantUploads:          1,
+			wantOperations: &attachments.UploadResult{
+				Uploaded:         1,
+				AppendOperations: 1,
+			},
 		},
 		{
 			name:                 "creating writes what uploaded when one upload fails",
@@ -222,6 +228,10 @@ func TestCommentableRunUploadsAndWritesBodies(t *testing.T) {
 			wantStdout:  "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
 			wantErr:     "could not upload ./b.png: attaching files requires write access to the repository",
 			wantUploads: 2,
+			wantOperations: &attachments.UploadResult{
+				Uploaded:         1,
+				AppendOperations: 1,
+			},
 		},
 		{
 			name:                 "creating writes nothing when every upload fails",
@@ -231,6 +241,7 @@ func TestCommentableRunUploadsAndWritesBodies(t *testing.T) {
 			uploads:              []attachments.UploadStub{{Name: "a.png", Status: 404, Body: `{"message":"Not Found"}`}},
 			wantErr:              "could not upload ./a.png: attaching files requires write access to the repository\nno comment was posted",
 			wantUploads:          1,
+			wantOperations:       &attachments.UploadResult{},
 		},
 		{
 			name:                 "creating writes nothing when every upload fails and the body has text",
@@ -247,6 +258,7 @@ func TestCommentableRunUploadsAndWritesBodies(t *testing.T) {
 			attach:               []string{"repro.mp4"},
 			repositoryDatabaseID: 1234,
 			wantErr:              "cannot embed a video as a reference-style image: ./repro.mp4\nno comment was posted",
+			wantOperations:       &attachments.UploadResult{},
 		},
 		{
 			name:                 "creating reports the upload and the write when both fail",
@@ -261,6 +273,10 @@ func TestCommentableRunUploadsAndWritesBodies(t *testing.T) {
 			writeFails:  true,
 			wantErr:     "could not upload ./b.png: attaching files requires write access to the repository\nGraphQL: the write failed",
 			wantUploads: 2,
+			wantOperations: &attachments.UploadResult{
+				Uploaded:         1,
+				AppendOperations: 1,
+			},
 		},
 		{
 			name: "editing keeps the comment when no body flag was given",
@@ -435,6 +451,10 @@ func TestCommentableRunUploadsAndWritesBodies(t *testing.T) {
 			if len(tt.attach) > 0 {
 				opts.Assets = attachments.NewTestAssets(t, tt.attach...)
 			}
+			attachmentRecorder := &telemetry.CommandRecorderSpy{}
+			if tt.wantOperations != nil {
+				opts.AttachTelemetry = attachments.NewTestInvocationTelemetry(t, attachmentRecorder, len(tt.attach))
+			}
 
 			host := tt.host
 			if host == "" {
@@ -474,6 +494,10 @@ func TestCommentableRunUploadsAndWritesBodies(t *testing.T) {
 			}
 
 			err := CommentableRun(&opts)
+			if tt.wantOperations != nil {
+				attachmentRecorder.Flush()
+				attachments.AssertTestTelemetryEvents(t, attachmentRecorder.Events, len(tt.attach), *tt.wantOperations)
+			}
 
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Follow-up to [#14327](https://github.com/cli/cli/pull/14327), which added attachment invocation counts.

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

Attachment telemetry records how many `--attach` flags a command received, but not how successful uploads changed the command's Markdown.

This adds `append_ops_count` and `replace_ops_count` measures to the existing `attachment_invocation` event. An attachment that replaces several textual references counts as one replacement.

The event is registered before argument validation and resolved when telemetry flushes. It still reports `attach_count` for failed invocations, including authentication and validation failures, while successful uploads can add their operation counts to the same event.

### How did you test this change?

<!--
Report only actions you actually performed and results you actually observed, using factual
first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
hypothetical, inferred, or merely expected scenarios as testing.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

If you did not exercise the changed behavior, write `Not tested` and explain why.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
   Given I was in a repo with no open pull requests
   When I ran `gh pr list`
   Then I saw "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

I built the local `gh` binary and exercised a disposable test issue. I attached two PNGs, referenced the first twice in the comment body, and left the second unreferenced.

The posted comment rewrote both references to the first uploaded URL and appended the second attachment. With `GH_TELEMETRY=log`, I saw one `attachment_invocation` event with `attach_count` set to `2` and `replace_ops_count` and `append_ops_count` each set to `1`, plus the paired `command_invocation` event.

I also ran the command with a missing attachment. It failed validation and logged `attach_count` as `1`, with both operation counts set to `0`.

The recordings project the raw log through `jq` so they show only event type, command, flags, and measures.

#### Mixed append and replace

![A mixed attachment invocation records one replacement and one append operation](https://github.com/user-attachments/assets/ce742b86-dde1-4590-bc38-ab9831ea3ce0)

#### Validation failure

![A failed attachment validation retains the attachment count and records zero operations](https://github.com/user-attachments/assets/84341c0b-6f73-4157-afcb-6ffed5de486d)

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- `attachment_invocation` uses dimensions `{command}` and measures `{attach_count, append_ops_count, replace_ops_count}`. It is sampled at 100%.
- After `--attach` is parsed, authentication, positional argument, and command validation failures retain `attach_count` and report zero operations.
- Partial failures count only uploads completed before the first failure. A final issue, pull request, or comment write failure does not erase completed Markdown operation counts.
- The event contains no paths, alt text, body content, repository information, or asset data.
- Generic command telemetry remains unaware of attachment behavior.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

![Before and after code diagram for deferred attachment telemetry](https://github.com/user-attachments/assets/d4531b02-e8e2-49d4-9c41-90f18d24c05a)

Start with the telemetry recorder interface and service implementation. The important new pattern is `RecordDeferred`: a caller registers an event early, with its original recorded timestamp, but supplies a callback that resolves the final event during `Flush`. Sampling and disabled-telemetry checks still happen before the callback is evaluated. The existing immediate `Record` path is unchanged.

Then review `InvocationTelemetry`, which references the parsed attachment flag but owns the recorder and mutable event. Each command options struct stores it beside `AttachFlag`. It registers the deferred event from Cobra's argument validator, after flags are parsed but before positional argument validation. Successful uploads update this telemetry object before the process-level flush, producing exactly one `attachment_invocation` across subsequent validation and execution paths.

The telemetry service test covers flush-time resolution. The rooted attachment command test covers failure in a parent persistent pre-run hook, the lifecycle edge case that motivated the deferred recorder.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @BagToad will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
