### PR TITLE
docs: fix broken "GitHub language" link in primer foundations

### DIFF
--- a/docs/primer/foundations/README.md
+++ b/docs/primer/foundations/README.md
@@ -54,7 +54,7 @@ _Tip: To get a better sense of what feels right, try writing out the commands in
 
 **When designing your command’s language system:**
 
-- Use [GitHub language](/getting-started/principles#make-it-feel-like-github)
+- Use [GitHub language](/docs/primer/getting-started#make-it-feel-like-github)
 - Use unambiguous language that can’t be confused for something else
 - Use shorter phrases if possible and appropriate
 


### PR DESCRIPTION
### Description

In `docs/primer/foundations/README.md`, the "GitHub language" bullet under **When designing your command's language system** links to:

```
/getting-started/principles#make-it-feel-like-github
```

Rendered on GitHub, a root-relative link resolves against the repository root, so this points at `cli/cli/blob/trunk/getting-started/principles` — a path that does not exist (404). There is no `principles` file; the intended "Make it feel like GitHub" section lives in `docs/primer/getting-started` (heading `### Make it feel like GitHub`, i.e. anchor `#make-it-feel-like-github`).

This updates the link to:

```
/docs/primer/getting-started#make-it-feel-like-github
```

which points to the correct location and matches the `/docs/primer/<dir>#<anchor>` convention already used elsewhere in the primer docs (for example, `docs/primer/getting-started/README.md` links to `/docs/primer/foundations#color`).

### How did you test this change?

I verified this by inspecting the repository rather than rendering the site:

- I confirmed the old target `getting-started/principles` does not exist anywhere in the repo.
- I confirmed `docs/primer/getting-started/README.md` exists and contains the heading `### Make it feel like GitHub`, which GitHub renders with the anchor `#make-it-feel-like-github`.
- I confirmed the new `/docs/primer/<dir>#<anchor>` form matches links already present in the primer docs, so the fixed link is consistent with the surrounding convention.

### Key points

Documentation-only, single-line change. No behavior or code is affected. The fix follows the linking convention already established in the primer docs rather than introducing a new one.

### Notes for reviewers

The change is on line 57 of `docs/primer/foundations/README.md`. The convention reference is `docs/primer/getting-started/README.md`, which uses the same `/docs/primer/<dir>#<anchor>` link style.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @areesh-ali will read and reply directly.
- [ ] An agent will draft replies and @areesh-ali will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
