### PR TITLE
fix(extension): compare binary extension versions using semantic precedence (#14361)

### DIFF
--- a/pkg/cmd/extension/extension.go
+++ b/pkg/cmd/extension/extension.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/hashicorp/go-version"
 	"gopkg.in/yaml.v3"
 )
 
@@ -212,12 +213,23 @@ func (e *Extension) Owner() string {
 }
 
 func (e *Extension) UpdateAvailable() bool {
+	currentVersion := e.CurrentVersion()
+	latestVersion := e.LatestVersion()
 	if e.IsLocal() ||
-		e.CurrentVersion() == "" ||
-		e.LatestVersion() == "" ||
-		e.CurrentVersion() == e.LatestVersion() {
+		currentVersion == "" ||
+		latestVersion == "" ||
+		currentVersion == latestVersion {
 		return false
 	}
+
+	if e.IsBinary() {
+		current, currentErr := version.NewVersion(currentVersion)
+		latest, latestErr := version.NewVersion(latestVersion)
+		if currentErr == nil && latestErr == nil {
+			return latest.GreaterThan(current)
+		}
+	}
+
 	return true
 }
 

--- a/pkg/cmd/extension/extension_test.go
+++ b/pkg/cmd/extension/extension_test.go
@@ -43,13 +43,61 @@ func TestUpdateAvailable_CurrentVersionIsLatestVersion(t *testing.T) {
 }
 
 func TestUpdateAvailable(t *testing.T) {
-	e := &Extension{
-		kind:           BinaryKind,
-		currentVersion: "1.0.0",
-		latestVersion:  "1.1.0",
+	tests := []struct {
+		name           string
+		kind           ExtensionKind
+		currentVersion string
+		latestVersion  string
+		want           bool
+	}{
+		{
+			name:           "binary extension: stable release before prerelease should not upgrade",
+			kind:           BinaryKind,
+			currentVersion: "v0.1.7-rc.1",
+			latestVersion:  "v0.1.6",
+			want:           false,
+		},
+		{
+			name:           "binary extension: stable release after prerelease should upgrade",
+			kind:           BinaryKind,
+			currentVersion: "v0.1.7-rc.1",
+			latestVersion:  "v0.1.7",
+			want:           true,
+		},
+		{
+			name:           "binary extension: regular semver upgrade",
+			kind:           BinaryKind,
+			currentVersion: "1.0.0",
+			latestVersion:  "1.1.0",
+			want:           true,
+		},
+		{
+			name:           "binary extension: unparseable version falls back to inequality",
+			kind:           BinaryKind,
+			currentVersion: "custom-build-a",
+			latestVersion:  "custom-build-b",
+			want:           true,
+		},
+		{
+			name:           "git extension: simple tag difference indicates update",
+			kind:           GitKind,
+			currentVersion: "abc1234",
+			latestVersion:  "def5678",
+			want:           true,
+		},
 	}
 
-	assert.True(t, e.UpdateAvailable())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Extension{
+				kind:           tt.kind,
+				currentVersion: tt.currentVersion,
+				latestVersion:  tt.latestVersion,
+			}
+
+			assert.Equal(t, tt.want, e.UpdateAvailable())
+		})
+	}
 }
 
 func TestOwnerLocalExtension(t *testing.T) {


### PR DESCRIPTION
Closes #14361

### Description

`Extension.UpdateAvailable()` in `pkg/cmd/extension/extension.go` previously checked `CurrentVersion() != LatestVersion()`. For binary extensions, any differing release tag was treated as an available update, even when the currently installed binary tag was semantically newer than the available release (for instance, when a user had pinned a prerelease such as `v0.1.7-rc.1` while the latest stable release was `v0.1.6`).

This caused both `gh extension upgrade --dry-run` and the automatic extension update notifier to recommend downgrading installed binary extensions.

This PR updates `Extension.UpdateAvailable()` for binary extensions to parse both `CurrentVersion()` and `LatestVersion()` with `github.com/hashicorp/go-version` (which is already a dependency in `cli/cli`). If both versions parse as valid semver, an update is only considered available if `latest.GreaterThan(current)`. If either version cannot be parsed as semver, it safely falls back to standard inequality comparison.

### How did you test this change?

Expanded unit tests in `pkg/cmd/extension/extension_test.go` with table-driven test cases covering:
1. Prerelease installed vs older stable latest (`v0.1.7-rc.1` vs `v0.1.6`) -> returns `false` (no upgrade).
2. Prerelease installed vs newer stable latest (`v0.1.7-rc.1` vs `v0.1.7`) -> returns `true` (upgrade available).
3. Standard semver upgrade (`1.0.0` vs `1.1.0`) -> returns `true`.
4. Unparseable/custom tag comparison fallback -> returns `true`.
5. Git extensions -> preserves existing tag inequality comparison.

### Key points

- Relies on `github.com/hashicorp/go-version`, which is already declared in `go.mod`, introducing zero new dependencies.
- Scoped to `e.IsBinary()`, preserving existing git extension hash/tag inequality detection.

### Notes for reviewers

Review should start in `pkg/cmd/extension/extension.go:UpdateAvailable` followed by test scenarios in `pkg/cmd/extension/extension_test.go`.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @sagarithm will read and reply directly.
- [x] An agent will draft replies and @sagarithm will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.
