### PR TITLE
docs: Add step to install working version on Ubuntu Pro

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -68,6 +68,23 @@ sudo apt install gh
 > curl -fsSL -o - https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --show-keys
 > ```
 
+> [!TIP]
+> On some Ubuntu systems, `apt` will default to installing an outdated (and broken) version of the
+> gh client from the official Ubuntu ESM repositories, even after following the instructions above.
+> 
+> To force use of the official GitHub repository, add the following file as `/etc/apt/preferences.d/gh`:
+> 
+> ```text
+> # gh: prefer GitHub official apt repo over Ubuntu ESM pin (510).
+> # ESM gh 2.45.x is broken vs current GitHub APIs - see https://github.com/cli/cli/issues/11992.
+> # Canonical documents this remedy: https://documentation.ubuntu.com/pro-client/en/latest/explanations/about_esm/
+> Package: gh
+> Pin: origin cli.github.com
+> Pin-Priority: 600
+> ```
+
+
+
 ### RPM
 
 RPM packages are hosted on the [GitHub CLI marketing site](https://cli.github.com) for various operating systems including:


### PR DESCRIPTION
### Description


The current install instructions do not work as expected with Ubuntu Pro at least on Ubuntu 24.04.4 LTS. 

They appear to succeed, but are essentially a no-op: `apt install gh`  behaves exactly the same as it would if the repo had never been added. The system installs a Ubuntu-maintained version of 2.45.0, and  will never detect or install any newer version from the official GitHub  repo.

This is because the `gh` package is present in the  Ubuntu Enhanced Security Maintenance repo, and this has a higher pin  priority than the GitHub repo.

This is exacerbated because 2.45.0 no longer actually works, due to  later changes to the GitHub API.

Unless GitHub changes its packaging, the only workaround for this is for end-users to explicitly configure a preference for the GitHub repo.

### How did you test this change?

* In the past, I had followed the official install instructions before first installing `gh`. I can see that I have the keyring, `sources.list.d/github-cli.list` etc with the expected content.
* I hit an error attempting to use `gh` this morning and identified that I was on `v2.45.0`
* I checked the repo and saw that the latest version is `v2.100.0`.
* I ran `apt update` - the first run (not in the screenshot below) failed due to the PGP rotation, but I fixed that without issues.
* I ran `apt update && apt install gh` assuming this would now upgrade me. The GH repo was fetched without warnings, but `apt install gh` reported that there was no newer version to install.
* I spent time googling / trying to find a solution. I found the advice / references below and added the preferences.d file as per this PR.
* I ran `apt update && apt install gh` and have now successfully updated to v2.100.0 (the latest stable at time of writing)

<img width="1923" height="2856" alt="gh-cli-install" src="https://github.com/user-attachments/assets/b6ee545a-53ed-4ddf-83b4-68981ae17627" />

### Key points

### Notes for reviewers

This problem, and the solution, was identified by multiple separate users in:

* https://github.com/cli/cli/issues/11992#issuecomment-3512593241
* https://github.com/cli/cli/issues/11992#issuecomment-3957876808
* https://github.com/cli/cli/issues/11992#issuecomment-4230163572 - this includes a suggestion of adding this to the docs, but it was after the issue was closed and has not had a response.

It is also covered in 
https://lukemanning.ie/blog/gh-issue-view-failing-ubuntu-deprecation-apt-pin

It may also be related to some of the cases reported in https://github.com/cli/cli/issues/9280 (although different posters in  that issue appear to have different issues).

### Authorship and follow-up

Who wrote this:

- [x] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @acoulton will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.