### PR TITLE
pr merge: use enqueuePullRequest when auto merge is disabled on repository

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -262,6 +262,7 @@ type PRRepository struct {
 	DatabaseID int64 `json:"databaseId,omitempty"`
 	// One of ADMIN, MAINTAIN, WRITE, TRIAGE, READ.
 	ViewerPermission string `json:"viewerPermission,omitempty"`
+	AutoMergeAllowed bool   `json:"autoMergeAllowed,omitempty"`
 }
 
 type AutoMergeRequest struct {

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -408,7 +408,7 @@ func IssueGraphQL(fields []string) string {
 			q = append(q, `milestone{number,title,description,dueOn}`)
 		case "repository":
 			// Selects every field PRRepository declares.
-			q = append(q, `repository{id,name,nameWithOwner,databaseId,viewerPermission}`)
+			q = append(q, `repository{id,name,nameWithOwner,databaseId,viewerPermission,autoMergeAllowed}`)
 		case "reactionGroups":
 			q = append(q, `reactionGroups{content,users{totalCount}}`)
 		case "mergeCommit":
@@ -417,6 +417,8 @@ func IssueGraphQL(fields []string) string {
 			q = append(q, `potentialMergeCommit{oid}`)
 		case "autoMergeRequest":
 			q = append(q, autoMergeRequest)
+		case "autoMergeAllowed": // pseudo-field
+			q = append(q, `repository{autoMergeAllowed}`)
 		case "comments":
 			q = append(q, issueComments)
 		case "lastComment": // pseudo-field

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -41,7 +41,12 @@ func TestPullRequestGraphQL(t *testing.T) {
 		{
 			name:   "repository",
 			fields: []string{"repository"},
-			want:   "repository{id,name,nameWithOwner,databaseId,viewerPermission}",
+			want:   "repository{id,name,nameWithOwner,databaseId,viewerPermission,autoMergeAllowed}",
+		},
+		{
+			name:   "autoMergeAllowed",
+			fields: []string{"autoMergeAllowed"},
+			want:   "repository{autoMergeAllowed}",
 		},
 		{
 			// headRepository shares a Go type with the selection above, which
@@ -96,7 +101,7 @@ func TestIssueGraphQL(t *testing.T) {
 		{
 			name:   "repository",
 			fields: []string{"repository"},
-			want:   "repository{id,name,nameWithOwner,databaseId,viewerPermission}",
+			want:   "repository{id,name,nameWithOwner,databaseId,viewerPermission,autoMergeAllowed}",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/pr/merge/http.go
+++ b/pkg/cmd/pr/merge/http.go
@@ -32,11 +32,17 @@ type mergePayload struct {
 	pullRequestID   string
 	method          PullRequestMergeMethod
 	auto            bool
+	enqueue         bool
 	commitSubject   string
 	commitBody      string
 	setCommitBody   bool
 	expectedHeadOid string
 	authorEmail     string
+}
+
+type EnqueuePullRequestInput struct {
+	PullRequestID   githubv4.ID           `json:"pullRequestId"`
+	ExpectedHeadOid *githubv4.GitObjectID `json:"expectedHeadOid,omitempty"`
 }
 
 // TODO: drop after githubv4 gets updated
@@ -84,6 +90,23 @@ func mergePullRequest(client *http.Client, payload mergePayload) error {
 	}
 
 	gql := api.NewClientFromHTTP(client)
+
+	if payload.enqueue {
+		var mutation struct {
+			EnqueuePullRequest struct {
+				ClientMutationId string
+			} `graphql:"enqueuePullRequest(input: $input)"`
+		}
+		enqueueInput := EnqueuePullRequestInput{
+			PullRequestID: githubv4.ID(payload.pullRequestID),
+		}
+		if payload.expectedHeadOid != "" {
+			expectedHeadOid := githubv4.GitObjectID(payload.expectedHeadOid)
+			enqueueInput.ExpectedHeadOid = &expectedHeadOid
+		}
+		variables["input"] = enqueueInput
+		return gql.Mutate(payload.repo.RepoHost(), "PullRequestEnqueue", &mutation, variables)
+	}
 
 	if payload.auto {
 		var mutation struct {

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -200,6 +200,7 @@ type mergeContext struct {
 	crossRepoPR        bool
 	deleteBranch       bool
 	mergeQueueRequired bool
+	autoMergeAllowed   bool
 }
 
 // Attempt to disable auto merge on the pull request.
@@ -300,8 +301,12 @@ func (m *mergeContext) merge() error {
 			// only warn for now
 			_ = m.warnf("%s The merge strategy for %s is set by the merge queue\n", m.cs.Yellow("!"), m.pr.BaseRefName)
 		}
-		// auto merge will either enable auto merge or add to the merge queue
-		payload.auto = true
+		if m.autoMergeAllowed {
+			// auto merge will either enable auto merge or add to the merge queue
+			payload.auto = true
+		} else {
+			payload.enqueue = true
+		}
 	} else {
 		// get user input if not already given
 		if m.opts.MergeStrategyEmpty {
@@ -568,7 +573,7 @@ func (m *mergeContext) infof(format string, args ...any) error {
 func NewMergeContext(opts *MergeOptions) (*mergeContext, error) {
 	findOptions := shared.FindOptions{
 		Selector: opts.SelectorArg,
-		Fields:   []string{"id", "number", "state", "title", "lastCommit", "mergeStateStatus", "headRepositoryOwner", "headRefName", "baseRefName", "headRefOid", "isInMergeQueue", "isMergeQueueEnabled"},
+		Fields:   []string{"id", "number", "state", "title", "lastCommit", "mergeStateStatus", "headRepositoryOwner", "headRefName", "baseRefName", "headRefOid", "isInMergeQueue", "isMergeQueueEnabled", "autoMergeAllowed"},
 	}
 	pr, baseRepo, err := opts.Finder.Find(findOptions)
 	if err != nil {
@@ -578,6 +583,11 @@ func NewMergeContext(opts *MergeOptions) (*mergeContext, error) {
 	httpClient, err := opts.HttpClient()
 	if err != nil {
 		return nil, err
+	}
+
+	autoMergeAllowed := true
+	if pr.Repository != nil {
+		autoMergeAllowed = pr.Repository.AutoMergeAllowed
 	}
 
 	return &mergeContext{
@@ -593,6 +603,7 @@ func NewMergeContext(opts *MergeOptions) (*mergeContext, error) {
 		autoMerge:          opts.AutoMergeEnable && !isImmediatelyMergeable(pr.MergeStateStatus),
 		localBranchExists:  opts.CanDeleteLocalBranch && opts.GitClient.HasLocalBranch(context.Background(), pr.HeadRefName),
 		mergeQueueRequired: pr.IsMergeQueueEnabled,
+		autoMergeAllowed:   autoMergeAllowed,
 	}, nil
 }
 

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -1948,6 +1948,93 @@ func TestPrAddToMergeQueueBlocked(t *testing.T) {
 	assert.Equal(t, "✓ Pull request OWNER/REPO#1 will be added to the merge queue for main when ready\n", output.Stderr())
 }
 
+func TestPrAddToMergeQueue_AutoMergeDisabled(t *testing.T) {
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t,
+		"1",
+		&api.PullRequest{
+			ID:                  "THE-ID",
+			Number:              1,
+			State:               "OPEN",
+			Title:               "The title of the PR",
+			MergeStateStatus:    "CLEAN",
+			IsInMergeQueue:      false,
+			IsMergeQueueEnabled: true,
+			BaseRefName:         "main",
+			Repository: &api.PRRepository{
+				AutoMergeAllowed: false,
+			},
+		},
+		baseRepo("OWNER", "REPO", "main"),
+	)
+
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestEnqueue\b`),
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
+			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
+			assert.NotContains(t, input, "expectedHeadOid")
+		}),
+	)
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+	cs.Register(`git rev-parse --verify refs/heads/`, 0, "")
+
+	output, err := runCommand(http, nil, "blueberries", true, "pr merge 1")
+	if err != nil {
+		t.Fatalf("error running command `pr merge`: %v", err)
+	}
+
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, "✓ Pull request OWNER/REPO#1 will be added to the merge queue for main when ready\n", output.Stderr())
+}
+
+func TestPrAddToMergeQueue_AutoMergeDisabled_MatchHeadCommit(t *testing.T) {
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t,
+		"1",
+		&api.PullRequest{
+			ID:                  "THE-ID",
+			Number:              1,
+			State:               "OPEN",
+			Title:               "The title of the PR",
+			MergeStateStatus:    "CLEAN",
+			IsInMergeQueue:      false,
+			IsMergeQueueEnabled: true,
+			BaseRefName:         "main",
+			HeadRefOid:          "1234567890abcdef",
+			Repository: &api.PRRepository{
+				AutoMergeAllowed: false,
+			},
+		},
+		baseRepo("OWNER", "REPO", "main"),
+	)
+
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestEnqueue\b`),
+		httpmock.GraphQLMutation(`{}`, func(input map[string]any) {
+			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
+			assert.Equal(t, "1234567890abcdef", input["expectedHeadOid"].(string))
+		}),
+	)
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+	cs.Register(`git rev-parse --verify refs/heads/`, 0, "")
+
+	output, err := runCommand(http, nil, "blueberries", true, "pr merge 1 --match-head-commit 1234567890abcdef")
+	if err != nil {
+		t.Fatalf("error running command `pr merge`: %v", err)
+	}
+
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, "✓ Pull request OWNER/REPO#1 will be added to the merge queue for main when ready\n", output.Stderr())
+}
+
 func TestPrAddToMergeQueueAdmin(t *testing.T) {
 	http := initFakeHTTP()
 	defer http.Verify(t)


### PR DESCRIPTION
Fixes #13398

### Description

When a repository configures a merge queue via rulesets without enabling `allow_auto_merge`, running `gh pr merge` failed with:
`GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)`

This occurs because `pr merge` assumed `enablePullRequestAutoMerge` was a catch-all for both auto-merge and merge queues.

This change:
1. Queries `autoMergeAllowed` on the repository as part of the initial PR lookup.
2. Checks `autoMergeAllowed` when adding a PR to a merge queue:
   - If `autoMergeAllowed` is true: continues using `enablePullRequestAutoMerge` (existing behavior).
   - If `autoMergeAllowed` is false: uses the `enqueuePullRequest` GraphQL mutation directly.
3. Supports `--match-head-commit` passing `expectedHeadOid` into `EnqueuePullRequestInput`.

### How did you test this change?

Added unit tests in `pkg/cmd/pr/merge/merge_test.go`:
- `TestPrAddToMergeQueue_AutoMergeDisabled`: verifies `mutation PullRequestEnqueue` is dispatched when a merge queue is required and `AutoMergeAllowed` is false.
- `TestPrAddToMergeQueue_AutoMergeDisabled_MatchHeadCommit`: verifies `expectedHeadOid` is passed to the enqueue mutation.
- Verified existing merge queue and auto-merge unit tests pass.
