### PR TITLE
Prepare exit errors for Go 1.27

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -46,6 +46,7 @@ var remoteRE = regexp.MustCompile(`(.+)\s+(.+)\s+\((push|fetch)\)`)
 var commitLogRE = regexp.MustCompile(`(?m)^[0-9a-fA-F]{7,40}\x00.*?\x00[\S\s]*?\x00$`)
 
 type errWithExitCode interface {
+	error
 	ExitCode() int
 }
 

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -26,6 +26,7 @@ import (
 )
 
 type errWithExitCode interface {
+	error
 	ExitCode() int
 }
 

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -54,6 +54,7 @@ type ForkOptions struct {
 }
 
 type errWithExitCode interface {
+	error
 	ExitCode() int
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Failed workflow run: https://github.com/cli/cli/actions/runs/34183103920

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

The Go bump workflow now reaches `go fix`, tests, and lint as intended, but the first post-merge run exposed a Go 1.27 source migration incompatibility.

Go 1.27 rewrites these `errors.As` calls to `errors.AsType[T]`. The generic API requires `T` to implement `error`, while our three local `errWithExitCode` interfaces only declared `ExitCode()`. Their runtime implementations are already errors; this makes that existing contract explicit so the generated migration compiles.

### How did you test this change?

<!--
Report only actions you actually performed and results you actually observed, using factual
first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
hypothetical, inferred, or merely expected scenarios as testing.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

If you did not exercise the changed behavior, write `Not tested` and explain why.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
   Given I was in a repo with no open pull requests
   When I ran `gh pr list`
   Then I saw "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

I reproduced the workflow failure in an isolated current-trunk worktree by running Go 1.27's `go fix` on the three affected packages and then testing them. Each package failed with `errWithExitCode does not satisfy error (missing method Error)`.

After this change, I repeated that same migration and the three package tests completed successfully. I then ran the complete merged bump script with Go 1.27.1 and golangci-lint v2.13.2; `go mod tidy`, `go fix`, the full test suite, lint, generated commit, and cleanup all completed.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

This does not apply the Go 1.27 migration itself. It only expresses the contract required for the next scheduled bump run to generate and validate that migration in its own pull request.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

The three changes are identical and correspond to the three `errors.As` targets that Go 1.27 migrates to `errors.AsType`.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.