### PR TITLE
Check for merged state when viewing a PR via the issues command

### DIFF
--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -393,6 +393,8 @@ func issueStateTitleWithColor(cs *iostreams.ColorScheme, issue *api.Issue) strin
 	state := "Open"
 	if issue.State == "CLOSED" {
 		state = "Closed"
+	} else if issue.State == "MERGED" {
+                state = "Merged"
 	}
 	return colorFunc(state)
 }


### PR DESCRIPTION
This simply checks to see if the state of a PR is MERGED when the user is trying to use `gh issue view XX` where XX is a PR number instead of an issue. Fixed #12195.
