### PR TITLE
Wait for repository readiness before archiving

### DIFF
--- a/acceptance/testdata/repo/repo-archive-unarchive.txtar
+++ b/acceptance/testdata/repo/repo-archive-unarchive.txtar
@@ -7,6 +7,9 @@ fixture-repo isolated REPO
 exec gh repo view $ORG/$REPO --json=isArchived --jq='.isArchived'
 stdout 'false'
 
+# Wait for asynchronous repository initialization before changing repository-global state
+wait-for-repository-ready $ORG/$REPO
+
 # Archive the repo
 exec gh repo archive $ORG/$REPO --yes
 


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

The `repo-archive-unarchive` acceptance script can attempt to archive its auto-initialized fixture while GitHub is still initializing the repository. In that state, the archive mutation can fail because another repository operation is still in progress.

Wait for the fixture's default-branch `HEAD` commit to become available before changing repository-global archive state. This uses the acceptance harness's existing bounded `wait-for-repository-ready` helper.

Failing run: https://github.com/cli/cli/actions/runs/34481717106/job/102885885080

### How did you test this change?

Not tested against the live acceptance environment because I did not have explicit authorization in this session to use acceptance credentials and mutate resources in the configured test organization.

### Key points

The wait is condition-based and bounded to 30 seconds. I did not add a fixed sleep; the acceptance guidance only requires an additional stabilization delay for repository rename operations.

### Notes for reviewers

Start with `acceptance/testdata/repo/repo-archive-unarchive.txtar`. The behavior and intended use of the helper are documented in `acceptance/README.md` and implemented in `acceptance/acceptance_test.go`.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.