### PR TITLE
Update Go bump validation tools

### DIFF
--- a/.github/govulncheck-version
+++ b/.github/govulncheck-version
@@ -1,0 +1,4 @@
+# This pin lives outside .github/workflows so bump-go can update it with the
+# workflow GITHUB_TOKEN, which cannot push workflow-file changes. govulncheck
+# embeds x/tools and is refreshed on Go language bumps to support new syntax.
+v1.1.4

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -23,7 +23,8 @@ jobs:
       # See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck#hdr-Exit_codes for more information on exit codes.
       - name: Check Go vulnerabilities
         run: |
-          go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 -format sarif ./... > gh.sarif
+          govulncheck_version=$(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' .github/govulncheck-version)
+          go run "golang.org/x/vuln/cmd/govulncheck@$govulncheck_version" -format sarif ./... > gh.sarif
 
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
       - go.mod
       - go.sum
       - ".github/golangci-lint-version"
+      - ".github/govulncheck-version"
       - ".github/licenses.tmpl"
       - ".github/workflows/lint.yml"
       - "script/licenses"
@@ -17,6 +18,7 @@ on:
       - go.mod
       - go.sum
       - ".github/golangci-lint-version"
+      - ".github/govulncheck-version"
       - ".github/licenses.tmpl"
       - ".github/workflows/lint.yml"
       - "script/licenses"
@@ -75,4 +77,5 @@ jobs:
       # Since our builds do not use `-buildvcs=false`, we run in source mode here instead.
       - name: Check Go vulnerabilities
         run: |
-          go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 ./...
+          govulncheck_version=$(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' .github/govulncheck-version)
+          go run "golang.org/x/vuln/cmd/govulncheck@$govulncheck_version" ./...

--- a/.github/workflows/scripts/bump-go.sh
+++ b/.github/workflows/scripts/bump-go.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# bump-go.sh -- Update go.mod `go` directive and toolchain to latest stable Go release.
+# bump-go.sh -- Update Go and its version-coupled validation tools.
 #
 # Usage:
 #   ./bump-go.sh [--apply|-a] [--version <version>] <path/to/go.mod>
@@ -50,9 +50,10 @@ fi
 REPO="cli/cli"
 MODULE_DIR=$(dirname "$GO_MOD")
 GO_SUM="$MODULE_DIR/go.sum"
-# Keep this mutable pin outside .github/workflows because the workflow's
+# Keep these mutable pins outside .github/workflows because the workflow's
 # GITHUB_TOKEN cannot push commits that create or update workflow files.
 LINTER_VERSION_FILE="$REPO_ROOT/.github/golangci-lint-version"
+GOVULNCHECK_VERSION_FILE="$REPO_ROOT/.github/govulncheck-version"
 
 # ---- Discover latest stable Go release --------------------------------------
 if [[ -n "$TARGET_GO_VERSION" ]]; then
@@ -89,6 +90,30 @@ CURRENT_TOOLCHAIN=$(jq -r '.Toolchain // ""' <<< "$GO_MOD_JSON")
 
 echo "  → current go    : $CURRENT_GO_DIRECTIVE"
 echo "  → current tc    : ${CURRENT_TOOLCHAIN:-(none)}"
+
+GO_DIRECTIVE_CHANGED=0
+if [[ "$CURRENT_GO_DIRECTIVE" != "$GO_DIRECTIVE_VERSION" ]]; then
+  GO_DIRECTIVE_CHANGED=1
+fi
+
+govulncheck_version_lines=$(grep -Ec '^v[0-9]+\.[0-9]+\.[0-9]+$' "$GOVULNCHECK_VERSION_FILE" || true)
+if [[ $govulncheck_version_lines -ne 1 ]]; then
+  echo "Error: expected exactly one pinned govulncheck version in '$GOVULNCHECK_VERSION_FILE'" >&2
+  exit 1
+fi
+GOVULNCHECK_VERSION=$(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' "$GOVULNCHECK_VERSION_FILE")
+
+if [[ $GO_DIRECTIVE_CHANGED -eq 1 ]]; then
+  # govulncheck builds SSA with x/tools, which must understand syntax added by
+  # the selected Go language version.
+  echo "Fetching latest govulncheck version..."
+  GOVULNCHECK_VERSION=$(go list -m -f '{{.Version}}' golang.org/x/vuln@latest)
+  if [[ ! "$GOVULNCHECK_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: unexpected govulncheck version '$GOVULNCHECK_VERSION'" >&2
+    exit 1
+  fi
+fi
+echo "  → govulncheck  : $GOVULNCHECK_VERSION"
 
 # ---- Prepare Git branch -----------------------------------------------------
 BRANCH="bump-go-$TOOLCHAIN_VERSION"
@@ -131,6 +156,13 @@ if ! git -C "$REPO_ROOT" diff --quiet -- "$GO_MOD"; then
 else
   echo "  • Go version unchanged; keeping the existing golangci-lint pin"
 fi
+if [[ $GO_DIRECTIVE_CHANGED -eq 1 ]]; then
+  sed -i.bak -E "s/^v[0-9]+\.[0-9]+\.[0-9]+$/$GOVULNCHECK_VERSION/" "$GOVULNCHECK_VERSION_FILE"
+  rm -f "$GOVULNCHECK_VERSION_FILE.bak"
+  echo "  • set govulncheck → $GOVULNCHECK_VERSION"
+else
+  echo "  • Go language version unchanged; keeping the existing govulncheck pin"
+fi
 echo "  • running go fix..."
 go fix ./...
 status=0
@@ -138,6 +170,8 @@ echo "  • running tests..."
 go test ./... || status=$?
 echo "  • running golangci-lint..."
 golangci-lint run ./... || status=$?
+echo "  • running govulncheck..."
+go run "golang.org/x/vuln/cmd/govulncheck@$GOVULNCHECK_VERSION" ./... || status=$?
 if [[ $status -ne 0 ]]; then
   exit "$status"
 fi
@@ -197,6 +231,7 @@ This PR updates Go to the latest stable release.
 * **go directive:** \`$FINAL_GO\`
 $TC_LINE
 * **golangci-lint:** \`v$LINTER_VERSION\`
+* **govulncheck:** \`$GOVULNCHECK_VERSION\`
 EOF
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

Follow-up to #14423.

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

The Go 1.27 bump generated valid promoted-field struct literals, but the `govulncheck` version pinned in CI used an older `x/tools` SSA builder that panicked on that syntax.

This moves the mutable govulncheck version into `.github/govulncheck-version`, where the bump workflow's `GITHUB_TOKEN` can update it without modifying workflow YAML. When the Go language version changes, `bump-go.sh` now selects the latest tagged govulncheck release and runs it against the generated source before opening the bump PR. Patch-only Go updates keep the existing pin.

The version file documents why it exists and why it needs to track Go language changes. Both vulnerability workflows consume the shared version.

### How did you test this change?

<!--
Report only actions you actually performed and results you actually observed, using factual
first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
hypothetical, inferred, or merely expected scenarios as testing.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

If you did not exercise the changed behavior, write `Not tested` and explain why.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
   Given I was in a repo with no open pull requests
   When I ran `gh pr list`
   Then I saw "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

Given an isolated clean checkout at Go 1.26, when I ran the modified bump script with `--version 1.27.1`, I saw it select govulncheck `v1.8.0`, update only the external version file, apply the Go 1.27 source migrations, and complete the vulnerability scan without the SSA panic. The generated dry-run diff did not modify workflow YAML.

I also replaced the version in a copy of `.github/govulncheck-version` and confirmed the explanatory comments were preserved while the workflow parser selected the new version.

### Key points

<!--
Tradeoffs you accepted, alternatives you rejected, and anything a reviewer would otherwise have to guess at.
-->

- The initial external pin remains `v1.1.4`, preserving current behavior until the next Go language bump.
- Govulncheck refreshes on language-version changes rather than every Go patch bump, limiting unrelated churn while keeping its SSA tooling compatible with new syntax.

### Notes for reviewers

<!--
Where should review start, and what should be read next? Call out anything you are unsure about.

Link related issues or prior discussion, with one sentence on why each matters.
-->

Start with `.github/workflows/scripts/bump-go.sh`, then review `.github/govulncheck-version` and its two workflow consumers. The failed govulncheck job in #14423 demonstrates the compatibility gap this prevents; this PR does not modify that bump PR.

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [x] Nobody has explicitly committed to replying.