### PR TITLE
Fix remote branch deletion for owner case mismatch

### DIFF
--- a/acceptance/testdata/pr/pr-merge-merge-strategy.txtar
+++ b/acceptance/testdata/pr/pr-merge-merge-strategy.txtar
@@ -12,6 +12,9 @@ env REBASE_BRANCH_NAME=${SCRIPT_NAME}-${RANDOM_STRING}-rebase
 env REBASE_PR_TITLE=${SCRIPT_NAME}-${RANDOM_STRING}-rebase
 env REBASE_BASE_BRANCH=${SCRIPT_NAME}-${RANDOM_STRING}-rebase-base
 
+# Ensure that branch deletion is performed by gh rather than repository settings
+exec gh api --method PATCH repos/$ORG/$REPO -F delete_branch_on_merge=false --silent
+
 # Clone the repo
 exec gh repo clone $ORG/$REPO
 
@@ -33,8 +36,12 @@ stdout2env PR_URL
 exec git checkout $BASE_BRANCH
 ! exists file.txt
 
-# Merge the PR
-exec gh pr merge $PR_URL --merge
+# Merge the PR and delete its local and remote branches
+exec git show-ref --verify refs/heads/$BRANCH_NAME
+exec git ls-remote --exit-code origin refs/heads/$BRANCH_NAME
+exec gh pr merge $PR_URL --merge --delete-branch
+! exec git show-ref --verify refs/heads/$BRANCH_NAME
+! exec git ls-remote --exit-code origin refs/heads/$BRANCH_NAME
 
 # Check that the state of the PR is now merged
 exec gh pr view $PR_URL

--- a/acceptance/testdata/pr/pr-merge-merge-strategy.txtar
+++ b/acceptance/testdata/pr/pr-merge-merge-strategy.txtar
@@ -12,9 +12,6 @@ env REBASE_BRANCH_NAME=${SCRIPT_NAME}-${RANDOM_STRING}-rebase
 env REBASE_PR_TITLE=${SCRIPT_NAME}-${RANDOM_STRING}-rebase
 env REBASE_BASE_BRANCH=${SCRIPT_NAME}-${RANDOM_STRING}-rebase-base
 
-# Ensure that branch deletion is performed by gh rather than repository settings
-exec gh api --method PATCH repos/$ORG/$REPO -F delete_branch_on_merge=false --silent
-
 # Clone the repo
 exec gh repo clone $ORG/$REPO
 

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
@@ -589,7 +590,7 @@ func NewMergeContext(opts *MergeOptions) (*mergeContext, error) {
 		httpClient:         httpClient,
 		merged:             pr.State == MergeStateStatusMerged,
 		deleteBranch:       opts.DeleteBranch,
-		crossRepoPR:        pr.HeadRepositoryOwner.Login != baseRepo.RepoOwner(),
+		crossRepoPR:        !strings.EqualFold(pr.HeadRepositoryOwner.Login, baseRepo.RepoOwner()),
 		autoMerge:          opts.AutoMergeEnable && !isImmediatelyMergeable(pr.MergeStateStatus),
 		localBranchExists:  opts.CanDeleteLocalBranch && opts.GitClient.HasLocalBranch(context.Background(), pr.HeadRefName),
 		mergeQueueRequired: pr.IsMergeQueueEnabled,

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
@@ -569,7 +568,7 @@ func (m *mergeContext) infof(format string, args ...any) error {
 func NewMergeContext(opts *MergeOptions) (*mergeContext, error) {
 	findOptions := shared.FindOptions{
 		Selector: opts.SelectorArg,
-		Fields:   []string{"id", "number", "state", "title", "lastCommit", "mergeStateStatus", "headRepositoryOwner", "headRefName", "baseRefName", "headRefOid", "isInMergeQueue", "isMergeQueueEnabled"},
+		Fields:   []string{"id", "number", "state", "title", "lastCommit", "mergeStateStatus", "headRefName", "baseRefName", "headRefOid", "isCrossRepository", "isInMergeQueue", "isMergeQueueEnabled"},
 	}
 	pr, baseRepo, err := opts.Finder.Find(findOptions)
 	if err != nil {
@@ -590,7 +589,7 @@ func NewMergeContext(opts *MergeOptions) (*mergeContext, error) {
 		httpClient:         httpClient,
 		merged:             pr.State == MergeStateStatusMerged,
 		deleteBranch:       opts.DeleteBranch,
-		crossRepoPR:        !strings.EqualFold(pr.HeadRepositoryOwner.Login, baseRepo.RepoOwner()),
+		crossRepoPR:        pr.IsCrossRepository,
 		autoMerge:          opts.AutoMergeEnable && !isImmediatelyMergeable(pr.MergeStateStatus),
 		localBranchExists:  opts.CanDeleteLocalBranch && opts.GitClient.HasLocalBranch(context.Background(), pr.HeadRefName),
 		mergeQueueRequired: pr.IsMergeQueueEnabled,

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -670,6 +670,32 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	`), output.Stderr())
 }
 
+func TestPrMerge_deleteBranch_ownerCaseMismatch(t *testing.T) {
+	reg := initFakeHTTP()
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.REST("DELETE", "repos/SomeCoolProject/some-cool-repo/git/refs/heads%2Ftopic"),
+		httpmock.StringResponse(`{}`))
+
+	ios, _, _, _ := iostreams.Test()
+	opts := &MergeOptions{
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		IO: ios,
+		Finder: shared.NewMockFinder("", &api.PullRequest{
+			State:               "OPEN",
+			HeadRefName:         "topic",
+			HeadRepositoryOwner: api.Owner{Login: "somecoolproject"},
+		}, baseRepo("SomeCoolProject", "some-cool-repo", "main")),
+		DeleteBranch: true,
+	}
+
+	ctx, err := NewMergeContext(opts)
+	require.NoError(t, err)
+	require.NoError(t, ctx.deleteRemoteBranch())
+}
+
 func TestPrMerge_deleteBranch_apiError(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -670,30 +670,58 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	`), output.Stderr())
 }
 
-func TestPrMerge_deleteBranch_ownerCaseMismatch(t *testing.T) {
+func TestDeleteRemoteBranchTreatsOwnerCaseAsSameRepository(t *testing.T) {
+	t.Parallel()
+
+	// Given a same-repository pull request whose canonical owner casing differs
+	// from the owner casing parsed from the Git remote.
 	reg := initFakeHTTP()
-	defer reg.Verify(t)
 	reg.Register(
 		httpmock.REST("DELETE", "repos/SomeCoolProject/some-cool-repo/git/refs/heads%2Ftopic"),
 		httpmock.StringResponse(`{}`))
 
 	ios, _, _, _ := iostreams.Test()
+	finder := shared.NewMockFinder("", &api.PullRequest{
+		State:               "OPEN",
+		HeadRefName:         "topic",
+		HeadRepositoryOwner: api.Owner{Login: "somecoolproject"},
+		IsCrossRepository:   false,
+	}, baseRepo("SomeCoolProject", "some-cool-repo", "main"))
+	finder.ExpectFields([]string{
+		"id",
+		"number",
+		"state",
+		"title",
+		"lastCommit",
+		"mergeStateStatus",
+		"headRefName",
+		"baseRefName",
+		"headRefOid",
+		"isCrossRepository",
+		"isInMergeQueue",
+		"isMergeQueueEnabled",
+	})
+
 	opts := &MergeOptions{
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil
 		},
-		IO: ios,
-		Finder: shared.NewMockFinder("", &api.PullRequest{
-			State:               "OPEN",
-			HeadRefName:         "topic",
-			HeadRepositoryOwner: api.Owner{Login: "somecoolproject"},
-		}, baseRepo("SomeCoolProject", "some-cool-repo", "main")),
+		IO:           ios,
+		Finder:       finder,
 		DeleteBranch: true,
 	}
 
 	ctx, err := NewMergeContext(opts)
 	require.NoError(t, err)
-	require.NoError(t, ctx.deleteRemoteBranch())
+
+	// When the remote branch is deleted.
+	err = ctx.deleteRemoteBranch()
+
+	// Then the same-repository branch deletion request is sent.
+	require.NoError(t, err)
+	require.Len(t, reg.Requests, 1)
+	assert.Equal(t, http.MethodDelete, reg.Requests[0].Method)
+	assert.Equal(t, "/repos/SomeCoolProject/some-cool-repo/git/refs/heads%2Ftopic", reg.Requests[0].URL.RequestURI())
 }
 
 func TestPrMerge_deleteBranch_apiError(t *testing.T) {
@@ -886,6 +914,7 @@ func TestPrMerge_deleteBranch_onlyLocally(t *testing.T) {
 			BaseRefName:         "main",
 			MergeStateStatus:    "CLEAN",
 			HeadRepositoryOwner: api.Owner{Login: "HEAD"}, // Not the same owner as the base repo
+			IsCrossRepository:   true,
 		},
 		baseRepo("OWNER", "REPO", "main"),
 	)


### PR DESCRIPTION
Fixes #14404

### Description

The repository owner parsed from a Git remote can preserve user-supplied casing while GitHub returns the canonical login casing. The merge command compared these values case-sensitively, incorrectly treating a same-repository pull request as cross-repository and silently skipping remote branch deletion.

This now requests and trusts GitHub's `isCrossRepository` value rather than deriving the relationship from owner login strings. It also adds regression coverage for a casing-only mismatch.

### How did you test this change?

I created a private test repository with automatic head-branch deletion disabled, set `prompt` to `disabled`, changed only the owner casing in `remote.origin.url`, and opened two pull requests from branches in the same repository.

With the baseline binary, I ran `gh pr merge 1 --merge --delete-branch`. The local branch was deleted, but an API lookup showed that the remote branch still existed.

With the changed binary, I ran `gh pr merge 2 --merge --delete-branch`. The command reported deleting both the local and remote branches, and an API lookup confirmed that the remote branch no longer existed.

The focused live acceptance script also passed against `github.com` using the `gh-acceptance-testing` organization:

```console
$ GH_ACCEPTANCE_SCRIPT=pr-merge-merge-strategy.txtar \
  GH_ACCEPTANCE_HOST=github.com \
  GH_ACCEPTANCE_ORG=gh-acceptance-testing \
  GH_ACCEPTANCE_TOKEN="$(gh auth token --hostname github.com)" \
  go test -tags=acceptance -count=1 \
    -run '^TestAcceptance$/^pr$' ./acceptance
ok      github.com/cli/cli/v2/acceptance        34.182s
```

![Terminal demonstration showing the reproduction setup, the baseline preserving the remote branch, and the changed binary deleting it](https://github.com/user-attachments/assets/047ffb8d-b20f-4282-a47c-df2084fa2493)

### Key points

The pull request model already exposes `IsCrossRepository`, which is the domain abstraction the merge command needs. Using it avoids adding a repository-owner type or duplicating GitHub login equivalence rules. The merge query no longer requests `headRepositoryOwner`, which was only used for the removed comparison.

### Notes for reviewers

Start with the requested fields and `crossRepoPR` initialization in `NewMergeContext`, then read `TestDeleteRemoteBranchTreatsOwnerCaseAsSameRepository`.

The reproduction and investigation are documented in #14404.

### Authorship and follow-up

Who wrote this:

- [ ] A human wrote it.
- [ ] An agent wrote it under close human direction.
- [x] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.