### PR TITLE
Retire multi-account migration

### DIFF
--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -1,5 +1,10 @@
 # Multiple Accounts with the CLI - v2.40.0
 
+> [!NOTE]
+> This document describes multi-account support as it was introduced in v2.40.0
+> and is retained for historical context. Some implementation details, including
+> automatic configuration migration, are outdated.
+
 Since its creation, `gh` has enforced a mapping of one account per host. Functionally, this meant that when targeting a
 single host (e.g. github.com) each `auth login` would replace the token being used for API requests, and for git
 operations when `gh` was configured as a git credential manager. Removing this limitation has been a [long requested

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -693,7 +693,7 @@ func TestUserWorksRightAfterMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// When we migrate
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	c := cfg{authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
@@ -710,7 +710,7 @@ func TestGitProtocolWorksRightAfterMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// When we migrate
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	c := cfg{authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
@@ -727,7 +727,7 @@ func TestHostsWorksRightAfterMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// When we migrate
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	c := cfg{authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
@@ -743,7 +743,7 @@ func TestDefaultHostWorksRightAfterMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// When we migrate
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	c := cfg{authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
@@ -760,7 +760,7 @@ func TestTokenWorksRightAfterMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// When we migrate
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	c := cfg{authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
@@ -837,7 +837,7 @@ func TestLogoutRightAfterMigrationRemovesHost(t *testing.T) {
 	require.NoError(t, err)
 
 	// When we migrate and logout
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	c := cfg{authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
@@ -852,7 +852,7 @@ func TestLoginInsecurePostMigrationUsesConfigForToken(t *testing.T) {
 	authCfg := newTestAuthConfig(t)
 
 	// When we migrate and login with insecure storage
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	c := cfg{authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
@@ -871,7 +871,7 @@ func TestLoginPostMigrationSetsGitProtocol(t *testing.T) {
 	// Given we have logged in after migration
 	authCfg := newTestAuthConfig(t)
 
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	c := cfg{authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
@@ -890,7 +890,7 @@ func TestLoginPostMigrationSetsUser(t *testing.T) {
 	// Given we have logged in after migration
 	authCfg := newTestAuthConfig(t)
 
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	c := cfg{authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
@@ -912,7 +912,7 @@ func TestLoginSecurePostMigrationRemovesTokenFromConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// When we migrate and login again with secure storage
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	c := cfg{authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 

--- a/internal/config/migration/multi_account.go
+++ b/internal/config/migration/multi_account.go
@@ -68,22 +68,31 @@ type tokenSource struct {
 // breaking existing users of go-gh which looks at a specific location
 // in the config for oauth tokens that are stored insecurely.
 
-type MultiAccount struct {
+// MultiAccountDeprecated migrates the pre-v2.40 one-account-per-host
+// configuration into the multi-account schema.
+//
+// This migration no longer runs automatically. Its compatibility window
+// covered upgrades from versions that predated the multi-account schema.
+// Supported configurations now already use that schema, so running it before
+// every command no longer provides value. The implementation remains as
+// executable documentation of the original migration and its compatibility
+// constraints.
+type MultiAccountDeprecated struct {
 	// Allow injecting a transport layer in tests.
 	Transport http.RoundTripper
 }
 
-func (m MultiAccount) PreVersion() string {
+func (m MultiAccountDeprecated) PreVersion() string {
 	// It is expected that there is no version key since this migration
 	// introduces it.
 	return ""
 }
 
-func (m MultiAccount) PostVersion() string {
+func (m MultiAccountDeprecated) PostVersion() string {
 	return "1"
 }
 
-func (m MultiAccount) Do(c *config.Config) error {
+func (m MultiAccountDeprecated) Do(c *config.Config) error {
 	hostnames, err := c.Keys(hostsKey)
 	// [github.com, github.localhost]
 	// We wouldn't expect to have a hosts key when this is the first time anyone

--- a/internal/config/migration/multi_account_test.go
+++ b/internal/config/migration/multi_account_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMigration(t *testing.T) {
+func TestMultiAccountDeprecatedMigration(t *testing.T) {
 	cfg := config.ReadFromString(`
 hosts:
   github.com:
@@ -25,7 +25,7 @@ hosts:
     git_protocol: https
 `)
 
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	require.NoError(t, m.Do(cfg))
 
 	// First we'll check that the oauth tokens have been moved to their new locations
@@ -60,7 +60,7 @@ hosts:
 	require.NoError(t, keyring.Set("gh:github.com", "", userOneToken))
 	require.NoError(t, keyring.Set("gh:enterprise.com", "", userTwoToken))
 
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	require.NoError(t, m.Do(cfg))
 
 	// Verify token gets stored with host and username
@@ -96,19 +96,19 @@ hosts:
 }
 
 func TestPreVersionIsEmptyString(t *testing.T) {
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	require.Equal(t, "", m.PreVersion())
 }
 
 func TestPostVersion(t *testing.T) {
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	require.Equal(t, "1", m.PostVersion())
 }
 
 func TestMigrationReturnsSuccessfullyWhenNoHostsEntry(t *testing.T) {
 	cfg := config.ReadFromString(``)
 
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	require.NoError(t, m.Do(cfg))
 }
 
@@ -117,7 +117,7 @@ func TestMigrationReturnsSuccessfullyWhenEmptyHosts(t *testing.T) {
 hosts:
 `)
 
-	var m migration.MultiAccount
+	var m migration.MultiAccountDeprecated
 	require.NoError(t, m.Do(cfg))
 }
 
@@ -142,7 +142,7 @@ hosts:
 		httpmock.StringResponse(`{"data":{"viewer":{"login":"monalisa"}}}`),
 	)
 
-	m := migration.MultiAccount{Transport: reg}
+	m := migration.MultiAccountDeprecated{Transport: reg}
 	require.NoError(t, m.Do(cfg))
 
 	require.Equal(t, fmt.Sprintf("token %s", token), reg.Requests[0].Header.Get("Authorization"))
@@ -182,7 +182,7 @@ hosts:
 		httpmock.StringResponse(`{"data":{"viewer":{"login":"monalisa"}}}`),
 	)
 
-	m := migration.MultiAccount{Transport: reg}
+	m := migration.MultiAccountDeprecated{Transport: reg}
 	require.NoError(t, m.Do(cfg))
 
 	require.Equal(t, "token test-token", reg.Requests[0].Header.Get("Authorization"))
@@ -201,7 +201,7 @@ hosts:
     git_protocol: ssh
 `)
 
-	m := migration.MultiAccount{}
+	m := migration.MultiAccountDeprecated{}
 	require.NoError(t, m.Do(cfg))
 
 	requireNoKey(t, cfg, []string{"hosts", "github.com"})
@@ -218,7 +218,7 @@ hosts:
     git_protocol: ssh
 `)
 
-	m := migration.MultiAccount{}
+	m := migration.MultiAccountDeprecated{}
 	err := m.Do(cfg)
 
 	require.ErrorContains(t, err, `couldn't find oauth token for "github.com": keyring test error`)

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cli/cli/v2/internal/build"
 	"github.com/cli/cli/v2/internal/ci"
 	"github.com/cli/cli/v2/internal/config"
-	"github.com/cli/cli/v2/internal/config/migration"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	"github.com/cli/cli/v2/internal/telemetry"
@@ -132,14 +131,6 @@ func Main() exitCode {
 	defer telemetryService.Finish()
 
 	cmdFactory := factory.New(buildVersion, string(invokingAgent), cfgFunc, ioStreams, ghExecutablePath, telemetryService)
-
-	if cfgErr == nil {
-		var m migration.MultiAccount
-		if err := cfg.Migrate(m); err != nil {
-			fmt.Fprintln(stderr, err)
-			return exitError
-		}
-	}
 
 	ctx := context.Background()
 	updateCtx, updateCancel := context.WithCancel(ctx)


### PR DESCRIPTION
<!--
Thank you for contributing to GitHub CLI!

If you are proposing a fix for a security issue, STOP and follow .github/SECURITY.md instead.
-->

<!-- List related issues here. Use `fixes` or `closes` keywords to associate an issue number. -->

### Description

<!--
What's the problem? How are we addressing it?

Write for a reviewer who has not worked in this part of the codebase. Give them the
background they need before the problem makes sense, and avoid jargon.
-->

When initial multi account support was added to `gh` in `v2.40.0` (December 2023, so almost 3 years ago at this point), we had to perform some [data migrations](https://github.com/cli/cli/blob/7f0590c2b8050bb04c5af52291062e6825dda9df/docs/multiple-accounts.md#data-migration). The code for this, with lots of nice explanations can be found in [multi-account.go](https://github.com/cli/cli/blob/7f0590c2b8050bb04c5af52291062e6825dda9df/internal/config/migration/multi_account.go), and it has been running on every invocation of `gh` for 3 years: https://github.com/cli/cli/blob/7f0590c2b8050bb04c5af52291062e6825dda9df/internal/ghcmd/cmd.go#L136-L142

The TL;DR was that we needed to take host level user/token data and namespace it by username. For example, a hosts entry of:

```
//	github.localhost:
//	  user: monalisa
//	  git_protocol: https
//    oauth_token: xyz
```

would become:

```
// github.localhost:
//	 user: monalisa
//	 git_protocol: https
//   oauth_token: xyz
//   users:
//	   monalisa:
//	     oauth_token: xyz
```

A similar operation would occur for the keyring with a key of:

```
"gh:" + hostname
```

being copied to:

"gh:" + hostname + ":" + username

This set the stage for `gh auth switch` to pick the user and token from a list and "activate" them in the config/keyring entry. The data format was both backwards **and** forwards compatible, to allow users to move back and forward between versions without breaking anything. However, this global keyring entry has been the source of a number of bugs such as:
 * https://github.com/cli/cli/issues/14370
 * https://github.com/cli/cli/issues/12885

These bugs occur because people use `GH_CONFIG_DIR` to swap config files (and therefore active users). This can cause a split brain in some cases where the active user in the config, and the user owning the token in the keyring aren't the same. We can fix the code paths, but we're now 3 years on and I don't think we should give much concern to compatability pre `v2.40.0`, so I want to remove that keyring entry altogether.

This PR doesn't do that work, but it does remove the migration that circles the area and just sits there as debt.

### How did you test this change?

<!--
Report only actions you actually performed and results you actually observed, using factual
first-person language (for example, "I ran..." and "I saw..."). Do not present planned,
hypothetical, inferred, or merely expected scenarios as testing.

Automated test results do not belong here. Passing unit tests, `go test ./...` output, and
coverage numbers tell a reviewer nothing they cannot see from CI, so do not paste them.

If you did not exercise the changed behavior, write `Not tested` and explain why.

Use one or more of these, whichever communicates best:

1. Screenshots or GIFs of the real command running. Preferred whenever the change is visible
   in terminal output. If output changed, show it before and after.
2. Given/When/Then scenarios, but only when you actually executed the steps. For example:
   Given I was in a repo with no open pull requests
   When I ran `gh pr list`
   Then I saw "no open pull requests in cli/cli"
3. A natural language walkthrough of what you did by hand, the states you covered, and what
   you saw, including error and edge cases.

If you leave this empty, your pull request will very likely be closed.
-->

```
➜  williammartin-probable-robot git:(williammartin-fix-keyring-user-lookup) ./bin/gh version       
gh version 2.100.0-103-g5fe0f89e1 (2026-09-11)
https://github.com/cli/cli/releases/latest
➜  williammartin-probable-robot git:(williammartin-fix-keyring-user-lookup) ./bin/gh api /zen | cat
Encourage flow.% 
```

### Authorship and follow-up

<!--
REQUIRED - If you are an AI agent filling in this template, answer "Who wrote this" for yourself and answer honestly. For "Who answers review comments," use only a choice the human has explicitly made in the conversation. If no choice has already been established, pause and ask the human to choose one of the three options before creating or updating the pull request. Do not infer the choice from repository ownership, authorship, assignees, prior interactions, or the current operator. After the human answers, check exactly the option they chose; the last option is valid when the human explicitly chooses nobody.

Check exactly one box in each list.
-->

Who wrote this:

- [ ] A human wrote it.
- [x] An agent wrote it under close human direction.
- [ ] An agent wrote it independently, and no human has guided the implementation beyond the initial prompt.

Who answers review comments:

- [x] @williammartin will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.